### PR TITLE
Use the arcane ocamlbuild incantation that actually gets debug symbols.

### DIFF
--- a/ml-proto/Makefile
+++ b/ml-proto/Makefile
@@ -19,13 +19,13 @@ all:		$(NAME) unopt
 $(NAME):	main.native
 		mv $< $@
 
-unopt:		main.byte
+unopt:		main.d.byte
 		mv $< $@
 
 main.native:	$(MAKEFILE)
 		$(OCB) $@
 
-main.byte:	$(MAKEFILE)
+main.d.byte:	$(MAKEFILE)
 		$(OCB) $@
 
 clean:


### PR DESCRIPTION
Apparently ocamlbuild decides whether or not to include debug symbols sufficient to perform a backtrace based on the output executable file name. This commit changes the name used, so that we can get backtraces.