### PR TITLE
Fix the min and max computation for the case where the operands are equal

### DIFF
--- a/ml-proto/src/given/float32.ml
+++ b/ml-proto/src/given/float32.ml
@@ -61,7 +61,7 @@ let min x y =
   let xf = arith_of_bits x in
   let yf = arith_of_bits y in
   (* min(-0, 0) is -0 *)
-  if xf = 0.0 && yf = 0.0 then (Int32.logor x y) else
+  if xf = yf then Int32.logor x y else
   if xf < yf then x else
   if xf > yf then y else
   nondeterministic_nan
@@ -70,7 +70,7 @@ let max x y =
   let xf = arith_of_bits x in
   let yf = arith_of_bits y in
   (* max(-0, 0) is 0 *)
-  if xf = 0.0 && yf = 0.0 then (Int32.logand x y) else
+  if xf = yf then Int32.logand x y else
   if xf > yf then x else
   if xf < yf then y else
   nondeterministic_nan

--- a/ml-proto/src/given/float64.ml
+++ b/ml-proto/src/given/float64.ml
@@ -61,7 +61,7 @@ let min x y =
   let xf = arith_of_bits x in
   let yf = arith_of_bits y in
   (* min(-0, 0) is -0 *)
-  if xf = 0.0 && yf = 0.0 then (Int64.logor x y) else
+  if xf = yf then Int64.logor x y else
   if xf < yf then x else
   if xf > yf then y else
   nondeterministic_nan
@@ -70,7 +70,7 @@ let max x y =
   let xf = arith_of_bits x in
   let yf = arith_of_bits y in
   (* max(-0, 0) is 0 *)
-  if xf = 0.0 && yf = 0.0 then (Int64.logand x y) else
+  if xf = yf then Int64.logand x y else
   if xf > yf then x else
   if xf < yf then y else
   nondeterministic_nan


### PR DESCRIPTION
This fixes a thinko in the min and max functions. Tests for this will be added soon; they're in development on the [float-tests](https://github.com/WebAssembly/spec/tree/float-tests) branch.