### PR TITLE
Add command (asserteq (invoke ...) expected)

### DIFF
--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -253,6 +253,7 @@ rule token = parse
   | "table" { TABLE }
 
   | "invoke" { INVOKE }
+  | "asserteq" { ASSERTEQ }
 
   | ";;"[^'\n']*eof { EOF }
   | ";;"[^'\n']*'\n' { Lexing.new_line lexbuf; token lexbuf }

--- a/ml-proto/src/parser.mly
+++ b/ml-proto/src/parser.mly
@@ -41,7 +41,7 @@ let literal at s t =
 %token GETPARAM GETLOCAL SETLOCAL GETGLOBAL SETGLOBAL GETMEMORY SETMEMORY
 %token CONST UNARY BINARY COMPARE CONVERT
 %token FUNC PARAM RESULT LOCAL MODULE MEMORY DATA GLOBAL IMPORT EXPORT TABLE
-%token INVOKE
+%token INVOKE ASSERTEQ
 %token EOF
 
 %token<string> INT
@@ -205,6 +205,8 @@ cmd :
   | modul { Define $1 @@ at() }
   | LPAR INVOKE INT expr_list RPAR { Invoke (int_of_string $3, $4) @@ at() }
   | LPAR INVOKE expr_list RPAR { Invoke (0, $3) @@ at() }  /* Sugar */
+  | LPAR ASSERTEQ LPAR INVOKE INT expr_list RPAR expr_list RPAR { AssertEqInvoke (int_of_string $5, $6, $8) @@ at() }
+  | LPAR ASSERTEQ LPAR INVOKE expr_list RPAR expr_list RPAR { AssertEqInvoke (0, $5, $7) @@ at() }  /* Sugar */
 ;
 cmd_list :
   | /* empty */ { [] }

--- a/ml-proto/src/script.mli
+++ b/ml-proto/src/script.mli
@@ -6,6 +6,7 @@ type command = command' Source.phrase
 and command' =
   | Define of Ast.modul
   | Invoke of int * Ast.expr list
+  | AssertEqInvoke of int * Ast.expr list * Ast.expr list
 
 type script = command list
 

--- a/ml-proto/test/basic.wasm
+++ b/ml-proto/test/basic.wasm
@@ -1,0 +1,9 @@
+(module
+  (func (param i32) (result i32)
+    (return (add.i32 (getparam 0) (const.i32 1)))
+  )
+
+  (export 0)
+)
+
+(asserteq (invoke 0 (const.i32 42)) (const.i32 43))


### PR DESCRIPTION
To write unit tests, it'd be useful to be able to assert an expected return value, otherwise all we're testing is that an error isn't hit.

The SExpr syntax is `(asserteq (invoke export-index args-to-call) expected-results)`.  The reason for the nested `invoke` is to clearly separate invoke args from expected results and to allow us to asserteq other forms later.  An alternative would have been to just have an `assert` that evaluates a boolean condition, but that would require injecting `Invoke` into general expressions or using an `Ast.Call` expression which violate the point of exports (all execution in a module originates with exports; `Eval.eval` sorta violates this already, but I was thinking of changing it to mock up a new module instead of reusing the current module).