### PR TITLE
Rename round to nearestint.

### DIFF
--- a/ml-proto/src/arithmetic.ml
+++ b/ml-proto/src/arithmetic.ml
@@ -185,7 +185,7 @@ struct
       | Ceil -> ceil
       | Floor -> floor
       | Trunc -> fun _ -> 0.0  (* TODO *)
-      | Round -> fun _ -> 0.0  (* TODO *)
+      | Nearest -> fun _ -> 0.0  (* TODO *)
       | Sqrt  -> sqrt
     in fun v -> Float.to_value (f (Float.of_value 1 v))
 

--- a/ml-proto/src/ast.ml
+++ b/ml-proto/src/ast.ml
@@ -43,7 +43,7 @@ end
 
 module FloatOp () =
 struct
-  type unop = Neg | Abs | Ceil | Floor | Trunc | Round | Sqrt
+  type unop = Neg | Abs | Ceil | Floor | Trunc | Nearest | Sqrt
   type binop = Add | Sub | Mul | Div | CopySign
   type relop = Eq | Neq | Lt | Le | Gt | Ge
   type cvt = ToInt32S | ToInt32U | ToInt64S | ToInt64U | ToIntCast

--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -172,7 +172,7 @@ rule token = parse
   | "ceil."(fxx as t) { UNARY (floatop t F32.Ceil F64.Ceil) }
   | "floor."(fxx as t) { UNARY (floatop t F32.Floor F64.Floor) }
   | "trunc."(fxx as t) { UNARY (floatop t F32.Trunc F64.Trunc) }
-  | "round."(fxx as t) { UNARY (floatop t F32.Round F64.Round) }
+  | "nearest."(fxx as t) { UNARY (floatop t F32.Nearest F64.Nearest) }
   | "sqrt."(fxx as t) { UNARY (floatop t F32.Sqrt F64.Sqrt) }
 
   | "add."(ixx as t) { BINARY (intop t I32.Add I64.Add) }


### PR DESCRIPTION
This is what the design repo calls it. And in particular, it's useful to
avoid calling it "round" because it's semantically different from both
JS's Math.round and C's round.