### PR TITLE
Cross-compiled C# wasm tests

### DIFF
--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -9,6 +9,9 @@ import sys
 
 class RunTests(unittest.TestCase):
   def _runTestFile(self, shortName, fileName, interpreterPath):
+    # HACK: Windows python compatibility
+    fileName = fileName.replace("\\", "/")
+
     logPath = fileName.replace("test/", "test/output/").replace(".wasm", ".wasm.log")
     try:
       os.remove(logPath)
@@ -59,6 +62,8 @@ def rebuild_interpreter(path):
 
 if __name__ == "__main__":
   interpreterPath = os.path.abspath("src/main.native")
+  # HACK: Windows python compatibility
+  interpreterPath = interpreterPath.replace("\\", "/")
 
   try:
     os.makedirs("test/output/")

--- a/ml-proto/test/countUp.wasm
+++ b/ml-proto/test/countUp.wasm
@@ -3,15 +3,14 @@
 (module 
 
   (func $Program_countUp
-    (param $outOffset i32) (param $count i32) (local $i i32) (local $num i32) 
-
+    (param $outOffset i32) (param $count i32) (local $i i32) 
 
     (block 
 
       ;; for (var (@<var System.Int32 i> = 0); ...)
       (setlocal $i (const.i32 0))
 
-      (label $loop_4096 
+      (label $loop_0 
         (loop 
           ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
 
@@ -21,32 +20,31 @@
               (getlocal $count)
             )
             (nop)
-            (break $loop_4096)
+            (break $loop_0)
           )
 
           ;; for (...) { 
-          (block 
-            (stores.1.i32 
-              (mul.i32 
-                (add.i32 
-                  (getlocal $outOffset)
-                  (getlocal $i)
-                )
-                (const.i32 4)
+          (stores.1.i32 
+            (mul.i32 
+              (add.i32 
+                (getlocal $outOffset)
+                (getlocal $i)
               )
-              (getlocal $i)
+              (const.i32 4)
             )
-            (setlocal $num (getlocal $i))
-            (setlocal $i (add.i32 
-                (getlocal $num)
-                (const.i32 1)
-              ))
+            (getlocal $i)
           )
+
+          ;; for (...; ...; <!>)
+          (setlocal $i (add.i32 
+              (getlocal $i)
+              (const.i32 1)
+            ))
         )
       )
     )
-
   )
+
   (func $Program_readI32
     (param $base i32) (param $offset i32) 
     (result i32)
@@ -61,12 +59,12 @@
   )
 
   (export "countUp" $Program_countUp)
-
   (export "readI32" $Program_readI32)
 
   (memory 4096 4096)
 
 )
+
 
 (invoke "countUp" (const.i32 0) (const.i32 32) )
 (invoke "countUp" (const.i32 16) (const.i32 4) )

--- a/ml-proto/test/countUp.wasm
+++ b/ml-proto/test/countUp.wasm
@@ -1,0 +1,77 @@
+;; CountUp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+
+(module 
+
+  (func $Program_countUp
+    (param $outOffset i32) (param $count i32) (local $i i32) (local $num i32) 
+
+
+    (block 
+
+      ;; for (var (@<var System.Int32 i> = 0); ...)
+      (setlocal $i (const.i32 0))
+
+      (label $loop_4096 
+        (loop 
+          ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
+
+          (if 
+            (lts.i32 
+              (getlocal $i)
+              (getlocal $count)
+            )
+            (nop)
+            (break $loop_4096)
+          )
+
+          ;; for (...) { 
+          (block 
+            (stores.1.i32 
+              (mul.i32 
+                (add.i32 
+                  (getlocal $outOffset)
+                  (getlocal $i)
+                )
+                (const.i32 4)
+              )
+              (getlocal $i)
+            )
+            (setlocal $num (getlocal $i))
+            (setlocal $i (add.i32 
+                (getlocal $num)
+                (const.i32 1)
+              ))
+          )
+        )
+      )
+    )
+
+  )
+  (func $Program_readI32
+    (param $base i32) (param $offset i32) 
+    (result i32)
+
+    (return (loads.1.i32 (mul.i32 
+          (add.i32 
+            (getlocal $base)
+            (getlocal $offset)
+          )
+          (const.i32 4)
+        ) ))
+  )
+
+  (export "countUp" $Program_countUp)
+
+  (export "readI32" $Program_readI32)
+
+  (memory 4096 4096)
+
+)
+
+(invoke "countUp" (const.i32 0) (const.i32 32) )
+(invoke "countUp" (const.i32 16) (const.i32 4) )
+(asserteq (invoke "readI32" (const.i32 0) (const.i32 0)  ) (const.i32 0) )
+(asserteq (invoke "readI32" (const.i32 0) (const.i32 2)  ) (const.i32 2) )
+(asserteq (invoke "readI32" (const.i32 0) (const.i32 31)  ) (const.i32 31) )
+(asserteq (invoke "readI32" (const.i32 16) (const.i32 0)  ) (const.i32 0) )
+(asserteq (invoke "readI32" (const.i32 16) (const.i32 3)  ) (const.i32 3) )

--- a/ml-proto/test/fannkuch.broken-wasm
+++ b/ml-proto/test/fannkuch.broken-wasm
@@ -4,16 +4,15 @@
 
   (func $Program_fannkuch
     (param $n i32) (local $sign i32) (local $maxflips i32) (local $sum i32) 
-    (local $j i32) (local $num i32) (local $q0 i32) (local $flag i32) 
-    (local $k i32) (local $flips i32) (local $qq i32) (local $flag2 i32) 
-    (local $flag3 i32) (local $l i32) (local $m i32) (local $t i32) 
-    (local $flag4 i32) (local $flag5 i32) (local $t3 i32) (local $i2 i32) 
-    (local $sx i32) (local $flag7 i32) (local $j2 i32) 
+    (local $j i32) (local $q0 i32) (local $k i32) (local $flips i32) 
+    (local $qq i32) (local $l i32) (local $m i32) (local $t i32) 
+    (local $t3 i32) (local $i2 i32) (local $sx i32) (local $j2 i32) 
+
     (local $currentLabel_0 i32) 
 
     (block 
 
-      ;; LabelGroup 0
+      ;; LabelGroup 0 (starting at $entry0)
       (setlocal $currentLabel_0 (const.i32 0))
 
       (label $labelgroup_0 (loop (label $labelgroup_0_dispatch 
@@ -27,7 +26,7 @@
             ;; for (var (@<var System.Int32 j> = 0); ...)
             (setlocal $j (const.i32 0))
 
-            (label $loop_4096 
+            (label $loop_0 
               (loop 
                 ;; for (...; (@<var System.Int32 j> < @<parameter System.Int32 n>); ...)
 
@@ -37,7 +36,7 @@
                     (getlocal $n)
                   )
                   (nop)
-                  (break $loop_4096)
+                  (break $loop_0)
                 )
 
                 ;; for (...) { 
@@ -72,41 +71,41 @@
                     )
                     (getlocal $j)
                   )
-                  (setlocal $num (getlocal $j))
-                  (setlocal $j (add.i32 
-                      (getlocal $num)
-                      (const.i32 1)
-                    ))
                 )
+
+                ;; for (...; ...; <!>)
+                (setlocal $j (add.i32 
+                    (getlocal $j)
+                    (const.i32 1)
+                  ))
               )
             )
 
             ;; while (<JSBooleanLiteral True>)
-            (label $loop_4097 
+            (label $loop_1 
               (loop 
 
                 (if 
                   (const.i32 1)
                   (nop)
-                  (break $loop_4097)
+                  (break $loop_1)
                 )
 
                 ;; while (...) { 
                 (block 
                   (setlocal $q0 (loads.1.i32 (const.i32 128) ))
-                  (setlocal $flag (gts.i32 
-                      (getlocal $q0)
-                      (const.i32 0)
-                    ))
 
                   (if 
-                    (getlocal $flag)
+                    (neq.i32 
+                      (getlocal $q0)
+                      (const.i32 0)
+                    )
                     (block 
 
                       ;; for (var (@<var System.Int32 k> = 1); ...)
                       (setlocal $k (const.i32 1))
 
-                      (label $loop_4098 
+                      (label $loop_2 
                         (loop 
                           ;; for (...; (@<var System.Int32 k> < @<parameter System.Int32 n>); ...)
 
@@ -116,33 +115,32 @@
                               (getlocal $n)
                             )
                             (nop)
-                            (break $loop_4098)
+                            (break $loop_2)
                           )
 
                           ;; for (...) { 
-                          (block 
-                            (stores.1.i32 
-                              (mul.i32 
+                          (stores.1.i32 
+                            (mul.i32 
+                              (add.i32 
+                                (const.i32 64)
+                                (getlocal $k)
+                              )
+                              (const.i32 4)
+                            )
+                            (loads.1.i32 (mul.i32 
                                 (add.i32 
-                                  (const.i32 64)
+                                  (const.i32 32)
                                   (getlocal $k)
                                 )
                                 (const.i32 4)
-                              )
-                              (loads.1.i32 (mul.i32 
-                                  (add.i32 
-                                    (const.i32 32)
-                                    (getlocal $k)
-                                  )
-                                  (const.i32 4)
-                                ) )
-                            )
-                            (setlocal $num (getlocal $k))
-                            (setlocal $k (add.i32 
-                                (getlocal $num)
-                                (const.i32 1)
-                              ))
+                              ) )
                           )
+
+                          ;; for (...; ...; <!>)
+                          (setlocal $k (add.i32 
+                              (getlocal $k)
+                              (const.i32 1)
+                            ))
                         )
                       )
                       (setlocal $flips (const.i32 1))
@@ -166,13 +164,12 @@
                                   )
                                   (const.i32 4)
                                 ) ))
-                            (setlocal $flag2 (eq.i32 
-                                (getlocal $qq)
-                                (const.i32 0)
-                              ))
 
                             (if 
-                              (getlocal $flag2)
+                              (eq.i32 
+                                (getlocal $qq)
+                                (const.i32 0)
+                              )
                               (break $loop_3)
                             )
                             (stores.1.i32 
@@ -185,13 +182,12 @@
                               )
                               (getlocal $q0)
                             )
-                            (setlocal $flag3 (ges.i32 
-                                (getlocal $q0)
-                                (const.i32 3)
-                              ))
 
                             (if 
-                              (getlocal $flag3)
+                              (ges.i32 
+                                (getlocal $q0)
+                                (const.i32 3)
+                              )
                               (block 
                                 (setlocal $l (const.i32 1))
                                 (setlocal $m (sub.i32 
@@ -200,7 +196,7 @@
                                   ))
 
                                 ;; do {
-                                (label $loop_4099 
+                                (label $loop_4 
                                   (loop 
                                     (block 
                                       (setlocal $t (loads.1.i32 (mul.i32 
@@ -236,14 +232,12 @@
                                         )
                                         (getlocal $t)
                                       )
-                                      (setlocal $num (getlocal $l))
                                       (setlocal $l (add.i32 
-                                          (getlocal $num)
+                                          (getlocal $l)
                                           (const.i32 1)
                                         ))
-                                      (setlocal $num (getlocal $m))
                                       (setlocal $m (sub.i32 
-                                          (getlocal $num)
+                                          (getlocal $m)
                                           (const.i32 1)
                                         ))
                                     )
@@ -256,16 +250,15 @@
                                         (getlocal $m)
                                       )
                                       (nop)
-                                      (break $loop_4099)
+                                      (break $loop_4)
                                     )
                                   )
                                 )
                               )
                             )
                             (setlocal $q0 (getlocal $qq))
-                            (setlocal $num (getlocal $flips))
                             (setlocal $flips (add.i32 
-                                (getlocal $num)
+                                (getlocal $flips)
                                 (const.i32 1)
                               ))
                           )
@@ -278,24 +271,22 @@
                             (getlocal $flips)
                           )
                         ))
-                      (setlocal $flag4 (gts.i32 
-                          (getlocal $flips)
-                          (getlocal $maxflips)
-                        ))
 
                       (if 
-                        (getlocal $flag4)
+                        (gts.i32 
+                          (getlocal $flips)
+                          (getlocal $maxflips)
+                        )
                         (setlocal $maxflips (getlocal $flips))
                       )
                     )
                   )
-                  (setlocal $flag5 (eq.i32 
-                      (getlocal $sign)
-                      (const.i32 1)
-                    ))
 
                   (if 
-                    (getlocal $flag5)
+                    (eq.i32 
+                      (getlocal $sign)
+                      (const.i32 1)
+                    )
                     (block 
                       (stores.1.i32 
                         (const.i32 132)
@@ -346,7 +337,7 @@
                                 ) ))
 
                             (if 
-                              (gts.i32 
+                              (neq.i32 
                                 (getlocal $sx)
                                 (const.i32 0)
                               )
@@ -367,16 +358,15 @@
                                 (break $loop_5)
                               )
                             )
-                            (setlocal $flag7 (eq.i32 
+
+                            (if 
+                              (eq.i32 
                                 (getlocal $i2)
                                 (sub.i32 
                                   (getlocal $n)
                                   (const.i32 1)
                                 )
-                              ))
-
-                            (if 
-                              (getlocal $flag7)
+                              )
                               ;; goto Block_8
                               (block (setlocal $currentLabel_0 (const.i32 1)) (break $labelgroup_0_dispatch) )
                             )
@@ -395,7 +385,7 @@
                             ;; for (var (@<var System.Int32 j2> = 0); ...)
                             (setlocal $j2 (const.i32 0))
 
-                            (label $loop_4100 
+                            (label $loop_6 
                               (loop 
                                 ;; for (...; (@<var System.Int32 j2> <= @<var System.Int32 i2>); ...)
 
@@ -405,36 +395,35 @@
                                     (getlocal $i2)
                                   )
                                   (nop)
-                                  (break $loop_4100)
+                                  (break $loop_6)
                                 )
 
                                 ;; for (...) { 
-                                (block 
-                                  (stores.1.i32 
-                                    (mul.i32 
+                                (stores.1.i32 
+                                  (mul.i32 
+                                    (add.i32 
+                                      (const.i32 32)
+                                      (getlocal $j2)
+                                    )
+                                    (const.i32 4)
+                                  )
+                                  (loads.1.i32 (mul.i32 
                                       (add.i32 
                                         (const.i32 32)
-                                        (getlocal $j2)
+                                        (add.i32 
+                                          (getlocal $j2)
+                                          (const.i32 1)
+                                        )
                                       )
                                       (const.i32 4)
-                                    )
-                                    (loads.1.i32 (mul.i32 
-                                        (add.i32 
-                                          (const.i32 32)
-                                          (add.i32 
-                                            (getlocal $j2)
-                                            (const.i32 1)
-                                          )
-                                        )
-                                        (const.i32 4)
-                                      ) )
-                                  )
-                                  (setlocal $num (getlocal $j2))
-                                  (setlocal $j2 (add.i32 
-                                      (getlocal $num)
-                                      (const.i32 1)
-                                    ))
+                                    ) )
                                 )
+
+                                ;; for (...; ...; <!>)
+                                (setlocal $j2 (add.i32 
+                                    (getlocal $j2)
+                                    (const.i32 1)
+                                  ))
                               )
                             )
                             (stores.1.i32 
@@ -450,12 +439,13 @@
                               )
                               (getlocal $t3)
                             )
-                            (setlocal $num (getlocal $i2))
-                            (setlocal $i2 (add.i32 
-                                (getlocal $num)
-                                (const.i32 1)
-                              ))
                           )
+
+                          ;; for (...; ...; <!>)
+                          (setlocal $i2 (add.i32 
+                              (getlocal $i2)
+                              (const.i32 1)
+                            ))
                         )
                       )
                     )
@@ -489,8 +479,8 @@
         )
       ))
     )
