### PR TITLE
Update runtests to compile with debugging information

### DIFF
--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -51,7 +51,7 @@ def find_interpreter(path):
 def rebuild_interpreter(path):
   print("// building %s" % path)
   sys.stdout.flush()
-  exitCode = subprocess.call(["ocamlbuild", "-libs", "bigarray, nums, str", "-Is", "given, spec, host", "host/main.native"], cwd=os.path.abspath("src"))
+  exitCode = subprocess.call(["ocamlbuild", "-libs", "bigarray, nums, str", "-Is", "given, spec, host", "-cflags", "-g", "host/main.native"], cwd=os.path.abspath("src"))
   if (exitCode != 0):
     raise Exception("ocamlbuild failed with exit code %i" % exitCode)
   if not os.path.exists(path):


### PR DESCRIPTION
With this change you can get full stack traces out of main.native by doing ```export OCAMLRUNPARAM=b```.

So:
```
/usr/local/google/home/kgadd/Projects/wasm-spec/ml-proto/src/_build/host/main.native: uncaught exception Failure("span")
Raised at file "pervasives.ml", line 31, characters 25-45
```
becomes
```
/usr/local/google/home/kgadd/Projects/wasm-spec/ml-proto/src/_build/host/main.native: uncaught exception Failure("span")
Raised at file "given/source.ml", line 24, characters 16-32
Called from file "spec/check.ml", line 222, characters 35-50
Called from file "spec/check.ml", line 157, characters 4-24
Called from file "spec/check.ml", line 204, characters 4-28
Called from file "list.ml", line 110, characters 24-31
Called from file "spec/check.ml", line 221, characters 6-38
Called from file "spec/check.ml", line 157, characters 4-24
Called from file "list.ml", line 73, characters 12-15
Called from file "spec/check.ml", line 130, characters 4-37
Called from file "list.ml", line 73, characters 12-15
Called from file "spec/check.ml", line 298, characters 2-33
Called from file "host/script.ml", line 40, characters 4-24
Called from file "list.ml", line 73, characters 12-15
Called from file "host/main.ml", line 36, characters 4-21
Called from file "host/main.ml", line 46, characters 9-30
Called from file "list.ml", line 73, characters 12-15
Called from file "host/main.ml", line 78, characters 4-33
```