### PR TITLE
Add invalid command

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -233,6 +233,7 @@ cmd:
   <module>                                       ;; define, validate, and initialize module
   ( invoke <name> <expr>* )                      ;; invoke export and print result
   ( asserteq (invoke <name> <expr>* ) <expr>* )  ;; assert expected results of invocation
+  ( assertinvalid <module> <failure> )           ;; assert invalid module with given failure string
 ```
 
 Invocation is only possible after a module has been defined.

--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -51,7 +51,7 @@ def find_interpreter(path):
 def rebuild_interpreter(path):
   print("// building %s" % path)
   sys.stdout.flush()
-  exitCode = subprocess.call(["ocamlbuild", "-libs", "bigarray", "main.native"], cwd=os.path.abspath("src"))
+  exitCode = subprocess.call(["ocamlbuild", "-libs", "bigarray, str", "main.native"], cwd=os.path.abspath("src"))
   if (exitCode != 0):
     raise Exception("ocamlbuild failed with exit code %i" % exitCode)
   if not os.path.exists(path):

--- a/ml-proto/src/Makefile
+++ b/ml-proto/src/Makefile
@@ -12,7 +12,7 @@ MODULES = \
 NOMLI = flags types values ast sexpr main
 PARSERS = parser
 LEXERS = lexer
-LIBRARIES = bigarray
+LIBRARIES = bigarray str
 SAMPLES = 
 TEXTS = 
 

--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -251,6 +251,7 @@ rule token = parse
   | "export" { EXPORT }
   | "table" { TABLE }
 
+  | "invalid" { INVALID }
   | "invoke" { INVOKE }
   | "asserteq" { ASSERTEQ }
 

--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -251,7 +251,7 @@ rule token = parse
   | "export" { EXPORT }
   | "table" { TABLE }
 
-  | "invalid" { INVALID }
+  | "assertinvalid" { ASSERTINVALID }
   | "invoke" { INVOKE }
   | "asserteq" { ASSERTEQ }
 

--- a/ml-proto/src/parser.mly
+++ b/ml-proto/src/parser.mly
@@ -98,7 +98,7 @@ let anon_label c = {c with labels = VarMap.map ((+) 1) c.labels}
 %token GETLOCAL SETLOCAL GETGLOBAL SETGLOBAL GETMEMORY SETMEMORY
 %token CONST UNARY BINARY COMPARE CONVERT
 %token FUNC PARAM RESULT LOCAL MODULE MEMORY SEGMENT GLOBAL IMPORT EXPORT TABLE
-%token INVALID INVOKE ASSERTEQ
+%token ASSERTINVALID INVOKE ASSERTEQ
 %token EOF
 
 %token<string> INT
@@ -308,11 +308,11 @@ modul :
 
 cmd :
   | modul { Define $1 @@ at() }
-  | LPAR INVALID modul TEXT RPAR { Invalid ($3, $4) @@ at() }
+  | LPAR ASSERTINVALID modul TEXT RPAR { AssertInvalid ($3, $4) @@ at() }
   | LPAR INVOKE TEXT expr_list RPAR
     { Invoke ($3, $4 (c0 ())) @@ at() }
   | LPAR ASSERTEQ LPAR INVOKE TEXT expr_list RPAR expr_list RPAR
-    { AssertEqInvoke ($5, $6 (c0 ()), $8 (c0 ())) @@ at() }
+    { AssertEq ($5, $6 (c0 ()), $8 (c0 ())) @@ at() }
 ;
 cmd_list :
   | /* empty */ { [] }

--- a/ml-proto/src/parser.mly
+++ b/ml-proto/src/parser.mly
@@ -98,7 +98,7 @@ let anon_label c = {c with labels = VarMap.map ((+) 1) c.labels}
 %token GETLOCAL SETLOCAL GETGLOBAL SETGLOBAL GETMEMORY SETMEMORY
 %token CONST UNARY BINARY COMPARE CONVERT
 %token FUNC PARAM RESULT LOCAL MODULE MEMORY SEGMENT GLOBAL IMPORT EXPORT TABLE
-%token INVOKE ASSERTEQ
+%token INVALID INVOKE ASSERTEQ
 %token EOF
 
 %token<string> INT
@@ -308,6 +308,7 @@ modul :
 
 cmd :
   | modul { Define $1 @@ at() }
+  | LPAR INVALID modul TEXT RPAR { Invalid ($3, $4) @@ at() }
   | LPAR INVOKE TEXT expr_list RPAR
     { Invoke ($3, $4 (c0 ())) @@ at() }
   | LPAR ASSERTEQ LPAR INVOKE TEXT expr_list RPAR expr_list RPAR

--- a/ml-proto/src/script.ml
+++ b/ml-proto/src/script.ml
@@ -9,9 +9,9 @@ open Source
 type command = command' phrase
 and command' =
   | Define of Ast.modul
-  | Invalid of Ast.modul * string
+  | AssertInvalid of Ast.modul * string
   | Invoke of string * Ast.expr list
-  | AssertEqInvoke of string * Ast.expr list * Ast.expr list
+  | AssertEq of string * Ast.expr list * Ast.expr list
 
 type script = command list
 
@@ -34,14 +34,15 @@ let run_command cmd =
     trace "Initializing...";
     current_module := Some (Eval.init m)
 
-  | Invalid (m, re) ->
+  | AssertInvalid (m, re) ->
     trace "Checking invalid...";
-    (match try Check.check_module m; None with Error.Error (at, s) -> Some s with
+    (match try Check.check_module m; None with Error.Error (_, s) -> Some s with
     | None ->
       Error.error cmd.at "expected invalid module"
     | Some s ->
       if not (Str.string_match (Str.regexp re) s 0) then
-        Error.error cmd.at ("validation failure \"" ^ s ^ "\" does not match: " ^ re))
+        Error.error cmd.at 
+          ("validation failure \"" ^ s ^ "\" does not match: \"" ^ re ^ "\""))
 
   | Invoke (name, es) ->
     trace "Invoking...";
@@ -53,7 +54,7 @@ let run_command cmd =
     let vs' = Eval.invoke m name vs in
     if vs' <> [] then Print.print_values vs'
 
-  | AssertEqInvoke (name, arg_es, expect_es) ->
+  | AssertEq (name, arg_es, expect_es) ->
     trace "Assert invoking...";
     let m = match !current_module with
       | Some m -> m
@@ -75,9 +76,9 @@ let dry_command cmd =
   | Define m ->
     Check.check_module m;
     if !Flags.print_sig then Print.print_module_sig m
-  | Invalid (m, re) -> ()
+  | AssertInvalid _ -> ()
   | Invoke _ -> ()
-  | AssertEqInvoke _ -> ()
+  | AssertEq _ -> ()
 
 let run script =
   List.iter (if !Flags.dry then dry_command else run_command) script

--- a/ml-proto/src/script.mli
+++ b/ml-proto/src/script.mli
@@ -5,9 +5,9 @@
 type command = command' Source.phrase
 and command' =
   | Define of Ast.modul
-  | Invalid of Ast.modul * string
+  | AssertInvalid of Ast.modul * string
   | Invoke of string * Ast.expr list
-  | AssertEqInvoke of string * Ast.expr list * Ast.expr list
+  | AssertEq of string * Ast.expr list * Ast.expr list
 
 type script = command list
 

--- a/ml-proto/src/script.mli
+++ b/ml-proto/src/script.mli
@@ -5,6 +5,7 @@
 type command = command' Source.phrase
 and command' =
   | Define of Ast.modul
+  | Invalid of Ast.modul * string
   | Invoke of string * Ast.expr list
   | AssertEqInvoke of string * Ast.expr list * Ast.expr list
 

--- a/ml-proto/test/basic.wasm
+++ b/ml-proto/test/basic.wasm
@@ -1,9 +1,0 @@
-(module
-  (func $f (param $n i32) (result i32)
-    (return (add.i32 (getlocal $n) (const.i32 1)))
-  )
-
-  (export "e" $f)
-)
-
-(asserteq (invoke "e" (const.i32 42)) (const.i32 43))

--- a/ml-proto/test/exports.wasm
+++ b/ml-proto/test/exports.wasm
@@ -1,0 +1,22 @@
+(module (func (const.i32 1)) (export "a" 0))
+(module (func (const.i32 1)) (export "a" 0) (export "b" 0))
+(module (func (const.i32 1)) (func (const.i32 2)) (export "a" 0) (export "b" 1))
+(invalid
+  (module (func (const.i32 1)) (export "a" 1))
+  "unknown function 1")
+(invalid
+  (module (func (const.i32 1)) (func (const.i32 2)) (export "a" 0) (export "a" 1))
+  "duplicate export name")
+(invalid
+  (module (func (const.i32 1)) (export "a" 0) (export "a" 0))
+  "duplicate export name")
+
+(module
+  (func $f (param $n i32) (result i32)
+    (return (add.i32 (getlocal $n) (const.i32 1)))
+  )
+
+  (export "e" $f)
+)
+
+(asserteq (invoke "e" (const.i32 42)) (const.i32 43))

--- a/ml-proto/test/exports.wasm
+++ b/ml-proto/test/exports.wasm
@@ -1,13 +1,13 @@
 (module (func (const.i32 1)) (export "a" 0))
 (module (func (const.i32 1)) (export "a" 0) (export "b" 0))
 (module (func (const.i32 1)) (func (const.i32 2)) (export "a" 0) (export "b" 1))
-(invalid
+(assertinvalid
   (module (func (const.i32 1)) (export "a" 1))
   "unknown function 1")
-(invalid
+(assertinvalid
   (module (func (const.i32 1)) (func (const.i32 2)) (export "a" 0) (export "a" 1))
   "duplicate export name")
-(invalid
+(assertinvalid
   (module (func (const.i32 1)) (export "a" 0) (export "a" 0))
   "duplicate export name")
 

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -7,22 +7,22 @@
 (module (memory 1 1 (segment 0 "a")))
 (module (memory 100 1000 (segment 0 "a") (segment 99 "b")))
 (module (memory 100 1000 (segment 0 "a") (segment 1 "b") (segment 2 "c")))
-(invalid
+(assertinvalid
   (module (memory 1 0))
   "initial memory size must be less than maximum")
-(invalid
+(assertinvalid
   (module (memory 0 0 (segment 0 "a")))
   "data segment does not fit memory")
-(invalid
+(assertinvalid
   (module (memory 100 1000 (segment 0 "a") (segment 500 "b")))
   "data segment does not fit memory")
-(invalid
+(assertinvalid
   (module (memory 100 1000 (segment 0 "abc") (segment 0 "def")))
   "data segment not disjoint and ordered")
-(invalid
+(assertinvalid
   (module (memory 100 1000 (segment 3 "ab") (segment 0 "de")))
   "data segment not disjoint and ordered")
-(invalid
+(assertinvalid
   (module (memory 100 1000 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
   "data segment not disjoint and ordered")
 

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -1,5 +1,31 @@
 ;; (c) 2015 Andreas Rossberg
 
+(module (memory 0 0))
+(module (memory 0 1))
+(module (memory 4096 16777216))
+(module (memory 0 0 (segment 0 "")))
+(module (memory 1 1 (segment 0 "a")))
+(module (memory 100 1000 (segment 0 "a") (segment 99 "b")))
+(module (memory 100 1000 (segment 0 "a") (segment 1 "b") (segment 2 "c")))
+(invalid
+  (module (memory 1 0))
+  "initial memory size must be less than maximum")
+(invalid
+  (module (memory 0 0 (segment 0 "a")))
+  "data segment does not fit memory")
+(invalid
+  (module (memory 100 1000 (segment 0 "a") (segment 500 "b")))
+  "data segment does not fit memory")
+(invalid
+  (module (memory 100 1000 (segment 0 "abc") (segment 0 "def")))
+  "data segment not disjoint and ordered")
+(invalid
+  (module (memory 100 1000 (segment 3 "ab") (segment 0 "de")))
+  "data segment not disjoint and ordered")
+(invalid
+  (module (memory 100 1000 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
+  "data segment not disjoint and ordered")
+
 (module
   (memory 1024 (segment 0 "ABC\a7D") (segment 20 "WASM"))
 

--- a/ml-proto/travis/build-test.sh
+++ b/ml-proto/travis/build-test.sh
@@ -16,7 +16,7 @@ rm -f lexer.ml
 rm -f parser.ml
 rm -f parser.mli
 
-ocamlbuild -libs bigarray str main.native
+ocamlbuild -libs "bigarray, str" main.native
 make
 
 cd ..

--- a/ml-proto/travis/build-test.sh
+++ b/ml-proto/travis/build-test.sh
@@ -16,7 +16,7 @@ rm -f lexer.ml
 rm -f parser.ml
 rm -f parser.mli
 
-ocamlbuild -libs bigarray main.native
+ocamlbuild -libs bigarray str main.native
 make
 
 cd ..


### PR DESCRIPTION
Two patches (on top of #14):

The first patch adds an `(invalid (module ...) "error")` command that checks that the given module fails in the checker (as opposed to during parsing which is outside the spec) with the given `"error"`.  This command is then used to test the corner cases of the `memory` section.

The second patch added tests for the corner cases of exports and caught a minor "bug"&mdash;the AST is allowed to export a single name twice&mdash;which is fixed.