### PR TITLE
Refine alignment

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -160,7 +160,9 @@ var: <int> | $<name>
 unop:  neg | abs | not | ...
 binop: add | sub | mul | ...
 relop: eq | neq | lt | ...
-memop: (unaligned)?(s|u)?
+sign: s|u
+align: 1|2|4|8|...
+memop: (<sign>.)?(<align>.)?
 
 expr:
   ( nop )
@@ -181,8 +183,8 @@ expr:
   ( setlocal <var> <expr> )
   ( load_global <var> )
   ( store_global <var> <expr> )
-  ( load<memop>.<memtype> <expr> )
-  ( store<memop>.<memtype> <expr> <expr> )
+  ( load<memop><memtype> <expr> )
+  ( store<memop><memtype> <expr> <expr> )
   ( const.<type> <num> )
   ( <unop>.<type> <expr> )
   ( <binop>.<type> <expr> <expr> )

--- a/ml-proto/src/ast.ml
+++ b/ml-proto/src/ast.ml
@@ -60,7 +60,8 @@ type binop = (Int32Op.binop, Int64Op.binop, Float32Op.binop, Float64Op.binop) op
 type relop = (Int32Op.relop, Int64Op.relop, Float32Op.relop, Float64Op.relop) op
 type cvt = (Int32Op.cvt, Int64Op.cvt, Float32Op.cvt, Float64Op.cvt) op
 
-type memop = {align : Memory.alignment; mem : Memory.mem_type}
+type alignment = int
+type memop = {align : alignment; mem : Memory.mem_type}
 
 
 (* Expressions *)

--- a/ml-proto/src/ast.ml
+++ b/ml-proto/src/ast.ml
@@ -60,8 +60,7 @@ type binop = (Int32Op.binop, Int64Op.binop, Float32Op.binop, Float64Op.binop) op
 type relop = (Int32Op.relop, Int64Op.relop, Float32Op.relop, Float64Op.relop) op
 type cvt = (Int32Op.cvt, Int64Op.cvt, Float32Op.cvt, Float64Op.cvt) op
 
-type alignment = int
-type memop = {align : alignment; mem : Memory.mem_type}
+type memop = {align : int; mem : Memory.mem_type}
 
 
 (* Expressions *)

--- a/ml-proto/src/check.ml
+++ b/ml-proto/src/check.ml
@@ -240,8 +240,7 @@ and check_arm c t ts arm =
   check_expr c (if fallthru then [] else ts) e
 
 and check_memop memop at =
