### PR TITLE
Rename Mod to Rem.

### DIFF
--- a/ml-proto/src/arithmetic.ml
+++ b/ml-proto/src/arithmetic.ml
@@ -103,8 +103,8 @@ struct
       | Mul -> Int.mul
       | DivS -> Int.div
       | DivU -> fun i j -> Int.of_big_int_u (unsigned div_big_int i j)
-      | ModS -> Int.rem
-      | ModU -> fun i j -> Int.of_big_int_u (unsigned mod_big_int i j)
+      | RemS -> Int.rem
+      | RemU -> fun i j -> Int.of_big_int_u (unsigned mod_big_int i j)
       | And -> Int.logand
       | Or -> Int.logor
       | Xor -> Int.logxor

--- a/ml-proto/src/ast.ml
+++ b/ml-proto/src/ast.ml
@@ -34,7 +34,7 @@ type value_type = Types.value_type Source.phrase
 module IntOp () =
 struct
   type unop = Neg | Abs | Not | Clz | Ctz
-  type binop = Add | Sub | Mul | DivS | DivU | ModS | ModU
+  type binop = Add | Sub | Mul | DivS | DivU | RemS | RemU
              | And | Or | Xor | Shl | Shr | Sar
   type relop = Eq | Neq | LtS | LtU | LeS | LeU | GtS | GtU | GeS | GeU
   type cvt = ToInt32S | ToInt32U | ToInt64S | ToInt64U

--- a/ml-proto/src/lexer.mll
+++ b/ml-proto/src/lexer.mll
@@ -179,8 +179,8 @@ rule token = parse
   | "mul."(ixx as t) { BINARY (intop t I32.Mul I64.Mul) }
   | "divs."(ixx as t) { BINARY (intop t I32.DivS I64.DivS) }
   | "divu."(ixx as t) { BINARY (intop t I32.DivU I64.DivU) }
-  | "mods."(ixx as t) { BINARY (intop t I32.ModS I64.ModS) }
-  | "modu."(ixx as t) { BINARY (intop t I32.ModU I64.ModU) }
+  | "rems."(ixx as t) { BINARY (intop t I32.RemS I64.RemS) }
+  | "remu."(ixx as t) { BINARY (intop t I32.RemU I64.RemU) }
   | "and."(ixx as t) { BINARY (intop t I32.And I64.And) }
   | "or."(ixx as t) { BINARY (intop t I32.Or I64.Or) }
   | "xor."(ixx as t) { BINARY (intop t I32.Xor I64.Xor) }

--- a/ml-proto/test/multivalue.wasm
+++ b/ml-proto/test/multivalue.wasm
@@ -54,7 +54,7 @@
       (case 7)
       (case 8
         (return
-          (if (eq.i32 (mods.i32 (getlocal $case) (const.i32 2)) (const.i32 0))
+          (if (eq.i32 (rems.i32 (getlocal $case) (const.i32 2)) (const.i32 0))
             (call $swap (getlocal $x1) (getlocal $x2))
             (call $swap (getlocal $x2) (getlocal $x1))
           )

--- a/ml-proto/test/unsigned.wasm
+++ b/ml-proto/test/unsigned.wasm
@@ -3,8 +3,8 @@
     (return
       (divs.i64 (getlocal $i) (getlocal $j))
       (divu.i64 (getlocal $i) (getlocal $j))
-      (mods.i64 (getlocal $i) (getlocal $j))
-      (modu.i64 (getlocal $i) (getlocal $j))
+      (rems.i64 (getlocal $i) (getlocal $j))
+      (remu.i64 (getlocal $i) (getlocal $j))
     )
   )
 


### PR DESCRIPTION
The signed remainder operator in particular is not clearly described as
a modulus function, because it returns negative values when the dividend
is negative. This patch renames it from "mod" to "rem", which is also in
accordance with AstSemantics.md.