### PR TITLE
Rename 'modul' to 'module_'.

### DIFF
--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -329,7 +329,7 @@ module_fields :
       | Some _ -> Error.error $1.at "more than one memory section"
       | None -> {m with memory = Some $1} }
 ;
-modul :
+module_ :
   | LPAR MODULE module_fields RPAR { $3 (c0 ()) @@ at() }
 ;
 
@@ -337,8 +337,8 @@ modul :
 /* Scripts */
 
 cmd :
-  | modul { Define $1 @@ at() }
-  | LPAR ASSERTINVALID modul TEXT RPAR { AssertInvalid ($3, $4) @@ at() }
+  | module_ { Define $1 @@ at() }
+  | LPAR ASSERTINVALID module_ TEXT RPAR { AssertInvalid ($3, $4) @@ at() }
   | LPAR INVOKE TEXT expr_list RPAR
     { Invoke ($3, $4 (c0 ())) @@ at() }
   | LPAR ASSERTEQ LPAR INVOKE TEXT expr_list RPAR expr RPAR

--- a/ml-proto/host/print.mli
+++ b/ml-proto/host/print.mli
@@ -2,7 +2,7 @@
  * (c) 2015 Andreas Rossberg
  *)
 
-val print_module : Ast.modul -> unit
-val print_module_sig : Ast.modul -> unit
+val print_module : Ast.module_ -> unit
+val print_module_sig : Ast.module_ -> unit
 val print_value : Values.value option -> unit
 

--- a/ml-proto/host/script.ml
+++ b/ml-proto/host/script.ml
@@ -8,8 +8,8 @@ open Source
 
 type command = command' phrase
 and command' =
-  | Define of Ast.modul
-  | AssertInvalid of Ast.modul * string
+  | Define of Ast.module_
+  | AssertInvalid of Ast.module_ * string
   | Invoke of string * Ast.expr list
   | AssertEq of string * Ast.expr list * Ast.expr
   | AssertTrap of string * Ast.expr list * string

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -4,8 +4,8 @@
 
 type command = command' Source.phrase
 and command' =
-  | Define of Ast.modul
-  | AssertInvalid of Ast.modul * string
+  | Define of Ast.module_
+  | AssertInvalid of Ast.module_ * string
   | Invoke of string * Ast.expr list
   | AssertEq of string * Ast.expr list * Ast.expr
   | AssertTrap of string * Ast.expr list * string

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -11,7 +11,7 @@
  *   v : value
  *   e : expr
  *   f : func
- *   m : modul
+ *   m : module_
  *
  *   t : value_type
  *   s : func_type
@@ -143,8 +143,8 @@ and import' =
 
 type table = var list Source.phrase
 
-type modul = modul' Source.phrase
-and modul' =
+type module_ = module_' Source.phrase
+and module_' =
 {
   memory : memory option;
   funcs : func list;

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -262,11 +262,11 @@ and check_mem_type ty sz at =
 
 (*
  * check_func : context -> func -> unit
- * check_module : context -> modul -> unit
+ * check_module : context -> module_ -> unit
  *
  * Conventions:
  *   c : context
- *   m : modul
+ *   m : module_
  *   f : func
  *   e : expr
  *   v : value

--- a/ml-proto/spec/check.mli
+++ b/ml-proto/spec/check.mli
@@ -2,4 +2,4 @@
  * (c) 2015 Andreas Rossberg
  *)
 
-val check_module : Ast.modul -> unit (* raise Error *)
+val check_module : Ast.module_ -> unit (* raise Error *)

--- a/ml-proto/spec/eval.mli
+++ b/ml-proto/spec/eval.mli
@@ -7,7 +7,7 @@ type value = Values.value
 type import = value list -> value option
 type host_params = {page_size : Memory.size}
 
-val init : Ast.modul -> import list -> host_params -> instance
+val init : Ast.module_ -> import list -> host_params -> instance
 val invoke : instance -> string -> value list -> value option
   (* raise Error.Error *)
 val eval : Ast.expr -> value option (* raise Error.Error *)


### PR DESCRIPTION
I suppose this is personal familiarity, but 'modul' initially made me wonder if it's some strange OCaml keyword that I hadn't previously encountered.