-  require (Lib.is_power_of_two memop.align) at "non-power-of-two alignment";
-  require (memop.align <= Memory.mem_size memop.mem) at "alignment too big"
+  require (Lib.is_power_of_two memop.align) at "non-power-of-two alignment"
 
 
 (*

--- a/ml-proto/src/check.ml
+++ b/ml-proto/src/check.ml
@@ -189,10 +189,12 @@ let rec check_expr c ts e =
     check_type [] ts e.at
 
   | Load (memop, e1) ->
+    check_memop memop e.at;
     check_expr c [Int32Type] e1;
     check_type [type_mem memop.mem] ts e.at
 
   | Store (memop, e1, e2) ->
+    check_memop memop e.at;
     check_expr c [Int32Type] e1;
     check_expr c [type_mem memop.mem] e2;
     check_type [] ts e.at
@@ -236,6 +238,13 @@ and check_arm c t ts arm =
   let {value = l; expr = e; fallthru} = arm.it in
   check_literal c [t] l;
   check_expr c (if fallthru then [] else ts) e
+
+and check_memop memop at =
+  require (memop.align = 1 || memop.align = 2 ||
+           memop.align = 4 || memop.align = 8)
+    at "invalid alignment";
+  require (memop.align <= (Memory.mem_size memop.mem))
+    at "alignment too big"
 
 
 (*

--- a/ml-proto/src/check.ml
+++ b/ml-proto/src/check.ml
@@ -243,7 +243,7 @@ and check_memop memop at =
   require (memop.align = 1 || memop.align = 2 ||
            memop.align = 4 || memop.align = 8)
     at "invalid alignment";
-  require (memop.align <= (Memory.mem_size memop.mem))
+  require (memop.align <= Memory.mem_size memop.mem)
     at "alignment too big"
 
 

--- a/ml-proto/src/check.ml
+++ b/ml-proto/src/check.ml
@@ -240,11 +240,8 @@ and check_arm c t ts arm =
   check_expr c (if fallthru then [] else ts) e
 
 and check_memop memop at =
-  require (memop.align = 1 || memop.align = 2 ||
-           memop.align = 4 || memop.align = 8)
-    at "invalid alignment";
-  require (memop.align <= Memory.mem_size memop.mem)
-    at "alignment too big"
+  require (Lib.is_power_of_two memop.align) at "invalid alignment";
+  require (memop.align <= Memory.mem_size memop.mem) at "alignment too big"
 
 
 (*

--- a/ml-proto/src/check.ml
+++ b/ml-proto/src/check.ml
@@ -240,7 +240,7 @@ and check_arm c t ts arm =
   check_expr c (if fallthru then [] else ts) e
 
 and check_memop memop at =
-  require (Lib.is_power_of_two memop.align) at "invalid alignment";
+  require (Lib.is_power_of_two memop.align) at "non-power-of-two alignment";
   require (memop.align <= Memory.mem_size memop.mem) at "alignment too big"
 
 

--- a/ml-proto/src/eval.ml
+++ b/ml-proto/src/eval.ml
@@ -64,7 +64,6 @@ end
 (* Type and memory errors *)
 
 let memory_error at = function
-  | Memory.Align -> error at "runtime: unaligned memory access"
   | Memory.Bounds -> error at "runtime: out of bounds memory access"
   | Memory.Address -> error at "runtime: illegal address value"
   | exn -> raise exn
@@ -163,15 +162,15 @@ let rec eval_expr c e =
     global c x := v1;
     []
 
-  | Load ({align; mem; _}, e1) ->
+  | Load ({mem; _}, e1) ->
     let v1 = unary (eval_expr c e1) e1.at in
-    (try [Memory.load c.modul.memory align (Memory.address_of_value v1) mem]
+    (try [Memory.load c.modul.memory (Memory.address_of_value v1) mem]
     with exn -> memory_error e.at exn)
 
-  | Store ({align; mem; _}, e1, e2) ->
+  | Store ({mem; _}, e1, e2) ->
     let v1 = unary (eval_expr c e1) e1.at in
     let v2 = unary (eval_expr c e2) e2.at in
-    (try Memory.store c.modul.memory align (Memory.address_of_value v1) mem v2
+    (try Memory.store c.modul.memory (Memory.address_of_value v1) mem v2
     with exn -> memory_error e.at exn);
     []
 

--- a/ml-proto/src/lib.ml
+++ b/ml-proto/src/lib.ml
@@ -37,3 +37,7 @@ struct
     | Some x -> f x
     | None -> ()
 end
+
+let is_power_of_two x =
+  assert (x >= 0);
+  x <> 0 && (x land (x - 1)) == 0

--- a/ml-proto/src/lib.mli
+++ b/ml-proto/src/lib.mli
@@ -18,3 +18,5 @@ sig
   val map : ('a -> 'b) -> 'a option -> 'b option
   val app : ('a -> unit) -> 'a option -> unit
 end
+
+val is_power_of_two : int -> bool

--- a/ml-proto/src/memory.mli
+++ b/ml-proto/src/memory.mli
@@ -6,11 +6,11 @@ type memory
 type t = memory
 type address = int
 type size = address
-type alignment = Aligned | Unaligned
 type mem_type =
   | SInt8Mem | SInt16Mem | SInt32Mem | SInt64Mem
   | UInt8Mem | UInt16Mem | UInt32Mem | UInt64Mem
   | Float32Mem | Float64Mem
+val mem_size : mem_type -> int
 
 type segment =
 {
@@ -19,12 +19,11 @@ type segment =
 }
 
 exception Bounds
-exception Align
 exception Address
 
 val create : size -> memory
 val init : memory -> segment list -> unit
-val load : memory -> alignment -> address -> mem_type -> Values.value
-val store : memory -> alignment -> address -> mem_type -> Values.value -> unit
+val load : memory -> address -> mem_type -> Values.value
+val store : memory -> address -> mem_type -> Values.value -> unit
 
 val address_of_value : Values.value -> address

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -28,10 +28,10 @@
   "data segment not disjoint and ordered")
 
 ;; Test alignment annotation rules
-(assertinvalid (module (func (loadu.2.i8 (const.i32 0)))) "alignment too big")
-(assertinvalid (module (func (loadu.4.i16 (const.i32 0)))) "alignment too big")
-(assertinvalid (module (func (loadu.8.i32 (const.i32 0)))) "alignment too big")
-(assertinvalid (module (func (load.8.f32 (const.i32 0)))) "alignment too big")
+(module (func (loadu.2.i8 (const.i32 0))))
+(module (func (loadu.4.i16 (const.i32 0))))
+(module (func (loadu.8.i32 (const.i32 0))))
+(module (func (load.8.f32 (const.i32 0))))
 (assertinvalid (module (func (loadu.0.i64 (const.i32 0)))) "non-power-of-two alignment")
 (assertinvalid (module (func (loadu.3.i64 (const.i32 0)))) "non-power-of-two alignment")
 (assertinvalid (module (func (loadu.5.i64 (const.i32 0)))) "non-power-of-two alignment")

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -32,11 +32,11 @@
 (assertinvalid (module (func (loadu.4.i16 (const.i32 0)))) "alignment too big")
 (assertinvalid (module (func (loadu.8.i32 (const.i32 0)))) "alignment too big")
 (assertinvalid (module (func (load.8.f32 (const.i32 0)))) "alignment too big")
-(assertinvalid (module (func (loadu.0.i64 (const.i32 0)))) "invalid alignment")
-(assertinvalid (module (func (loadu.3.i64 (const.i32 0)))) "invalid alignment")
-(assertinvalid (module (func (loadu.5.i64 (const.i32 0)))) "invalid alignment")
-(assertinvalid (module (func (loadu.6.i64 (const.i32 0)))) "invalid alignment")
-(assertinvalid (module (func (loadu.7.i64 (const.i32 0)))) "invalid alignment")
+(assertinvalid (module (func (loadu.0.i64 (const.i32 0)))) "non-power-of-two alignment")
+(assertinvalid (module (func (loadu.3.i64 (const.i32 0)))) "non-power-of-two alignment")
+(assertinvalid (module (func (loadu.5.i64 (const.i32 0)))) "non-power-of-two alignment")
+(assertinvalid (module (func (loadu.6.i64 (const.i32 0)))) "non-power-of-two alignment")
+(assertinvalid (module (func (loadu.7.i64 (const.i32 0)))) "non-power-of-two alignment")
 
 (module
   (memory 1024 (segment 0 "ABC\a7D") (segment 20 "WASM"))

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -1,5 +1,6 @@
 ;; (c) 2015 Andreas Rossberg
 
+;; Test memory section structure
 (module (memory 0 0))
 (module (memory 0 1))
 (module (memory 4096 16777216))
@@ -25,6 +26,17 @@
 (assertinvalid
   (module (memory 100 1000 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
   "data segment not disjoint and ordered")
+
+;; Test alignment annotation rules
+(assertinvalid (module (func (loadu.2.i8 (const.i32 0)))) "alignment too big")
+(assertinvalid (module (func (loadu.4.i16 (const.i32 0)))) "alignment too big")
+(assertinvalid (module (func (loadu.8.i32 (const.i32 0)))) "alignment too big")
+(assertinvalid (module (func (load.8.f32 (const.i32 0)))) "alignment too big")
+(assertinvalid (module (func (loadu.0.i64 (const.i32 0)))) "invalid alignment")
+(assertinvalid (module (func (loadu.3.i64 (const.i32 0)))) "invalid alignment")
+(assertinvalid (module (func (loadu.5.i64 (const.i32 0)))) "invalid alignment")
+(assertinvalid (module (func (loadu.6.i64 (const.i32 0)))) "invalid alignment")
+(assertinvalid (module (func (loadu.7.i64 (const.i32 0)))) "invalid alignment")
 
 (module
   (memory 1024 (segment 0 "ABC\a7D") (segment 20 "WASM"))
@@ -77,8 +89,8 @@
           (break)
         )
         (setlocal 2 (converts.i32.f64 (getlocal 0)))
-        (storeunaligned.f64 (getlocal 0) (getlocal 2))
-        (setlocal 1 (loadunaligned.f64 (getlocal 0)))
+        (store.1.f64 (getlocal 0) (getlocal 2))
+        (setlocal 1 (load.1.f64 (getlocal 0)))
         (if
           (neq.f64 (getlocal 2) (getlocal 1))
           (return (const.i32 0))
@@ -96,9 +108,9 @@
       (eq.f64 (load.f64 (const.i32 8)) (cast.i64.f64 (const.i64 -12345)))
       (return (const.f64 0))
     )
-    (storeunaligneds.i64 (const.i32 9) (const.i64 0))
-    (storeunaligneds.i16 (const.i32 15) (const.i32 16453))
-    (return (loadunaligned.f64 (const.i32 9)))
+    (stores.1.i64 (const.i32 9) (const.i64 0))
+    (stores.1.i16 (const.i32 15) (const.i32 16453))
+    (return (load.1.f64 (const.i32 9)))
   )
 
   (export "data" $data)


### PR DESCRIPTION
Extending #30, this patch moves the alignment aspect of linear memory ops to what's in the [design repo](https://github.com/WebAssembly/design/blob/master/AstSemantics.md#alignment) as follows:
* remove `Memory.alignment` from `Memory` since alignment makes no semantic difference
* add `Ast.alignment`, since load/store AST nodes do have an alignment field
* switches `alignment` from a binary `Aligned|Unaligned` to an `int` which is validated to be {1,2,4,8} and smaller than the element size