### PR TITLE
Rename 'or' to 'ior', to match the design repo.

### DIFF
--- a/ml-proto/src/host/lexer.mll
+++ b/ml-proto/src/host/lexer.mll
@@ -178,7 +178,7 @@ rule token = parse
   | (ixx as t)".rem_s" { BINARY (intop t Int32Op.RemS Int64Op.RemS) }
   | (ixx as t)".rem_u" { BINARY (intop t Int32Op.RemU Int64Op.RemU) }
   | (ixx as t)".and" { BINARY (intop t Int32Op.And Int64Op.And) }
-  | (ixx as t)".or" { BINARY (intop t Int32Op.Or Int64Op.Or) }
+  | (ixx as t)".ior" { BINARY (intop t Int32Op.Ior Int64Op.Ior) }
   | (ixx as t)".xor" { BINARY (intop t Int32Op.Xor Int64Op.Xor) }
   | (ixx as t)".shl" { BINARY (intop t Int32Op.Shl Int64Op.Shl) }
   | (ixx as t)".shr_u" { BINARY (intop t Int32Op.ShrU Int64Op.ShrU) }

--- a/ml-proto/src/spec/arithmetic.ml
+++ b/ml-proto/src/spec/arithmetic.ml
@@ -164,7 +164,7 @@ struct
       | RemS -> Int.rem
       | RemU -> fun i j -> Int.of_big_int_u (unsigned mod_big_int i j)
       | And -> Int.logand
-      | Or -> Int.logor
+      | Ior -> Int.logor
       | Xor -> Int.logxor
       | Shl -> fun i j -> Int.shift_left i (Int.to_int j)
       | ShrU -> fun i j -> Int.shift_right_logical i (Int.to_int j)

--- a/ml-proto/src/spec/ast.ml
+++ b/ml-proto/src/spec/ast.ml
@@ -36,7 +36,7 @@ module IntOp () =
 struct
   type unop = Clz | Ctz | Popcnt
   type binop = Add | Sub | Mul | DivS | DivU | RemS | RemU
-             | And | Or | Xor | Shl | ShrU | ShrS
+             | And | Ior | Xor | Shl | ShrU | ShrS
   type relop = Eq | Ne | LtS | LtU | LeS | LeU | GtS | GtU | GeS | GeU
   type cvt = ExtendSInt32 | ExtendUInt32 | WrapInt64
            | TruncSFloat32 | TruncUFloat32 | TruncSFloat64 | TruncUFloat64


### PR DESCRIPTION
I don't have a strong preference either way; I just want spec and design to match here.