### PR TITLE
Fix a bug in the detection of end-of-file.

### DIFF
--- a/ml-proto/src/host/main.ml
+++ b/ml-proto/src/host/main.ml
@@ -12,7 +12,7 @@ let load file =
   let rec loop () =
     let len = input f buf 0 size in
     let source = Bytes.sub_string buf 0 len in
-    if len < size then source else source ^ loop ()
+    if len == 0 then source else source ^ loop ()
   in
   let source = loop () in
   close_in f;


### PR DESCRIPTION
input returns 0 when it reaches the end of the file; other values may
indicate merely a short read. This fixes #72.