### PR TITLE
use ocaml modern build system

### DIFF
--- a/ml-proto/.gitignore
+++ b/ml-proto/.gitignore
@@ -1,0 +1,5 @@
+_build
+main.native
+
+setup.data
+setup.log

--- a/ml-proto/.merlin
+++ b/ml-proto/.merlin
@@ -1,0 +1,5 @@
+PKG bigarray
+
+S src
+
+B _build/src

--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -33,6 +33,17 @@ ocamlbuild -libs bigarray main.native
 
 and get an executable named `src/main.native`.
 
+#### Optional: Oasis
+
+If you have oasis installed, either via `opam` or [built from source](http://oasis.forge.ocamlcore.org/), in the base directory (`ml-proto`) you can run:
+
+```
+oasis setup
+```
+
+And it will automatically generate the necessary build files, etc.
+
+Add (experimental) dependencies as you normally would, by including them in the `BuildDepends` section, but do not push back these changes to the `_oasis` file please.  See [this tutorial](https://ocaml.org/learn/tutorials/setting_up_with_oasis.html) on how to use oasis for fun and adventure.
 
 ### Building on Windows
 

--- a/ml-proto/_oasis
+++ b/ml-proto/_oasis
@@ -1,0 +1,21 @@
+OASISFormat: 0.4
+Name:        ml-proto
+Version:     0.1
+Synopsis:    This repository implements a prototypical reference interpreter
+  for WebAssembly
+Description: It is written for clarity and simplicity, not speed (although it should be reasonably fast). Hopefully, it can be useful as a playground for trying out ideas and a device for nailing down the exact semantics. For that purpose, the code is written in a fairly declarative, "speccy" way.
+Authors:     WebAssembly Authors
+License:     Apache-2.0
+Plugins:     META (0.4), DevFiles (0.4)
+
+Executable "wasm"
+  Path:       src
+  BuildTools: ocamlbuild
+  MainIs:     main.ml
+  CompiledObject: best
+  BuildDepends: 
+    bigarray
+  
+Test "all-tests"
+  Command: ./runtests.py
+  


### PR DESCRIPTION
This PR sets up the project to use the oasis build system, which is a modern, extensible build system for OCaml.  As this project becomes larger, it will become a necessity.

A quick survey is here: https://ocaml.org/learn/tutorials/setting_up_with_oasis.html

A basic .merlin file was added as well, for info on how to use, setup: https://github.com/the-lambda-church/merlin/wiki

Changes:
+ Makefile in ml-proto
+ no building in src anymore
+ `make test`
+ .merlin file for autocomplete and :heart_eyes: 
+ updated README