### PR TITLE
Don't Eval.eval in existing module

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -230,10 +230,12 @@ In order to be able to check and run modules for testing purposes, the S-express
 script: <cmd>*
 
 cmd:
-  <module>                  ;; define, validate, and initialize module
-  ( invoke <var> <expr>* )  ;; invoke export and print result
-  <func>                    ;; = (module <func> (export 0))
-  ( invoke <expr>* )        ;; = (invoke 0 <expr>*)
+  <module>                                      ;; define, validate, and initialize module
+  ( invoke <var> <expr>* )                      ;; invoke export and print result
+  ( asserteq (invoke <var> <expr>* ) <expr>* )  ;; assert expected results of invocation
+  <func>                                        ;; = (module <func> (export 0))
+  ( invoke <expr>* )                            ;; = (invoke 0 <expr>*)
+  ( asserteq (invoke <expr>* ) <expr>* )        ;; = (asserteq (invoke 0 <expr>*) <expr>*)
 ```
 
 Invocation is only possible after a module has been defined.

--- a/ml-proto/src/eval.ml
+++ b/ml-proto/src/eval.ml
@@ -266,6 +266,7 @@ let invoke m x vs =
   let f = export m (x @@ Source.no_region) in
   eval_func m f vs
 
-let eval m e =
-  let f = {params = []; results = []; locals = []; body = e} @@ Source.no_region
-  in unary (eval_func m f []) e.at
+let eval e =
+  let f = {params = []; results = []; locals = []; body = e} @@ Source.no_region in
+  let m = {funcs = [f]; exports = [f]; tables = []; globals = []; memory = (Memory.create 0)} in
+  unary (eval_func m f []) e.at

--- a/ml-proto/src/eval.mli
+++ b/ml-proto/src/eval.mli
@@ -8,4 +8,4 @@ type value = Values.value
 val init : Ast.modul -> module_instance
 val invoke : module_instance -> int -> value list -> value list
   (* raise Error.Error *)
-val eval : module_instance -> Ast.expr -> value (* raise Error.Error *)
+val eval : Ast.expr -> value (* raise Error.Error *)

--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -253,6 +253,7 @@ rule token = parse
   | "table" { TABLE }
 
   | "invoke" { INVOKE }
+  | "asserteq" { ASSERTEQ }
 
   | ";;"[^'\n']*eof { EOF }
   | ";;"[^'\n']*'\n' { Lexing.new_line lexbuf; token lexbuf }

--- a/ml-proto/src/parser.mly
+++ b/ml-proto/src/parser.mly
@@ -41,7 +41,7 @@ let literal at s t =
 %token GETPARAM GETLOCAL SETLOCAL GETGLOBAL SETGLOBAL GETMEMORY SETMEMORY
 %token CONST UNARY BINARY COMPARE CONVERT
 %token FUNC PARAM RESULT LOCAL MODULE MEMORY DATA GLOBAL IMPORT EXPORT TABLE
-%token INVOKE
+%token INVOKE ASSERTEQ
 %token EOF
 
 %token<string> INT
@@ -205,6 +205,8 @@ cmd :
   | modul { Define $1 @@ at() }
   | LPAR INVOKE INT expr_list RPAR { Invoke (int_of_string $3, $4) @@ at() }
   | LPAR INVOKE expr_list RPAR { Invoke (0, $3) @@ at() }  /* Sugar */
+  | LPAR ASSERTEQ LPAR INVOKE INT expr_list RPAR expr_list RPAR { AssertEqInvoke (int_of_string $5, $6, $8) @@ at() }
+  | LPAR ASSERTEQ LPAR INVOKE expr_list RPAR expr_list RPAR { AssertEqInvoke (0, $5, $7) @@ at() }  /* Sugar */
 ;
 cmd_list :
   | /* empty */ { [] }

--- a/ml-proto/src/parser.mly
+++ b/ml-proto/src/parser.mly
@@ -205,8 +205,10 @@ cmd :
   | modul { Define $1 @@ at() }
   | LPAR INVOKE INT expr_list RPAR { Invoke (int_of_string $3, $4) @@ at() }
   | LPAR INVOKE expr_list RPAR { Invoke (0, $3) @@ at() }  /* Sugar */
-  | LPAR ASSERTEQ LPAR INVOKE INT expr_list RPAR expr_list RPAR { AssertEqInvoke (int_of_string $5, $6, $8) @@ at() }
-  | LPAR ASSERTEQ LPAR INVOKE expr_list RPAR expr_list RPAR { AssertEqInvoke (0, $5, $7) @@ at() }  /* Sugar */
+  | LPAR ASSERTEQ LPAR INVOKE INT expr_list RPAR expr_list RPAR 
+    { AssertEqInvoke (int_of_string $5, $6, $8) @@ at() }
+  | LPAR ASSERTEQ LPAR INVOKE expr_list RPAR expr_list RPAR 
+    { AssertEqInvoke (0, $5, $7) @@ at() }  /* Sugar */
 ;
 cmd_list :
   | /* empty */ { [] }

--- a/ml-proto/src/script.ml
+++ b/ml-proto/src/script.ml
@@ -51,7 +51,7 @@ let run_command cmd =
       let arg_vs = List.map Eval.eval arg_es in
       let got_vs = Eval.invoke m i arg_vs in
       let expect_vs = List.map Eval.eval expect_es in
-      if List.exists2 (<>) got_vs expect_vs then begin
+      if got_vs <> expect_vs then begin
         print_string "Got: ";
         Print.print_values got_vs;
         print_string "Expect: ";

--- a/ml-proto/src/script.ml
+++ b/ml-proto/src/script.ml
@@ -35,11 +35,11 @@ let run_command cmd =
       current_module := Some (Eval.init m)
     | Invoke (i, es) ->
       trace "Invoking...";
+      let vs = List.map Eval.eval es in
       let m = match !current_module with
         | Some m -> m
         | None -> Error.error cmd.at "no module defined to invoke"
       in
-      let vs = List.map (Eval.eval m) es in
       let vs' = Eval.invoke m i vs in
       if vs' <> [] then Print.print_values vs'
     | AssertEqInvoke (i, arg_es, expect_es) ->
@@ -48,10 +48,9 @@ let run_command cmd =
         | Some m -> m
         | None -> Error.error cmd.at "no module defined to invoke"
       in
-      let eval = Eval.eval m in
-      let arg_vs = List.map eval arg_es in
+      let arg_vs = List.map Eval.eval arg_es in
       let got_vs = Eval.invoke m i arg_vs in
-      let expect_vs = List.map eval expect_es in
+      let expect_vs = List.map Eval.eval expect_es in
       if List.exists2 (<>) got_vs expect_vs then begin
         print_string "Got: ";
         Print.print_values got_vs;

--- a/ml-proto/src/script.mli
+++ b/ml-proto/src/script.mli
@@ -6,6 +6,7 @@ type command = command' Source.phrase
 and command' =
   | Define of Ast.modul
   | Invoke of int * Ast.expr list
+  | AssertEqInvoke of int * Ast.expr list * Ast.expr list
 
 type script = command list
 

--- a/ml-proto/test/basic.wasm
+++ b/ml-proto/test/basic.wasm
@@ -1,0 +1,9 @@
+(module
+  (func (param i32) (result i32)
+    (return (add.i32 (getparam 0) (const.i32 1)))
+  )
+
+  (export 0)
+)
+
+(asserteq (invoke 0 (const.i32 42)) (const.i32 43))


### PR DESCRIPTION
Currently `Eval.eval` evaluates expressions inside the current wasm module (kinda like a JS direct eval) which feels like it violates module encapsulation invariants.  This patch mocks up a dummy module.