### PR TITLE
Update load/store to match design changes

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -127,8 +127,8 @@ type expr =
   | SetLocal of var * expr                  (* write local variable
   | LoadGlobal of var                       (* read global variable
   | StoreGlobal of var * expr               (* write global variable
-  | Load of memop * expr                    (* read memory address
-  | Store of memop * expr * expr            (* write memory address
+  | Load of loadop * expr                   (* read memory address
+  | Store of storeop * expr * expr          (* write memory address
   | Const of value                          (* constant
   | Unary of unop * expr                    (* unary arithmetic operator
   | Binary of binop * expr * expr           (* binary arithmetic operator
@@ -147,7 +147,6 @@ The S-expression syntax is defined in `parser.mly`, the opcodes in `lexer.mll`. 
 
 ```
 type: i32 | i64 | f32 | f64
-memtype: <type> | i8 | i16
 
 value: <int> | <float>
 var: <int> | $<name>
@@ -157,7 +156,6 @@ binop: add | sub | mul | ...
 relop: eq | neq | lt | ...
 sign: s|u
 align: 1|2|4|8|...
-memop: (<sign>.)?(<align>.)?
 cvtop: trunc_s | trunc_u | extend_s | extend_u | ...
 
 expr:
@@ -177,8 +175,8 @@ expr:
   ( set_local <var> <expr> )
   ( load_global <var> )
   ( store_global <var> <expr> )
-  ( <type>.load<memop><memtype> <expr> )
-  ( <type>.store<memop><memtype> <expr> <expr> )
+  ( <type>.load((8|16)_<sign>)?(/<align>)? <expr> )
+  ( <type>.store(/<align>)? <expr> <expr> )
   ( <type>.const <value> )
   ( <type>.<unop> <expr> )
   ( <type>.<binop> <expr> <expr> )

--- a/ml-proto/src/host/parser.mly
+++ b/ml-proto/src/host/parser.mly
@@ -113,8 +113,8 @@ let anon_label c = {c with labels = VarMap.map ((+) 1) c.labels}
 %token<Ast.binop> BINARY
 %token<Ast.relop> COMPARE
 %token<Ast.cvt> CONVERT
-%token<Ast.memop> LOAD
-%token<Ast.memop> STORE
+%token<Ast.loadop> LOAD
+%token<Ast.storeop> STORE
 
 %start script
 %type<Script.script> script

--- a/ml-proto/src/spec/ast.ml
+++ b/ml-proto/src/spec/ast.ml
@@ -63,7 +63,8 @@ type binop = (Int32Op.binop, Int64Op.binop, Float32Op.binop, Float64Op.binop) op
 type relop = (Int32Op.relop, Int64Op.relop, Float32Op.relop, Float64Op.relop) op
 type cvt = (Int32Op.cvt, Int64Op.cvt, Float32Op.cvt, Float64Op.cvt) op
 
-type memop = {ty : Types.value_type; mem : Memory.mem_type; align : int}
+type loadop = {mem : Memory.mem_type; ext : Memory.extension; align : int}
+type storeop = {mem : Memory.mem_type; align : int}
 
 
 (* Expressions *)
@@ -87,8 +88,8 @@ and expr' =
   | SetLocal of var * expr
   | LoadGlobal of var
   | StoreGlobal of var * expr
-  | Load of memop * expr
-  | Store of memop * expr * expr
+  | Load of loadop * expr
+  | Store of storeop * expr * expr
   | Const of literal
   | Unary of unop * expr
   | Binary of binop * expr * expr

--- a/ml-proto/src/spec/check.ml
+++ b/ml-proto/src/spec/check.ml
@@ -181,12 +181,12 @@ let rec check_expr c et e =
     check_type None et e.at
 
   | Load (loadop, e1) ->
-    check_memop loadop.align e.at;
+    check_align loadop.align e.at;
     check_expr c (Some Int32Type) e1;
     check_type (Some (type_mem loadop.mem)) et e.at
 
   | Store (storeop, e1, e2) ->
-    check_memop storeop.align e.at;
+    check_align storeop.align e.at;
     check_expr c (Some Int32Type) e1;
     check_expr c (Some (type_mem storeop.mem)) e2;
     check_type None et e.at
@@ -234,7 +234,7 @@ and check_arm c t et arm =
   check_literal c (Some t) l;
   check_expr c (if fallthru then None else et) e
 
-and check_memop align at =
+and check_align align at =
   require (Lib.Int.is_power_of_two align) at "non-power-of-two alignment"
 
 

--- a/ml-proto/src/spec/eval.ml
+++ b/ml-proto/src/spec/eval.ml
@@ -156,12 +156,14 @@ let rec eval_expr (c : config) (e : expr) =
     global c x := v1;
     None
 
-  | Load ({mem; ty; _}, e1) ->
+  | Load ({mem; ext; align}, e1) ->
+    ignore align;
     let v1 = some (eval_expr c e1) e1.at in
-    (try Some (Memory.load c.modul.memory (Memory.address_of_value v1) mem ty)
+    (try Some (Memory.load c.modul.memory (Memory.address_of_value v1) mem ext)
     with exn -> memory_error e.at exn)
 
-  | Store ({mem; _}, e1, e2) ->
+  | Store ({mem; align}, e1, e2) ->
+    ignore align;
     let v1 = some (eval_expr c e1) e1.at in
     let v2 = some (eval_expr c e2) e2.at in
     (try Memory.store c.modul.memory (Memory.address_of_value v1) mem v2

--- a/ml-proto/src/spec/eval.ml
+++ b/ml-proto/src/spec/eval.ml
@@ -156,14 +156,12 @@ let rec eval_expr (c : config) (e : expr) =
     global c x := v1;
     None
 
-  | Load ({mem; ext; align}, e1) ->
-    ignore align;
+  | Load ({mem; ext; align = _}, e1) ->
     let v1 = some (eval_expr c e1) e1.at in
     (try Some (Memory.load c.modul.memory (Memory.address_of_value v1) mem ext)
     with exn -> memory_error e.at exn)
 
-  | Store ({mem; align}, e1, e2) ->
-    ignore align;
+  | Store ({mem; align = _}, e1, e2) ->
     let v1 = some (eval_expr c e1) e1.at in
     let v2 = some (eval_expr c e2) e2.at in
     (try Memory.store c.modul.memory (Memory.address_of_value v1) mem v2

--- a/ml-proto/src/spec/memory.mli
+++ b/ml-proto/src/spec/memory.mli
@@ -7,10 +7,9 @@ type t = memory
 type address = int
 type size = address
 type mem_size = int
+type extension = SX | ZX | NX
 type mem_type =
-  | SInt8Mem | SInt16Mem | SInt32Mem | SInt64Mem
-  | UInt8Mem | UInt16Mem | UInt32Mem | UInt64Mem
-  | Float32Mem | Float64Mem
+  Int8Mem | Int16Mem | Int32Mem | Int64Mem | Float32Mem | Float64Mem
 
 type segment = {addr : address; data : string}
 
@@ -20,7 +19,7 @@ exception Address
 
 val create : size -> memory
 val init : memory -> segment list -> unit
-val load : memory -> address -> mem_type -> Types.value_type -> Values.value
+val load : memory -> address -> mem_type -> extension -> Values.value
 val store : memory -> address -> mem_type -> Values.value -> unit
 
 val mem_size : mem_type -> mem_size

--- a/ml-proto/test/memory.wasm
+++ b/ml-proto/test/memory.wasm
@@ -35,29 +35,29 @@
 )
 
 ;; Test alignment annotation rules
-(module (func (i32.load_u/i8/2 (i32.const 0))))
-(module (func (i32.load_u/i16/4 (i32.const 0))))
-(module (func (i32.load_u/i32/8 (i32.const 0))))
-(module (func (f32.load/f32/8 (i32.const 0))))
+(module (func (i32.load8_u/2 (i32.const 0))))
+(module (func (i32.load16_u/4 (i32.const 0))))
+(module (func (i32.load/8 (i32.const 0))))
+(module (func (f32.load/8 (i32.const 0))))
 
 (assert_invalid
-  (module (func (i64.load_u/i64/0 (i32.const 0))))
+  (module (func (i64.load/0 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (func (i64.load_u/i64/3 (i32.const 0))))
+  (module (func (i64.load/3 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (func (i64.load_u/i64/5 (i32.const 0))))
+  (module (func (i64.load/5 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (func (i64.load_u/i64/6 (i32.const 0))))
+  (module (func (i64.load/6 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (func (i64.load_u/i64/7 (i32.const 0))))
+  (module (func (i64.load/7 (i32.const 0))))
   "non-power-of-two alignment"
 )
 
@@ -68,12 +68,12 @@
   (func $data (result i32)
     (i32.and
       (i32.and
-        (i32.eq (i32.load_u/i8 (i32.const 0)) (i32.const 65))
-        (i32.eq (i32.load_u/i8 (i32.const 3)) (i32.const 167))
+        (i32.eq (i32.load8_u (i32.const 0)) (i32.const 65))
+        (i32.eq (i32.load8_u (i32.const 3)) (i32.const 167))
       )
       (i32.and
-        (i32.eq (i32.load_u/i8 (i32.const 20)) (i32.const 87))
-        (i32.eq (i32.load_u/i8 (i32.const 23)) (i32.const 77))
+        (i32.eq (i32.load8_u (i32.const 20)) (i32.const 87))
+        (i32.eq (i32.load8_u (i32.const 23)) (i32.const 77))
       )
     )
   )
@@ -89,8 +89,8 @@
           (break)
         )
         (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
-        (i32.store/i32 (get_local 2) (get_local 0))
-        (set_local 1 (i32.load_s/i32 (get_local 2)))
+        (i32.store (get_local 2) (get_local 0))
+        (set_local 1 (i32.load (get_local 2)))
         (if
           (i32.neq (get_local 0) (get_local 1))
           (return (i32.const 0))
@@ -112,8 +112,8 @@
           (break)
         )
         (set_local 2 (f64.convert_s/i32 (get_local 0)))
-        (f64.store/f64/1 (get_local 0) (get_local 2))
-        (set_local 1 (f64.load/f64/1 (get_local 0)))
+        (f64.store/1 (get_local 0) (get_local 2))
+        (set_local 1 (f64.load/1 (get_local 0)))
         (if
           (f64.neq (get_local 2) (get_local 1))
           (return (i32.const 0))
@@ -126,17 +126,17 @@
 
   ;; Memory cast
   (func $cast (result f64)
-    (i64.store/i64 (i32.const 8) (i64.const -12345))
+    (i64.store (i32.const 8) (i64.const -12345))
     (if
       (f64.eq
-        (f64.load/f64 (i32.const 8))
+        (f64.load (i32.const 8))
         (f64.reinterpret/i64 (i64.const -12345))
       )
       (return (f64.const 0))
     )
-    (i64.store/i64/1 (i32.const 9) (i64.const 0))
-    (i32.store/i16/1 (i32.const 15) (i32.const 16453))
-    (return (f64.load/f64/1 (i32.const 9)))
+    (i64.store/1 (i32.const 9) (i64.const 0))
+    (i32.store16/1 (i32.const 15) (i32.const 16453))
+    (return (f64.load/1 (i32.const 9)))
   )
 
   (export "data" $data)


### PR DESCRIPTION
This patch updates ml-proto to match the changes in #341.  The only remaining difference is that, for all opcode names, not just load/store, ml-proto uses the "i32" form vs. "int32".  (I could see this difference resolved in either spec or design, so I'll leave that for a separate issue.)