-
   )
+
   (func $Program_readI32
     (param $base i32) (param $offset i32) 
     (result i32)
@@ -505,12 +495,12 @@
   )
 
   (export "fannkuch" $Program_fannkuch)
-
   (export "readI32" $Program_readI32)
 
   (memory 4096 4096)
 
 )
+
 
 (invoke "fannkuch" (const.i32 7) )
 (asserteq (invoke "readI32" (const.i32 0) (const.i32 0)  ) (const.i32 228) )

--- a/ml-proto/test/fannkuch.broken-wasm
+++ b/ml-proto/test/fannkuch.broken-wasm
@@ -1,0 +1,517 @@
+;; FannkuchRedux, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+
+(module 
+
+  (func $Program_fannkuch
+    (param $n i32) (local $sign i32) (local $maxflips i32) (local $sum i32) 
+    (local $j i32) (local $num i32) (local $q0 i32) (local $flag i32) 
+    (local $k i32) (local $flips i32) (local $qq i32) (local $flag2 i32) 
+    (local $flag3 i32) (local $l i32) (local $m i32) (local $t i32) 
+    (local $flag4 i32) (local $flag5 i32) (local $t3 i32) (local $i2 i32) 
+    (local $sx i32) (local $flag7 i32) (local $j2 i32) 
+    (local $currentLabel_0 i32) 
+
+    (block 
+
+      ;; LabelGroup 0
+      (setlocal $currentLabel_0 (const.i32 0))
+
+      (label $labelgroup_0 (loop (label $labelgroup_0_dispatch 
+        ;; Begin Label $entry0
+        (if (eq.i32 (getlocal $currentLabel_0) (const.i32 0)) 
+          (block 
+            (setlocal $sign (const.i32 1))
+            (setlocal $maxflips (const.i32 0))
+            (setlocal $sum (const.i32 0))
+
+            ;; for (var (@<var System.Int32 j> = 0); ...)
+            (setlocal $j (const.i32 0))
+
+            (label $loop_4096 
+              (loop 
+                ;; for (...; (@<var System.Int32 j> < @<parameter System.Int32 n>); ...)
+
+                (if 
+                  (lts.i32 
+                    (getlocal $j)
+                    (getlocal $n)
+                  )
+                  (nop)
+                  (break $loop_4096)
+                )
+
+                ;; for (...) { 
+                (block 
+                  (stores.1.i32 
+                    (mul.i32 
+                      (add.i32 
+                        (const.i32 32)
+                        (getlocal $j)
+                      )
+                      (const.i32 4)
+                    )
+                    (getlocal $j)
+                  )
+                  (stores.1.i32 
+                    (mul.i32 
+                      (add.i32 
+                        (const.i32 64)
+                        (getlocal $j)
+                      )
+                      (const.i32 4)
+                    )
+                    (getlocal $j)
+                  )
+                  (stores.1.i32 
+                    (mul.i32 
+                      (add.i32 
+                        (const.i32 96)
+                        (getlocal $j)
+                      )
+                      (const.i32 4)
+                    )
+                    (getlocal $j)
+                  )
+                  (setlocal $num (getlocal $j))
+                  (setlocal $j (add.i32 
+                      (getlocal $num)
+                      (const.i32 1)
+                    ))
+                )
+              )
+            )
+
+            ;; while (<JSBooleanLiteral True>)
+            (label $loop_4097 
+              (loop 
+
+                (if 
+                  (const.i32 1)
+                  (nop)
+                  (break $loop_4097)
+                )
+
+                ;; while (...) { 
+                (block 
+                  (setlocal $q0 (loads.1.i32 (const.i32 128) ))
+                  (setlocal $flag (gts.i32 
+                      (getlocal $q0)
+                      (const.i32 0)
+                    ))
+
+                  (if 
+                    (getlocal $flag)
+                    (block 
+
+                      ;; for (var (@<var System.Int32 k> = 1); ...)
+                      (setlocal $k (const.i32 1))
+
+                      (label $loop_4098 
+                        (loop 
+                          ;; for (...; (@<var System.Int32 k> < @<parameter System.Int32 n>); ...)
+
+                          (if 
+                            (lts.i32 
+                              (getlocal $k)
+                              (getlocal $n)
+                            )
+                            (nop)
+                            (break $loop_4098)
+                          )
+
+                          ;; for (...) { 
+                          (block 
+                            (stores.1.i32 
+                              (mul.i32 
+                                (add.i32 
+                                  (const.i32 64)
+                                  (getlocal $k)
+                                )
+                                (const.i32 4)
+                              )
+                              (loads.1.i32 (mul.i32 
+                                  (add.i32 
+                                    (const.i32 32)
+                                    (getlocal $k)
+                                  )
+                                  (const.i32 4)
+                                ) )
+                            )
+                            (setlocal $num (getlocal $k))
+                            (setlocal $k (add.i32 
+                                (getlocal $num)
+                                (const.i32 1)
+                              ))
+                          )
+                        )
+                      )
+                      (setlocal $flips (const.i32 1))
+
+                      ;; while (<JSBooleanLiteral True>)
+                      (label $loop_3 
+                        (loop 
+
+                          (if 
+                            (const.i32 1)
+                            (nop)
+                            (break $loop_3)
+                          )
+
+                          ;; while (...) { 
+                          (block 
+                            (setlocal $qq (loads.1.i32 (mul.i32 
+                                  (add.i32 
+                                    (const.i32 64)
+                                    (getlocal $q0)
+                                  )
+                                  (const.i32 4)
+                                ) ))
+                            (setlocal $flag2 (eq.i32 
+                                (getlocal $qq)
+                                (const.i32 0)
+                              ))
+
+                            (if 
+                              (getlocal $flag2)
+                              (break $loop_3)
+                            )
+                            (stores.1.i32 
+                              (mul.i32 
+                                (add.i32 
+                                  (const.i32 64)
+                                  (getlocal $q0)
+                                )
+                                (const.i32 4)
+                              )
+                              (getlocal $q0)
+                            )
+                            (setlocal $flag3 (ges.i32 
+                                (getlocal $q0)
+                                (const.i32 3)
+                              ))
+
+                            (if 
+                              (getlocal $flag3)
+                              (block 
+                                (setlocal $l (const.i32 1))
+                                (setlocal $m (sub.i32 
+                                    (getlocal $q0)
+                                    (const.i32 1)
+                                  ))
+
+                                ;; do {
+                                (label $loop_4099 
+                                  (loop 
+                                    (block 
+                                      (setlocal $t (loads.1.i32 (mul.i32 
+                                            (add.i32 
+                                              (const.i32 64)
+                                              (getlocal $l)
+                                            )
+                                            (const.i32 4)
+                                          ) ))
+                                      (stores.1.i32 
+                                        (mul.i32 
+                                          (add.i32 
+                                            (const.i32 64)
+                                            (getlocal $l)
+                                          )
+                                          (const.i32 4)
+                                        )
+                                        (loads.1.i32 (mul.i32 
+                                            (add.i32 
+                                              (const.i32 64)
+                                              (getlocal $m)
+                                            )
+                                            (const.i32 4)
+                                          ) )
+                                      )
+                                      (stores.1.i32 
+                                        (mul.i32 
+                                          (add.i32 
+                                            (const.i32 64)
+                                            (getlocal $m)
+                                          )
+                                          (const.i32 4)
+                                        )
+                                        (getlocal $t)
+                                      )
+                                      (setlocal $num (getlocal $l))
+                                      (setlocal $l (add.i32 
+                                          (getlocal $num)
+                                          (const.i32 1)
+                                        ))
+                                      (setlocal $num (getlocal $m))
+                                      (setlocal $m (sub.i32 
+                                          (getlocal $num)
+                                          (const.i32 1)
+                                        ))
+                                    )
+
+                                    ;; do { ... } while ((@<var System.Int32 l> < @<var System.Int32 m>))
+
+                                    (if 
+                                      (lts.i32 
+                                        (getlocal $l)
+                                        (getlocal $m)
+                                      )
+                                      (nop)
+                                      (break $loop_4099)
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                            (setlocal $q0 (getlocal $qq))
+                            (setlocal $num (getlocal $flips))
+                            (setlocal $flips (add.i32 
+                                (getlocal $num)
+                                (const.i32 1)
+                              ))
+                          )
+                        )
+                      )
+                      (setlocal $sum (add.i32 
+                          (getlocal $sum)
+                          (mul.i32 
+                            (getlocal $sign)
+                            (getlocal $flips)
+                          )
+                        ))
+                      (setlocal $flag4 (gts.i32 
+                          (getlocal $flips)
+                          (getlocal $maxflips)
+                        ))
+
+                      (if 
+                        (getlocal $flag4)
+                        (setlocal $maxflips (getlocal $flips))
+                      )
+                    )
+                  )
+                  (setlocal $flag5 (eq.i32 
+                      (getlocal $sign)
+                      (const.i32 1)
+                    ))
+
+                  (if 
+                    (getlocal $flag5)
+                    (block 
+                      (stores.1.i32 
+                        (const.i32 132)
+                        (loads.1.i32 (const.i32 128) )
+                      )
+                      (stores.1.i32 
+                        (const.i32 128)
+                        (loads.1.i32 (const.i32 132) )
+                      )
+                      (setlocal $sign (const.i32 -1))
+                    )
+                    (block 
+                      (setlocal $t3 (loads.1.i32 (const.i32 132) ))
+                      (stores.1.i32 
+                        (const.i32 132)
+                        (loads.1.i32 (const.i32 136) )
+                      )
+                      (stores.1.i32 
+                        (const.i32 136)
+                        (getlocal $t3)
+                      )
+                      (setlocal $sign (const.i32 1))
+
+                      ;; for (var (@<var System.Int32 i2> = 2); ...)
+                      (setlocal $i2 (const.i32 2))
+
+                      (label $loop_5 
+                        (loop 
+                          ;; for (...; (@<var System.Int32 i2> < @<parameter System.Int32 n>); ...)
+
+                          (if 
+                            (lts.i32 
+                              (getlocal $i2)
+                              (getlocal $n)
+                            )
+                            (nop)
+                            (break $loop_5)
+                          )
+
+                          ;; for (...) { 
+                          (block 
+                            (setlocal $sx (loads.1.i32 (mul.i32 
+                                  (add.i32 
+                                    (const.i32 96)
+                                    (getlocal $i2)
+                                  )
+                                  (const.i32 4)
+                                ) ))
+
+                            (if 
+                              (gts.i32 
+                                (getlocal $sx)
+                                (const.i32 0)
+                              )
+                              (block 
+                                (stores.1.i32 
+                                  (mul.i32 
+                                    (add.i32 
+                                      (const.i32 96)
+                                      (getlocal $i2)
+                                    )
+                                    (const.i32 4)
+                                  )
+                                  (sub.i32 
+                                    (getlocal $sx)
+                                    (const.i32 1)
+                                  )
+                                )
+                                (break $loop_5)
+                              )
+                            )
+                            (setlocal $flag7 (eq.i32 
+                                (getlocal $i2)
+                                (sub.i32 
+                                  (getlocal $n)
+                                  (const.i32 1)
+                                )
+                              ))
+
+                            (if 
+                              (getlocal $flag7)
+                              ;; goto Block_8
+                              (block (setlocal $currentLabel_0 (const.i32 1)) (break $labelgroup_0_dispatch) )
+                            )
+                            (stores.1.i32 
+                              (mul.i32 
+                                (add.i32 
+                                  (const.i32 96)
+                                  (getlocal $i2)
+                                )
+                                (const.i32 4)
+                              )
+                              (getlocal $i2)
+                            )
+                            (setlocal $t3 (loads.1.i32 (const.i32 128) ))
+
+                            ;; for (var (@<var System.Int32 j2> = 0); ...)
+                            (setlocal $j2 (const.i32 0))
+
+                            (label $loop_4100 
+                              (loop 
+                                ;; for (...; (@<var System.Int32 j2> <= @<var System.Int32 i2>); ...)
+
+                                (if 
+                                  (les.i32 
+                                    (getlocal $j2)
+                                    (getlocal $i2)
+                                  )
+                                  (nop)
+                                  (break $loop_4100)
+                                )
+
+                                ;; for (...) { 
+                                (block 
+                                  (stores.1.i32 
+                                    (mul.i32 
+                                      (add.i32 
+                                        (const.i32 32)
+                                        (getlocal $j2)
+                                      )
+                                      (const.i32 4)
+                                    )
+                                    (loads.1.i32 (mul.i32 
+                                        (add.i32 
+                                          (const.i32 32)
+                                          (add.i32 
+                                            (getlocal $j2)
+                                            (const.i32 1)
+                                          )
+                                        )
+                                        (const.i32 4)
+                                      ) )
+                                  )
+                                  (setlocal $num (getlocal $j2))
+                                  (setlocal $j2 (add.i32 
+                                      (getlocal $num)
+                                      (const.i32 1)
+                                    ))
+                                )
+                              )
+                            )
+                            (stores.1.i32 
+                              (mul.i32 
+                                (add.i32 
+                                  (const.i32 32)
+                                  (add.i32 
+                                    (getlocal $i2)
+                                    (const.i32 1)
+                                  )
+                                )
+                                (const.i32 4)
+                              )
+                              (getlocal $t3)
+                            )
+                            (setlocal $num (getlocal $i2))
+                            (setlocal $i2 (add.i32 
+                                (getlocal $num)
+                                (const.i32 1)
+                              ))
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+
+        )
+        ;; End Label $entry0
+
+        ;; Begin Label Block_8
+        (if (eq.i32 (getlocal $currentLabel_0) (const.i32 1)) 
+          (block 
+            (stores.1.i32 
+              (const.i32 0)
+              (getlocal $sum)
+            )
+            (stores.1.i32 
+              (const.i32 4)
+              (getlocal $maxflips)
+            )
+          )
+
+        )
+        ;; End Label Block_8
+
+        ;; Fallthrough exit from labelgroup 0
+        (break $labelgroup_0)
+        )
+      ))
+    )
+
+  )
+  (func $Program_readI32
+    (param $base i32) (param $offset i32) 
+    (result i32)
+
+    (return (loads.1.i32 (mul.i32 
+          (add.i32 
+            (getlocal $base)
+            (getlocal $offset)
+          )
+          (const.i32 4)
+        ) ))
+  )
+
+  (export "fannkuch" $Program_fannkuch)
+
+  (export "readI32" $Program_readI32)
+
+  (memory 4096 4096)
+
+)
+
+(invoke "fannkuch" (const.i32 7) )
+(asserteq (invoke "readI32" (const.i32 0) (const.i32 0)  ) (const.i32 228) )
+(asserteq (invoke "readI32" (const.i32 0) (const.i32 1)  ) (const.i32 16) )

--- a/ml-proto/test/goto.wasm
+++ b/ml-proto/test/goto.wasm
@@ -1,0 +1,207 @@
+;; Goto, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+
+(module 
+
+  (func $Program_AddResult
+    (param $result i32) (local $count i32) 
+
+    (block 
+      (setlocal $count (loads.1.i32 (const.i32 0) ))
+      (storeu.1.i8 
+        (add.i32 
+          (const.i32 4)
+          (getlocal $count)
+        )
+        (getlocal $result)
+      )
+      (stores.1.i32 
+        (const.i32 0)
+        (add.i32 
+          (getlocal $count)
+          (const.i32 1)
+        )
+      )
+    )
+
+  )
+  (func $Program_Clear
+    (param $offset i32) (param $count i32) (local $i i32) 
+
+    (block 
+
+      ;; for (var (@<var System.Int32 i> = 0); ...)
+      (setlocal $i (const.i32 0))
+
+      (label $loop_4096 
+        (loop 
+          ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
+
+          (if 
+            (lts.i32 
+              (getlocal $i)
+              (getlocal $count)
+            )
+            (nop)
+            (break $loop_4096)
+          )
+
+          ;; for (...) { 
+          (storeu.1.i8 
+            (add.i32 
+              (getlocal $offset)
+              (getlocal $i)
+            )
+            (const.i32 0)
+          )
+
+          ;; for (...; ...; <!>)
+          (setlocal $i (add.i32 
+              (getlocal $i)
+              (const.i32 1)
+            ))
+        )
+      )
+    )
+
+  )
+  (func $Program_GetResult
+    (param $index i32) 
+    (result i32)
+
+    (return (loadu.1.i8 (add.i32 
+          (const.i32 4)
+          (getlocal $index)
+        ) ))
+  )
+  (func $Program_GetResultCount
+
+    (result i32)
+
+    (return (loads.1.i32 (const.i32 0) ))
+  )
+  (func $Program_Gotos
+
+
+    (block 
+      (stores.1.i32 
+        (const.i32 0)
+        (const.i32 0)
+      )
+      (call $Program_Clear (const.i32 4) (const.i32 128) )
+      (call $Program_GotosInner )
+    )
+
+  )
+  (func $Program_GotosInner
+    (local $i i32) 
+    (local $currentLabel_0 i32) 
+
+    (block 
+      (setlocal $i (const.i32 0))
+
+      ;; while (<JSBooleanLiteral True>)
+      (label $loop_0 
+        (loop 
+
+          (if 
+            (const.i32 1)
+            (nop)
+            (break $loop_0)
+          )
+
+          ;; while (...) { 
+          (block 
+
+            ;; LabelGroup 0 (starting at IL_03)
+            (setlocal $currentLabel_0 (const.i32 0))
+
+            (label $labelgroup_0 (loop (label $labelgroup_0_dispatch 
+              ;; Begin Label IL_03
+              (if (eq.i32 (getlocal $currentLabel_0) (const.i32 0)) 
+                (block 
+                  (setlocal $i (add.i32 
+                      (getlocal $i)
+                      (const.i32 1)
+                    ))
+                  (call $Program_AddResult (const.i32 1) )
+
+                  (label $loop_4097 
+                    (loop 
+                      ;; for (...; (@<var System.Int32 i> < 16); ...)
+
+                      (if 
+                        (lts.i32 
+                          (getlocal $i)
+                          (const.i32 16)
+                        )
+                        (nop)
+                        (break $loop_4097)
+                      )
+
+                      ;; for (...) { 
+                      (block 
+
+                        (if 
+                          (eq.i32 
+                            (getlocal $i)
+                            (const.i32 8)
+                          )
+                          ;; goto IL_03
+                          (block (setlocal $currentLabel_0 (const.i32 0)) (break $labelgroup_0_dispatch) )
+                        )
+                        (call $Program_AddResult (const.i32 3) )
+                      )
+
+                      ;; for (...; ...; <!>)
+                      (setlocal $i (add.i32 
+                          (getlocal $i)
+                          (const.i32 1)
+                        ))
+                    )
+                  )
+                  (break $loop_0)
+                )
+
+              )
+              ;; End Label IL_03
+
+              ;; Fallthrough exit from labelgroup 0
+              (break $labelgroup_0)
+              )
+            ))
+          )
+        )
+      )
+    )
+
+  )
+
+  (export "getResult" $Program_GetResult)
+
+  (export "getResultCount" $Program_GetResultCount)
+
+  (export "gotos" $Program_Gotos)
+
+  (memory 1024 1024)
+
+)
+
+(invoke "gotos" )
+(asserteq (invoke "getResultCount"  ) (const.i32 16) )
+(asserteq (invoke "getResult" (const.i32 0)  ) (const.i32 1) )
+(asserteq (invoke "getResult" (const.i32 1)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 2)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 3)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 4)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 5)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 6)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 7)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 8)  ) (const.i32 1) )
+(asserteq (invoke "getResult" (const.i32 9)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 10)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 11)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 12)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 13)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 14)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 15)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 16)  ) (const.i32 0) )

--- a/ml-proto/test/goto.wasm
+++ b/ml-proto/test/goto.wasm
@@ -6,24 +6,21 @@
     (param $result i32) (local $count i32) 
 
     (block 
-      (setlocal $count (loads.1.i32 (const.i32 0) ))
+      (setlocal $count (call $Program_get_ResultCount))
       (storeu.1.i8 
         (add.i32 
-          (const.i32 4)
+          (const.i32 0)
           (getlocal $count)
         )
         (getlocal $result)
       )
-      (stores.1.i32 
-        (const.i32 0)
-        (add.i32 
+      (call $Program_set_ResultCount (add.i32 
           (getlocal $count)
           (const.i32 1)
-        )
-      )
+        ))
     )
-
   )
+
   (func $Program_Clear
     (param $offset i32) (param $count i32) (local $i i32) 
 
@@ -32,7 +29,7 @@
       ;; for (var (@<var System.Int32 i> = 0); ...)
       (setlocal $i (const.i32 0))
 
-      (label $loop_4096 
+      (label $loop_0 
         (loop 
           ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
 
@@ -42,7 +39,7 @@
               (getlocal $count)
             )
             (nop)
-            (break $loop_4096)
+            (break $loop_0)
           )
 
           ;; for (...) { 
@@ -62,36 +59,34 @@
         )
       )
     )
-
   )
+
+  (func $Program_get_ResultCount
+
+    (result i32)
+
+    (return (load_global $Program_ResultCount_value))
+  )
+
   (func $Program_GetResult
     (param $index i32) 
     (result i32)
 
     (return (loadu.1.i8 (add.i32 
-          (const.i32 4)
+          (const.i32 0)
           (getlocal $index)
         ) ))
   )
-  (func $Program_GetResultCount
 
-    (result i32)
-
-    (return (loads.1.i32 (const.i32 0) ))
-  )
   (func $Program_Gotos
 
-
     (block 
-      (stores.1.i32 
-        (const.i32 0)
-        (const.i32 0)
-      )
-      (call $Program_Clear (const.i32 4) (const.i32 128) )
+      (call $Program_set_ResultCount (const.i32 0))
+      (call $Program_Clear (const.i32 0) (const.i32 128) )
       (call $Program_GotosInner )
     )
-
   )
+
   (func $Program_GotosInner
     (local $i i32) 
     (local $currentLabel_0 i32) 
@@ -125,7 +120,7 @@
                     ))
                   (call $Program_AddResult (const.i32 1) )
 
-                  (label $loop_4097 
+                  (label $loop_1 
                     (loop 
                       ;; for (...; (@<var System.Int32 i> < 16); ...)
 
@@ -135,7 +130,7 @@
                           (const.i32 16)
                         )
                         (nop)
-                        (break $loop_4097)
+                        (break $loop_1)
                       )
 
                       ;; for (...) { 
@@ -173,21 +168,28 @@
         )
       )
     )
-
   )
 
+  (func $Program_set_ResultCount
+    (param $value i32) 
+
+    (store_global $Program_ResultCount_value (getlocal $value))
+  )
+
+  (export "get_ResultCount" $Program_get_ResultCount)
   (export "getResult" $Program_GetResult)
-
-  (export "getResultCount" $Program_GetResultCount)
-
   (export "gotos" $Program_Gotos)
+  (export "set_ResultCount" $Program_set_ResultCount)
+
+  (global $Program_ResultCount_value i32)
 
   (memory 1024 1024)
 
 )
 
+
 (invoke "gotos" )
-(asserteq (invoke "getResultCount"  ) (const.i32 16) )
+(asserteq (invoke "get_ResultCount"  ) (const.i32 16) )
 (asserteq (invoke "getResult" (const.i32 0)  ) (const.i32 1) )
 (asserteq (invoke "getResult" (const.i32 1)  ) (const.i32 3) )
 (asserteq (invoke "getResult" (const.i32 2)  ) (const.i32 3) )

--- a/ml-proto/test/sieve.wasm
+++ b/ml-proto/test/sieve.wasm
@@ -1,0 +1,214 @@
+;; Sieve, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+
+(module 
+
+  (func $Program_AddResult
+    (param $result i32) (local $count i32) 
+
+    (block 
+      (setlocal $count (loads.1.i32 (const.i32 0) ))
+      (stores.1.i32 
+        (mul.i32 
+          (add.i32 
+            (const.i32 4)
+            (getlocal $count)
+          )
+          (const.i32 4)
+        )
+        (getlocal $result)
+      )
+      (stores.1.i32 
+        (const.i32 0)
+        (add.i32 
+          (getlocal $count)
+          (const.i32 1)
+        )
+      )
+    )
+
+  )
+  (func $Program_Clear
+    (param $offset i32) (param $count i32) (local $i i32) 
+
+    (block 
+
+      ;; for (var (@<var System.Int32 i> = 0); ...)
+      (setlocal $i (const.i32 0))
+
+      (label $loop_4096 
+        (loop 
+          ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
+
+          (if 
+            (lts.i32 
+              (getlocal $i)
+              (getlocal $count)
+            )
+            (nop)
+            (break $loop_4096)
+          )
+
+          ;; for (...) { 
+          (storeu.1.i8 
+            (add.i32 
+              (getlocal $offset)
+              (getlocal $i)
+            )
+            (const.i32 0)
+          )
+
+          ;; for (...; ...; <!>)
+          (setlocal $i (add.i32 
+              (getlocal $i)
+              (const.i32 1)
+            ))
+        )
+      )
+    )
+
+  )
+  (func $Program_GetResult
+    (param $index i32) 
+    (result i32)
+
+    (return (loads.1.i32 (mul.i32 
+          (add.i32 
+            (const.i32 4)
+            (getlocal $index)
+          )
+          (const.i32 4)
+        ) ))
+  )
+  (func $Program_GetResultCount
+
+    (result i32)
+
+    (return (loads.1.i32 (const.i32 0) ))
+  )
+  (func $Program_Sieve
+    (param $target i32) (local $squareRoot f64) (local $candidate i32) (local $multiple i32) 
+
+
+    (block 
+      (stores.1.i32 
+        (const.i32 0)
+        (const.i32 0)
+      )
+      (call $Program_Clear (const.i32 4) (const.i32 16384) )
+      (call $Program_Clear (const.i32 16388) (getlocal $target) )
+      (setlocal $squareRoot (sqrt.f64 (converts.i32.f64 (getlocal $target)) ))
+      (call $Program_AddResult (const.i32 2) )
+
+      ;; for (var (@<var System.Int32 candidate> = 3); ...)
+      (setlocal $candidate (const.i32 3))
+
+      (label $loop_4097 
+        (loop 
+          ;; for (...; (@<var System.Int32 candidate> < @<parameter System.Int32 target>); ...)
+
+          (if 
+            (lts.i32 
+              (getlocal $candidate)
+              (getlocal $target)
+            )
+            (nop)
+            (break $loop_4097)
+          )
+
+          ;; for (...) { 
+          (block 
+
+            (if 
+              (eq.i32 
+                (loadu.1.i8 (add.i32 
+                    (const.i32 16388)
+                    (getlocal $candidate)
+                  ) )
+                (const.i32 0)
+              )
+              (block 
+
+                (if 
+                  (lt.f64 
+                    (converts.i32.f64 (getlocal $candidate))
+                    (getlocal $squareRoot)
+                  )
+                  (block 
+
+                    ;; for (var (@<var System.Int32 multiple> = (@<var System.Int32 candidate> * @<var System.Int32 candidate>)); ...)
+                    (setlocal $multiple (mul.i32 
+                        (getlocal $candidate)
+                        (getlocal $candidate)
+                      ))
+
+                    (label $loop_4098 
+                      (loop 
+                        ;; for (...; (@<var System.Int32 multiple> < @<parameter System.Int32 target>); ...)
+
+                        (if 
+                          (lts.i32 
+                            (getlocal $multiple)
+                            (getlocal $target)
+                          )
+                          (nop)
+                          (break $loop_4098)
+                        )
+
+                        ;; for (...) { 
+                        (storeu.1.i8 
+                          (add.i32 
+                            (const.i32 16388)
+                            (getlocal $multiple)
+                          )
+                          (const.i32 1)
+                        )
+
+                        ;; for (...; ...; <!>)
+                        (setlocal $multiple (add.i32 
+                            (getlocal $multiple)
+                            (mul.i32 
+                              (const.i32 2)
+                              (getlocal $candidate)
+                            )
+                          ))
+                      )
+                    )
+                  )
+                )
+                (call $Program_AddResult (getlocal $candidate) )
+              )
+            )
+          )
+
+          ;; for (...; ...; <!>)
+          (setlocal $candidate (add.i32 
+              (getlocal $candidate)
+              (const.i32 2)
+            ))
+        )
+      )
+    )
+
+  )
+
+  (export "getResult" $Program_GetResult)
+
+  (export "getResultCount" $Program_GetResultCount)
+
+  (export "sieve" $Program_Sieve)
+
+  (memory 131072 131072)
+
+)
+
+(invoke "sieve" (const.i32 24) )
+(asserteq (invoke "getResultCount"  ) (const.i32 9) )
+(asserteq (invoke "getResult" (const.i32 0)  ) (const.i32 2) )
+(asserteq (invoke "getResult" (const.i32 1)  ) (const.i32 3) )
+(asserteq (invoke "getResult" (const.i32 2)  ) (const.i32 5) )
+(asserteq (invoke "getResult" (const.i32 3)  ) (const.i32 7) )
+(asserteq (invoke "getResult" (const.i32 4)  ) (const.i32 11) )
+(asserteq (invoke "getResult" (const.i32 5)  ) (const.i32 13) )
+(asserteq (invoke "getResult" (const.i32 6)  ) (const.i32 17) )
+(asserteq (invoke "getResult" (const.i32 7)  ) (const.i32 19) )
+(asserteq (invoke "getResult" (const.i32 8)  ) (const.i32 23) )

--- a/ml-proto/test/sieve.wasm
+++ b/ml-proto/test/sieve.wasm
@@ -6,27 +6,24 @@
     (param $result i32) (local $count i32) 
 
     (block 
-      (setlocal $count (loads.1.i32 (const.i32 0) ))
+      (setlocal $count (call $Program_get_ResultCount))
       (stores.1.i32 
         (mul.i32 
           (add.i32 
-            (const.i32 4)
+            (const.i32 0)
             (getlocal $count)
           )
           (const.i32 4)
         )
         (getlocal $result)
       )
-      (stores.1.i32 
-        (const.i32 0)
-        (add.i32 
+      (call $Program_set_ResultCount (add.i32 
           (getlocal $count)
           (const.i32 1)
-        )
-      )
+        ))
     )
-
   )
+
   (func $Program_Clear
     (param $offset i32) (param $count i32) (local $i i32) 
 
@@ -35,7 +32,7 @@
       ;; for (var (@<var System.Int32 i> = 0); ...)
       (setlocal $i (const.i32 0))
 
-      (label $loop_4096 
+      (label $loop_0 
         (loop 
           ;; for (...; (@<var System.Int32 i> < @<parameter System.Int32 count>); ...)
 
@@ -45,7 +42,7 @@
               (getlocal $count)
             )
             (nop)
-            (break $loop_4096)
+            (break $loop_0)
           )
 
           ;; for (...) { 
@@ -65,36 +62,40 @@
         )
       )
     )
-
   )
+
+  (func $Program_get_ResultCount
+
+    (result i32)
+
+    (return (load_global $Program_ResultCount_value))
+  )
+
   (func $Program_GetResult
     (param $index i32) 
     (result i32)
 
     (return (loads.1.i32 (mul.i32 
           (add.i32 
-            (const.i32 4)
+            (const.i32 0)
             (getlocal $index)
           )
           (const.i32 4)
         ) ))
   )
-  (func $Program_GetResultCount
 
-    (result i32)
+  (func $Program_set_ResultCount
+    (param $value i32) 
 
-    (return (loads.1.i32 (const.i32 0) ))
+    (store_global $Program_ResultCount_value (getlocal $value))
   )
+
   (func $Program_Sieve
     (param $target i32) (local $squareRoot f64) (local $candidate i32) (local $multiple i32) 
 
-
     (block 
-      (stores.1.i32 
-        (const.i32 0)
-        (const.i32 0)
-      )
-      (call $Program_Clear (const.i32 4) (const.i32 16384) )
+      (call $Program_set_ResultCount (const.i32 0))
+      (call $Program_Clear (const.i32 0) (const.i32 16384) )
       (call $Program_Clear (const.i32 16388) (getlocal $target) )
       (setlocal $squareRoot (sqrt.f64 (converts.i32.f64 (getlocal $target)) ))
       (call $Program_AddResult (const.i32 2) )
@@ -102,7 +103,7 @@
       ;; for (var (@<var System.Int32 candidate> = 3); ...)
       (setlocal $candidate (const.i32 3))
 
-      (label $loop_4097 
+      (label $loop_0 
         (loop 
           ;; for (...; (@<var System.Int32 candidate> < @<parameter System.Int32 target>); ...)
 
@@ -112,7 +113,7 @@
               (getlocal $target)
             )
             (nop)
-            (break $loop_4097)
+            (break $loop_0)
           )
 
           ;; for (...) { 
@@ -141,7 +142,7 @@
                         (getlocal $candidate)
                       ))
 
-                    (label $loop_4098 
+                    (label $loop_1 
                       (loop 
                         ;; for (...; (@<var System.Int32 multiple> < @<parameter System.Int32 target>); ...)
 
@@ -151,7 +152,7 @@
                             (getlocal $target)
                           )
                           (nop)
-                          (break $loop_4098)
+                          (break $loop_1)
                         )
 
                         ;; for (...) { 
@@ -188,21 +189,22 @@
         )
       )
     )
-
   )
 
+  (export "get_ResultCount" $Program_get_ResultCount)
   (export "getResult" $Program_GetResult)
-
-  (export "getResultCount" $Program_GetResultCount)
-
+  (export "set_ResultCount" $Program_set_ResultCount)
   (export "sieve" $Program_Sieve)
+
+  (global $Program_ResultCount_value i32)
 
   (memory 131072 131072)
 
 )
 
+
 (invoke "sieve" (const.i32 24) )
-(asserteq (invoke "getResultCount"  ) (const.i32 9) )
+(asserteq (invoke "get_ResultCount"  ) (const.i32 9) )
 (asserteq (invoke "getResult" (const.i32 0)  ) (const.i32 2) )
 (asserteq (invoke "getResult" (const.i32 1)  ) (const.i32 3) )
 (asserteq (invoke "getResult" (const.i32 2)  ) (const.i32 5) )


### PR DESCRIPTION
This isn't necessarily something we want to merge yet, but I wanted to make a PR so people can look at it and we can start a discussion.

I did some work to cross-compile simple test cases from C# to wasm. I have some basic stuff working. CountUp passes; Fannkuch starts, runs, then fails (which is progress, since it was hanging before!)

See https://gist.github.com/kg/3f66f50e2428d9d47a41 for the source to Fannkuch and https://gist.github.com/kg/4cd6e23a73ac232dcca5 for the source to CountUp.

My goal here was to start translating more-realistic functions and workflows from a source language to wasm, instead of just hand-writing wasm tests. This will be helpful in the interim until LLVM's wasm backend is working, and we might still want to have another source language for tests just to make sure we aren't overly focused on LLVM.

It would be great to get help stepping through fannkuch to figure out why it's broken. The current state of the interpreter is basically impossible to debug - if it hangs, it just hangs, and ```-t``` doesn't seem to trace the actual instructions being executed. I may take a shot at adding more instrumentation to the interpreter once I can figure out the code.

Some related code quality/syntax questions came up while porting these tests, so I'll file issues about them separately.