### PR TITLE
Remove globals

### DIFF
--- a/ml-proto/src/host/lexer.mll
+++ b/ml-proto/src/host/lexer.mll
@@ -143,9 +143,6 @@ rule token = parse
   | "get_local" { GETLOCAL }
   | "set_local" { SETLOCAL }
 
-  | "load_global" { LOADGLOBAL }
-  | "store_global" { STOREGLOBAL }
-
   | (nxx as t)".load" { LOAD (loadop t ' ' "") }
   | (nxx as t)".load/"(align as a) { LOAD (loadop t ' ' a) }
   | (ixx)".load"(width as w)"_"(sign as s) { LOAD (loadop ("i" ^ w) s "") }
@@ -246,7 +243,6 @@ rule token = parse
   | "module" { MODULE }
   | "memory" { MEMORY }
   | "segment" { SEGMENT }
-  | "global" { GLOBAL }
   | "import" { IMPORT }
   | "export" { EXPORT }
   | "table" { TABLE }

--- a/ml-proto/src/host/print.ml
+++ b/ml-proto/src/host/print.ml
@@ -38,9 +38,6 @@ let print_table_sig prefix i t_opt =
 let print_func i f =
   print_func_sig "func" i f
 
-let print_global i t =
-  print_var_sig "global" i t
-
 let print_export m i ex =
   print_export_sig "export" ex.it.name (List.nth m.it.funcs ex.it.func.it)
 
@@ -53,9 +50,8 @@ let print_table m i tab =
 
 
 let print_module m =
-  let {funcs; globals; exports; tables} = m.it in
+  let {funcs; exports; tables} = m.it in
   List.iteri print_func funcs;
-  List.iteri print_global globals;
   List.iteri (print_export m) exports;
   List.iteri (print_table m) tables;
   flush_all ()

--- a/ml-proto/src/spec/ast.ml
+++ b/ml-proto/src/spec/ast.ml
@@ -87,8 +87,6 @@ and expr' =
   | Return of expr option
   | GetLocal of var
   | SetLocal of var * expr
-  | LoadGlobal of var
-  | StoreGlobal of var * expr
   | Load of loadop * expr
   | Store of storeop * expr * expr
   | Const of literal
@@ -151,5 +149,4 @@ and modul' =
   imports : import list;
   exports : export list;
   tables : table list;
-  globals : value_type list
 }

--- a/ml-proto/test/forward.wasm
+++ b/ml-proto/test/forward.wasm
@@ -12,14 +12,11 @@
   )
 
   (func $odd (param $n i32) (result i32)
-    (store_global $scratch (get_local $n))
     (if (i32.eq (get_local $n) (i32.const 0))
       (i32.const 0)
       (call $even (i32.sub (get_local $n) (i32.const 1)))
     )
   )
-
-  (global $scratch i32)
 )
 
 (assert_eq (invoke "even" (i32.const 13)) (i32.const 0))


### PR DESCRIPTION
Globals were moved out of the MVP in [design/#344](https://github.com/WebAssembly/design/pull/344); this patch updates the ML spec accordingly.