### PR TITLE
Rename StoreTrunc to StoreWrap for consistency

### DIFF
--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -77,7 +77,7 @@ let extension = function
 let extendop t sz s a =
   {memop = memop t a; sz = mem_size sz; ext = extension s}
 
-let truncop t sz a =
+let wrapop t sz a =
   {memop = memop t a; sz = mem_size sz}
 }
 
@@ -147,9 +147,9 @@ rule token = parse
   | (ixx as t)".load"(mem_size as sz)"_"(sign as s)"/"(align as a)
     { LOADEXTEND (extendop t sz s a) }
   | (ixx as t)".store"(mem_size as sz)
-    { STORETRUNC (truncop t sz "") }
+    { STOREWRAP (wrapop t sz "") }
   | (ixx as t)".store"(mem_size as sz)"/"(align as a)
-    { STORETRUNC (truncop t sz a) }
+    { STOREWRAP (wrapop t sz a) }
 
   | (nxx as t)".switch" { SWITCH (value_type t) }
   | (nxx as t)".const" { CONST (value_type t) }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -116,7 +116,7 @@ let anon_label c = {c with labels = VarMap.map ((+) 1) c.labels}
 %token<Ast.memop> LOAD
 %token<Ast.memop> STORE
 %token<Ast.extendop> LOADEXTEND
-%token<Ast.truncop> STORETRUNC
+%token<Ast.wrapop> STOREWRAP
 
 %start script
 %type<Script.script> script
@@ -182,7 +182,7 @@ oper :
   | LOAD expr { fun c -> Load ($1, $2 c) }
   | STORE expr expr { fun c -> Store ($1, $2 c, $3 c) }
   | LOADEXTEND expr { fun c -> LoadExtend ($1, $2 c) }
-  | STORETRUNC expr expr { fun c -> StoreTrunc ($1, $2 c, $3 c) }
+  | STOREWRAP expr expr { fun c -> StoreWrap ($1, $2 c, $3 c) }
   | CONST literal { let at = at() in fun c -> Const (literal at $2 $1) }
   | UNARY expr { fun c -> Unary ($1, $2 c) }
   | BINARY expr expr { fun c -> Binary ($1, $2 c, $3 c) }

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -65,7 +65,7 @@ type cvt = (Int32Op.cvt, Int64Op.cvt, Float32Op.cvt, Float64Op.cvt) op
 
 type memop = {ty : Types.value_type; align : int option}
 type extendop = {memop : memop; sz : Memory.mem_size; ext : Memory.extension}
-type truncop = {memop : memop; sz : Memory.mem_size}
+type wrapop = {memop : memop; sz : Memory.mem_size}
 
 (* Expressions *)
 
@@ -90,7 +90,7 @@ and expr' =
   | Load of memop * expr                          (* read memory address *)
   | Store of memop * expr * expr                  (* write memory address *)
   | LoadExtend of extendop * expr
-  | StoreTrunc of truncop * expr * expr
+  | StoreWrap of wrapop * expr * expr
   | Const of literal                              (* constant *)
   | Unary of unop * expr                          (* unary arithmetic operator *)
   | Binary of binop * expr * expr                 (* binary arithmetic operator *)

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -184,9 +184,9 @@ let rec check_expr c et e =
     check_mem_type extendop.memop.ty extendop.sz e.at;
     check_load c et extendop.memop e1 e.at
 
-  | StoreTrunc (truncop, e1, e2) ->
-    check_mem_type truncop.memop.ty truncop.sz e.at;
-    check_store c et truncop.memop e1 e2 e.at
+  | StoreWrap (wrapop, e1, e2) ->
+    check_mem_type wrapop.memop.ty wrapop.sz e.at;
+    check_store c et wrapop.memop e1 e2 e.at
 
   | Const v ->
     check_literal c et v

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -188,11 +188,11 @@ let rec eval_expr (c : config) (e : expr) =
     (try Some (Memory.load_extend c.module_.memory a sz ext ty)
     with exn -> memory_error e.at exn)
 
-  | StoreTrunc ({memop = {ty; align = _}; sz}, e1, e2) ->
+  | StoreWrap ({memop = {ty; align = _}; sz}, e1, e2) ->
     let v1 = some (eval_expr c e1) e1.at in
     let v2 = some (eval_expr c e2) e2.at in
     let a = Memory.address_of_value v1 in
-    (try Memory.store_trunc c.module_.memory a sz v2
+    (try Memory.store_wrap c.module_.memory a sz v2
     with exn -> memory_error e.at exn);
     None
 

--- a/ml-proto/spec/memory.ml
+++ b/ml-proto/spec/memory.ml
@@ -115,7 +115,7 @@ let load_extend mem a sz ext t =
   | Mem32, SX, Int64Type -> Int64 (loadn_sx mem 4 a)
   | _ -> raise Type
 
-let store_trunc mem a sz v =
+let store_wrap mem a sz v =
   match sz, v with
   | Mem8,  Int32 x -> storen mem 1 a (Int64.of_int32 x)
   | Mem8,  Int64 x -> storen mem 1 a x

--- a/ml-proto/spec/memory.mli
+++ b/ml-proto/spec/memory.mli
@@ -23,6 +23,6 @@ val resize : memory -> size -> unit
 val load : memory -> address -> value_type -> value
 val store : memory -> address -> value -> unit
 val load_extend : memory -> address -> mem_size -> extension -> value_type -> value
-val store_trunc : memory -> address -> mem_size -> value -> unit
+val store_wrap : memory -> address -> mem_size -> value -> unit
 
 val address_of_value : Values.value -> address


### PR DESCRIPTION
@sunfishcode pointed out that we consistently use "wrap" instead of "truncate" to describe larger-to-smaller integer conversions, so this PR renames `StoreTrunc` to `StoreWrap` which is nicer anyway since it's shorter and replaces an abbreviation with a real word.  Also tidies up README.md.