### PR TITLE
Add assert_heap_eq script command to check contents of a heap region

### DIFF
--- a/ml-proto/src/host/lexer.mll
+++ b/ml-proto/src/host/lexer.mll
@@ -249,6 +249,7 @@ rule token = parse
   | "assert_invalid" { ASSERTINVALID }
   | "assert_eq" { ASSERTEQ }
   | "assert_trap" { ASSERTTRAP }
+  | "assert_heap_eq" { ASSERTHEAPEQ }
   | "invoke" { INVOKE }
 
   | name as s { VAR s }

--- a/ml-proto/src/host/script.ml
+++ b/ml-proto/src/host/script.ml
@@ -134,6 +134,8 @@ and char_at_memory_offset m base offset =
     | Int32 i -> Int32.to_int i
     | _ -> assert false
   in
+  assert (code >= 0);
+  assert (code <= 255);
   Char.chr code
 
 and memory_as_string m offset count =

--- a/ml-proto/src/host/script.ml
+++ b/ml-proto/src/host/script.ml
@@ -130,7 +130,7 @@ let rec run_command cmd =
     done;
 
 and char_at_memory_offset m base offset =
-  let code = match Memory.load m (base + offset) Int8Mem ZX with
+  let code = match Memory.load_extend m (base + offset) Mem8 ZX Int32Type with
     | Int32 i -> Int32.to_int i
     | _ -> assert false
   in

--- a/ml-proto/src/host/script.ml
+++ b/ml-proto/src/host/script.ml
@@ -130,7 +130,7 @@ let rec run_command cmd =
     done;
 
 and char_at_memory_offset m base offset =
-  let code = match Memory.load m (base + offset) Int8Mem SX with
+  let code = match Memory.load m (base + offset) Int8Mem ZX with
     | Int32 i -> Int32.to_int i
     | _ -> assert false
   in

--- a/ml-proto/src/host/script.mli
+++ b/ml-proto/src/host/script.mli
@@ -9,6 +9,7 @@ and command' =
   | Invoke of string * Ast.expr list
   | AssertEq of string * Ast.expr list * Ast.expr
   | AssertTrap of string * Ast.expr list * string
+  | AssertHeapEq of int * string
 
 type script = command list
 

--- a/ml-proto/src/spec/eval.ml
+++ b/ml-proto/src/spec/eval.ml
@@ -305,3 +305,6 @@ let eval e =
   let host = {page_size = 1} in
   let m = {imports = []; exports; tables = []; funcs = [f]; memory; host} in
   eval_func m f []
+
+let memory_for_module m =
+  m.memory

--- a/ml-proto/src/spec/eval.mli
+++ b/ml-proto/src/spec/eval.mli
@@ -11,3 +11,4 @@ val init : Ast.modul -> import list -> host_params -> instance
 val invoke : instance -> string -> value list -> value option
   (* raise Error.Error *)
 val eval : Ast.expr -> value option (* raise Error.Error *)
+val memory_for_module : instance -> Memory.t


### PR DESCRIPTION
Added an ```assert_heap_eq``` script command alongside ```assert_eq```. You specify a base offset into the module heap along with an expected series of bytes (as a string with escapes, like memory segments).

This allows straightforward tests for algorithms that don't merely produce a few bytes ([this test](https://github.com/WebAssembly/ilwasm/blob/master/third_party/tests/Strcat.cs), for example.)