### PR TITLE
Branch-like structured control flow

### DIFF
--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -129,12 +129,10 @@ rule token = parse
 
   | "nop" { NOP }
   | "block" { BLOCK }
-  | "if" { IF }
   | "loop" { LOOP }
-  | "label" { LABEL }
-  | "break" { BREAK }
-  | "case" { CASE }
-  | "fallthrough" { FALLTHROUGH }
+  | "br" { BR }
+  | "br_if" { BRIF }
+  | "br_unless" { BRUNLESS }
   | "call" { CALL }
   | "call_import" { CALLIMPORT }
   | "call_indirect" { CALLINDIRECT }
@@ -157,7 +155,7 @@ rule token = parse
   | (ixx as t)".store"(mem_size as sz)"/"(align as a)
     { STOREWRAP (wrapop t sz a) }
 
-  | (nxx as t)".switch" { SWITCH (value_type t) }
+  | (nxx as t)".br_switch" { BRSWITCH (value_type t) }
   | (nxx as t)".const" { CONST (value_type t) }
 
   | (ixx as t)".clz" { UNARY (intop t Int32Op.Clz Int64Op.Clz) }

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -133,6 +133,11 @@ rule token = parse
   | "br" { BR }
   | "br_if" { BRIF }
   | "br_unless" { BRUNLESS }
+  | "if" { IF }
+  | "forever" { FOREVER }
+  | "case" { CASE }
+  | "fallthrough" { FALLTHROUGH }
+  | "break" { BREAK }
   | "call" { CALL }
   | "call_import" { CALLIMPORT }
   | "call_indirect" { CALLINDIRECT }
@@ -156,6 +161,7 @@ rule token = parse
     { STOREWRAP (wrapop t sz a) }
 
   | (nxx as t)".br_switch" { BRSWITCH (value_type t) }
+  | (nxx as t)".switch" { SWITCH (value_type t) }
   | (nxx as t)".const" { CONST (value_type t) }
 
   | (ixx as t)".clz" { UNARY (intop t Int32Op.Clz Int64Op.Clz) }

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -75,12 +75,13 @@ type literal = value Source.phrase
 type expr = expr' Source.phrase
 and expr' =
   | Nop                                           (* do nothing *)
-  | Block of expr list                            (* execute in sequence *)
-  | If of expr * expr * expr                      (* conditional *)
-  | Loop of expr                                  (* infinite loop *)
-  | Label of expr                                 (* labelled expression *)
-  | Break of var * expr option                    (* break to n-th surrounding label *)
-  | Switch of value_type * expr * arm list * expr (* switch, latter expr is default *)
+  | Block of expr list                            (* execute in sequence, label at end *)
+  | Loop of expr list                             (* execute in sequence, label at beginning *)
+  | Br of var * expr option                       (* branch to label *)
+  | BrIf of var * expr * expr option              (* branch to label if expr is true *)
+  | BrUnless of var * expr * expr option          (* branch to label if expr is false *)
+  | BrSwitch of value_type * expr * var * (value * var) list * expr option
+                                                  (* branch to label selected by expr *)
   | Call of var * expr list                       (* call function *)
   | CallImport of var * expr list                 (* call imported function *)
   | CallIndirect of var * expr * expr list        (* call function through table *)
@@ -99,15 +100,6 @@ and expr' =
   | PageSize                                      (* return host-defined page_size *)
   | MemorySize                                    (* return current size of linear memory *)
   | ResizeMemory of expr                          (* resize linear memory *)
-
-and arm = arm' Source.phrase
-and arm' =
-{
-  value : literal;
-  expr : expr;
-  fallthru : bool
-}
-
 
 (* Functions and Modules *)
 

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -81,6 +81,7 @@ and expr' =
   | BrIf of var * expr * expr option              (* branch to label if expr is true *)
   | BrUnless of var * expr * expr option          (* branch to label if expr is false *)
   | BrSwitch of value_type * expr * var * (value * var) list * expr option
+  | Switch of value_type * expr * arm list * expr (* switch, latter expr is default *)
                                                   (* branch to label selected by expr *)
   | Call of var * expr list                       (* call function *)
   | CallImport of var * expr list                 (* call imported function *)
@@ -100,6 +101,15 @@ and expr' =
   | PageSize                                      (* return host-defined page_size *)
   | MemorySize                                    (* return current size of linear memory *)
   | ResizeMemory of expr                          (* resize linear memory *)
+
+and arm = arm' Source.phrase
+and arm' =
+{
+  value : literal;
+  expr : expr;
+  fallthru : bool
+}
+
 
 (* Functions and Modules *)
 

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -146,6 +146,13 @@ let rec check_expr c et e =
     check_expr c (Some t.it) ec;
     check_expr_option c (label c default) eo e.at
 
+  | Switch (t, e1, arms, e2) ->
+    require (t.it = Int32Type || t.it = Int64Type) t.at "invalid switch type";
+    (* TODO: Check that cases are unique. *)
+    check_expr c (Some t.it) e1;
+    List.iter (check_arm c t.it et) arms;
+    check_expr c et e2
+
   | Call (x, es) ->
     let {ins; out} = func c x in
     check_exprs c ins es;
@@ -237,6 +244,11 @@ and check_expr_option c et eo at =
 
 and check_literal c et l =
   check_type (Some (type_value l.it)) et l.at
+
+and check_arm c t et arm =
+  let {value = l; expr = e; fallthru} = arm.it in
+  check_literal c (Some t) l;
+  check_expr c (if fallthru then None else et) e
 
 and check_load c et memop e1 at =
   check_has_memory c at;

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -126,32 +126,47 @@ let rec eval_expr (c : config) (e : expr) =
     None
 
   | Block es ->
-    let es', eN = Lib.List.split_last es in
-    List.iter (fun eI -> ignore (eval_expr c eI)) es';
-    eval_expr c eN
-
-  | If (e1, e2, e3) ->
-    let i = int32 (eval_expr c e1) e1.at in
-    eval_expr c (if i <> Int32.zero then e2 else e3)
-
-  | Loop e1 ->
-    ignore (eval_expr c e1);
-    eval_expr c e
-
-  | Label e1 ->
     let module L = MakeLabel () in
     let c' = {c with labels = L.label :: c.labels} in
-    (try eval_expr c' e1 with L.Label vo -> vo)
+    (try
+      (let es', eN = Lib.List.split_last es in
+       List.iter (fun eI -> ignore (eval_expr c' eI)) es';
+       eval_expr c' eN)
+     with L.Label vo -> vo)
 
-  | Break (x, eo) ->
+  | Loop es ->
+    let module L = MakeLabel () in
+    let c' = {c with labels = L.label :: c.labels} in
+    (try
+      (let es', eN = Lib.List.split_last es in
+       List.iter (fun eI -> ignore (eval_expr c' eI)) es';
+       eval_expr c' eN)
+     with L.Label _ -> eval_expr c e)
+
+  | Br (x, eo) ->
     raise (label c x (eval_expr_option c eo))
 
-  | Switch (_t, e1, arms, e2) ->
-    let vo = some (eval_expr c e1) e1.at in
-    (match List.fold_left (eval_arm c vo) `Seek arms with
-    | `Seek | `Fallthru -> eval_expr c e2
-    | `Done vs -> vs
-    )
+  | BrIf (x, ec, eo) ->
+    let i = int32 (eval_expr c ec) ec.at in
+    if i <> Int32.zero then
+      raise (label c x (eval_expr_option c eo))
+    else
+      None
+
+  | BrUnless (x, ec, eo) ->
+    let i = int32 (eval_expr c ec) ec.at in
+    if i = Int32.zero then
+      raise (label c x (eval_expr_option c eo))
+    else
+      None
+
+  | BrSwitch (_t, ec, default, labels, eo) ->
+    let e = some (eval_expr c ec) ec.at in
+    raise (label c
+           (try
+              let i, l = List.find (fun (i, l) -> i = e) labels in l
+            with Not_found -> default)
+           (eval_expr_option c eo))
 
   | Call (x, es) ->
     let vs = List.map (fun vo -> some (eval_expr c vo) vo.at) es in
@@ -258,16 +273,6 @@ and eval_expr_option c eo =
   match eo with
   | Some e -> eval_expr c e
   | None -> None
-
-and eval_arm c vo stage arm =
-  let {value; expr = e; fallthru} = arm.it in
-  match stage, vo = value.it with
-  | `Seek, true | `Fallthru, _ ->
-    if fallthru
-    then (ignore (eval_expr c e); `Fallthru)
-    else `Done (eval_expr c e)
-  | `Seek, false | `Done _, _ ->
-    stage
 
 and eval_func (m : instance) (f : func) (evs : value list) =
   let module Return = MakeLabel () in

--- a/ml-proto/test/br_switch.wase
+++ b/ml-proto/test/br_switch.wase
@@ -1,0 +1,60 @@
+(module
+  ;; Statement br_switch
+  (func $stmt (param $i i32) (result i32)
+    (local $j i32)
+    (set_local $j (i32.const 100))
+    (block (block (block (block (block (block (block (block (block
+
+    (i32.br_switch (get_local $i)
+                   $default 0 $case0 1 $case1 2 $case2 3 $case3 4 $case4 5 $case5 6 $case6)
+    $case0) (return (get_local $i))
+    $case1)
+    $case2)
+    $case3) (set_local $j (i32.sub (i32.const 0) (get_local $i))) (br $end)
+    $case4) (br $end)
+    $case5) (set_local $j (i32.const 101)) (br $end)
+    $case6) (set_local $j (i32.const 101))
+    $default) (set_local $j (i32.const 102))
+    $end)
+    (return (get_local $j))
+  )
+
+  ;; Expression br_switch
+  (func $expr (param $i i64) (result i64)
+    (local $j i64)
+    (set_local $j (i64.const 100))
+    (return
+      (block (block (block (block (block (block (block
+      (i64.br_switch (get_local $i)
+                     $default 0 $case0 1 $case1 2 $case2 3 $case3 6 $case6)
+      $case0) (return (get_local $i))
+      $case1)
+      $case2)
+      $case3) (br $exit (i64.sub (i64.const 0) (get_local $i)))
+      $case6) (set_local $j (i64.const 101))
+      $default) (get_local $j)
+      $exit)
+    )
+  )
+
+  (export "stmt" $stmt)
+  (export "expr" $expr)
+)
+
+(assert_eq (invoke "stmt" (i32.const 0)) (i32.const 0))
+(assert_eq (invoke "stmt" (i32.const 1)) (i32.const -1))
+(assert_eq (invoke "stmt" (i32.const 2)) (i32.const -2))
+(assert_eq (invoke "stmt" (i32.const 3)) (i32.const -3))
+(assert_eq (invoke "stmt" (i32.const 4)) (i32.const 100))
+(assert_eq (invoke "stmt" (i32.const 5)) (i32.const 101))
+(assert_eq (invoke "stmt" (i32.const 6)) (i32.const 102))
+(assert_eq (invoke "stmt" (i32.const 7)) (i32.const 102))
+(assert_eq (invoke "stmt" (i32.const -10)) (i32.const 102))
+
+(assert_eq (invoke "expr" (i64.const 0)) (i64.const 0))
+(assert_eq (invoke "expr" (i64.const 1)) (i64.const -1))
+(assert_eq (invoke "expr" (i64.const 2)) (i64.const -2))
+(assert_eq (invoke "expr" (i64.const 3)) (i64.const -3))
+(assert_eq (invoke "expr" (i64.const 6)) (i64.const 101))
+(assert_eq (invoke "expr" (i64.const 7)) (i64.const 100))
+(assert_eq (invoke "expr" (i64.const -10)) (i64.const 100))

--- a/ml-proto/test/fac.wast
+++ b/ml-proto/test/fac.wast
@@ -3,62 +3,51 @@
 (module
   ;; Recursive factorial
   (func (param i64) (result i64)
-    (if (i64.eq (get_local 0) (i64.const 0))
-      (i64.const 1)
+      (block
+      (br_unless $else (i64.eq (get_local 0) (i64.const 0)))
+      (return (i64.const 1))
+    $else)
       (i64.mul (get_local 0) (call 0 (i64.sub (get_local 0) (i64.const 1))))
-    )
   )
 
   ;; Recursive factorial named
   (func $fac-rec (param $n i64) (result i64)
-    (if (i64.eq (get_local $n) (i64.const 0))
-      (i64.const 1)
+      (block
+      (br_unless $else (i64.eq (get_local $n) (i64.const 0)))
+      (return (i64.const 1))
+    $else)
       (i64.mul
         (get_local $n)
-        (call $fac-rec (i64.sub (get_local $n) (i64.const 1)))
-      )
-    )
+        (call $fac-rec (i64.sub (get_local $n) (i64.const 1))))
   )
 
   ;; Iterative factorial
   (func (param i64) (result i64)
     (local i64 i64)
-    (set_local 1 (get_local 0))
-    (set_local 2 (i64.const 1))
-    (label
-      (loop
-        (if
-          (i64.eq (get_local 1) (i64.const 0))
-          (break 0)
-          (block
-            (set_local 2 (i64.mul (get_local 1) (get_local 2)))
-            (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
-          )
-        )
-      )
-    )
-    (return (get_local 2))
+      (set_local 1 (get_local 0))
+      (set_local 2 (i64.const 1))
+      (loop $loop
+        (br_if $done (i64.eq (get_local 1) (i64.const 0)))
+        (set_local 2 (i64.mul (get_local 1) (get_local 2)))
+        (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
+        (br $loop)
+        $done)
+      (return (get_local 2))
   )
 
   ;; Iterative factorial named
   (func $fac-iter (param $n i64) (result i64)
     (local $i i64)
     (local $res i64)
-    (set_local $i (get_local $n))
-    (set_local $res (i64.const 1))
-    (label $done
-      (loop
-        (if
-          (i64.eq (get_local $i) (i64.const 0))
-          (break $done)
-          (block
-            (set_local $res (i64.mul (get_local $i) (get_local $res)))
-            (set_local $i (i64.sub (get_local $i) (i64.const 1)))
-          )
-        )
-      )
-    )
-    (return (get_local $res))
+      (set_local $i (get_local $n))
+      (set_local $res (i64.const 1))
+      (loop $loop
+        (br_if $done (i64.eq (get_local $i) (i64.const 0)))
+        (set_local $res (i64.mul (get_local $i) (get_local $res)))
+        (set_local $i (i64.sub (get_local $i) (i64.const 1)))
+        (br $loop)
+        $done)
+      (return (get_local $res))
   )
 
   (export "fac-rec" 0)

--- a/ml-proto/test/forward.wast
+++ b/ml-proto/test/forward.wast
@@ -5,17 +5,19 @@
   (export "odd" $odd)
 
   (func $even (param $n i32) (result i32)
-    (if (i32.eq (get_local $n) (i32.const 0))
-      (i32.const 1)
+      (block
+      (br_unless $endif (i32.eq (get_local $n) (i32.const 0)))
+      (return (i32.const 1))
+    $endif)
       (call $odd (i32.sub (get_local $n) (i32.const 1)))
-    )
   )
 
   (func $odd (param $n i32) (result i32)
-    (if (i32.eq (get_local $n) (i32.const 0))
-      (i32.const 0)
+      (block
+      (br_unless $endif (i32.eq (get_local $n) (i32.const 0)))
+      (return (i32.const 0))
+    $endif)
       (call $even (i32.sub (get_local $n) (i32.const 1)))
-    )
   )
 )
 

--- a/ml-proto/test/sugar-fac.wase
+++ b/ml-proto/test/sugar-fac.wase
@@ -1,0 +1,73 @@
+;; (c) 2015 Andreas Rossberg
+
+(module
+  ;; Recursive factorial
+  (func (param i64) (result i64)
+    (if (i64.eq (get_local 0) (i64.const 0))
+      (i64.const 1)
+      (i64.mul (get_local 0) (call 0 (i64.sub (get_local 0) (i64.const 1))))
+    )
+  )
+
+  ;; Recursive factorial named
+  (func $fac-rec (param $n i64) (result i64)
+    (if (i64.eq (get_local $n) (i64.const 0))
+      (i64.const 1)
+      (i64.mul
+        (get_local $n)
+        (call $fac-rec (i64.sub (get_local $n) (i64.const 1)))
+      )
+    )
+  )
+
+  ;; Iterative factorial
+  (func (param i64) (result i64)
+    (local i64 i64)
+    (set_local 1 (get_local 0))
+    (set_local 2 (i64.const 1))
+    (label
+      (loop
+        (if
+          (i64.eq (get_local 1) (i64.const 0))
+          (break 0)
+          (block
+            (set_local 2 (i64.mul (get_local 1) (get_local 2)))
+            (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
+          )
+        )
+      )
+    )
+    (return (get_local 2))
+  )
+
+  ;; Iterative factorial named
+  (func $fac-iter (param $n i64) (result i64)
+    (local $i i64)
+    (local $res i64)
+    (set_local $i (get_local $n))
+    (set_local $res (i64.const 1))
+    (label $done
+      (loop
+        (if
+          (i64.eq (get_local $i) (i64.const 0))
+          (break $done)
+          (block
+            (set_local $res (i64.mul (get_local $i) (get_local $res)))
+            (set_local $i (i64.sub (get_local $i) (i64.const 1)))
+          )
+        )
+      )
+    )
+    (return (get_local $res))
+  )
+
+  (export "fac-rec" 0)
+  (export "fac-iter" 2)
+  (export "fac-rec-named" $fac-rec)
+  (export "fac-iter-named" $fac-iter)
+)
+
+(assert_eq (invoke "fac-rec" (i64.const 25)) (i64.const 7034535277573963776))
+(assert_eq (invoke "fac-iter" (i64.const 25)) (i64.const 7034535277573963776))
+(assert_eq (invoke "fac-rec-named" (i64.const 25)) (i64.const 7034535277573963776))
+(assert_eq (invoke "fac-iter-named" (i64.const 25)) (i64.const 7034535277573963776))

--- a/ml-proto/test/sugar-fac.wase
+++ b/ml-proto/test/sugar-fac.wase
@@ -25,15 +25,13 @@
     (local i64 i64)
     (set_local 1 (get_local 0))
     (set_local 2 (i64.const 1))
-    (label
-      (loop
-        (if
-          (i64.eq (get_local 1) (i64.const 0))
-          (break 0)
-          (block
-            (set_local 2 (i64.mul (get_local 1) (get_local 2)))
-            (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
-          )
+    (forever
+      (if
+        (i64.eq (get_local 1) (i64.const 0))
+        (break)
+        (block
+          (set_local 2 (i64.mul (get_local 1) (get_local 2)))
+          (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
         )
       )
     )
@@ -46,18 +44,18 @@
     (local $res i64)
     (set_local $i (get_local $n))
     (set_local $res (i64.const 1))
-    (label $done
-      (loop
+    (block
+      (forever
         (if
           (i64.eq (get_local $i) (i64.const 0))
-          (break $done)
+          (br $done)
           (block
             (set_local $res (i64.mul (get_local $i) (get_local $res)))
             (set_local $i (i64.sub (get_local $i) (i64.const 1)))
           )
         )
       )
-    )
+      $done)
     (return (get_local $res))
   )
 

--- a/ml-proto/test/sugar-forward.wase
+++ b/ml-proto/test/sugar-forward.wase
@@ -1,0 +1,25 @@
+;; (c) 2015 Andreas Rossberg
+
+(module
+  (export "even" $even)
+  (export "odd" $odd)
+
+  (func $even (param $n i32) (result i32)
+    (if (i32.eq (get_local $n) (i32.const 0))
+      (i32.const 1)
+      (call $odd (i32.sub (get_local $n) (i32.const 1)))
+    )
+  )
+
+  (func $odd (param $n i32) (result i32)
+    (if (i32.eq (get_local $n) (i32.const 0))
+      (i32.const 0)
+      (call $even (i32.sub (get_local $n) (i32.const 1)))
+    )
+  )
+)
+
+(assert_eq (invoke "even" (i32.const 13)) (i32.const 0))
+(assert_eq (invoke "even" (i32.const 20)) (i32.const 1))
+(assert_eq (invoke "odd" (i32.const 13)) (i32.const 1))
+(assert_eq (invoke "odd" (i32.const 20)) (i32.const 0))

--- a/ml-proto/test/sugar-memory.wase
+++ b/ml-proto/test/sugar-memory.wase
@@ -35,29 +35,29 @@
 )
 
 ;; Test alignment annotation rules
-(module (memory 0) (func (i32.load8_u/2 (i32.const 0))))
-(module (memory 0) (func (i32.load16_u/4 (i32.const 0))))
-(module (memory 0) (func (i32.load/8 (i32.const 0))))
-(module (memory 0) (func (f32.load/8 (i32.const 0))))
+(module (func (i32.load8_u/2 (i32.const 0))))
+(module (func (i32.load16_u/4 (i32.const 0))))
+(module (func (i32.load/8 (i32.const 0))))
+(module (func (f32.load/8 (i32.const 0))))
 
 (assert_invalid
-  (module (memory 0) (func (i64.load/0 (i32.const 0))))
+  (module (func (i64.load/0 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (memory 0) (func (i64.load/3 (i32.const 0))))
+  (module (func (i64.load/3 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (memory 0) (func (i64.load/5 (i32.const 0))))
+  (module (func (i64.load/5 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (memory 0) (func (i64.load/6 (i32.const 0))))
+  (module (func (i64.load/6 (i32.const 0))))
   "non-power-of-two alignment"
 )
 (assert_invalid
-  (module (memory 0) (func (i64.load/7 (i32.const 0))))
+  (module (func (i64.load/7 (i32.const 0))))
   "non-power-of-two alignment"
 )
 
@@ -81,55 +81,62 @@
   ;; Aligned read/write
   (func $aligned (result i32)
     (local i32 i32 i32)
-      (set_local 0 (i32.const 10))
-      (loop $loop
-          (block
-          (br_unless $break (i32.eq (get_local 0) (i32.const 0)))
-          (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
-          (i32.store (get_local 2) (get_local 0))
-          (set_local 1 (i32.load (get_local 2)))
-          (br_unless $endif (i32.ne (get_local 0) (get_local 1)))
+    (set_local 0 (i32.const 10))
+    (label
+      (loop
+        (if
+          (i32.eq (get_local 0) (i32.const 0))
+          (break)
+        )
+        (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
+        (i32.store (get_local 2) (get_local 0))
+        (set_local 1 (i32.load (get_local 2)))
+        (if
+          (i32.ne (get_local 0) (get_local 1))
           (return (i32.const 0))
-        $endif)
-          (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
-          (br $loop)
-        $break)
-      (return (i32.const 1))
+        )
+        (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
+      )
+    )
+    (return (i32.const 1))
   )
 
   ;; Unaligned read/write
   (func $unaligned (result i32)
     (local i32 f64 f64)
-      (set_local 0 (i32.const 10))
-      (loop $loop
-          (block
-          (br_unless $break (i32.eq (get_local 0) (i32.const 0)))
-          (set_local 2 (f64.convert_s/i32 (get_local 0)))
-          (f64.store/1 (get_local 0) (get_local 2))
-          (set_local 1 (f64.load/1 (get_local 0)))
-          (br_unless $endif (f64.ne (get_local 2) (get_local 1)))
+    (set_local 0 (i32.const 10))
+    (label
+      (loop
+        (if
+          (i32.eq (get_local 0) (i32.const 0))
+          (break)
+        )
+        (set_local 2 (f64.convert_s/i32 (get_local 0)))
+        (f64.store/1 (get_local 0) (get_local 2))
+        (set_local 1 (f64.load/1 (get_local 0)))
+        (if
+          (f64.ne (get_local 2) (get_local 1))
           (return (i32.const 0))
-        $endif)
-          (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
-          (br $loop)
-        $break)
-      (return (i32.const 1))
+        )
+        (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
+      )
+    )
+    (return (i32.const 1))
   )
 
   ;; Memory cast
   (func $cast (result f64)
-      (block
-      (i64.store (i32.const 8) (i64.const -12345))
-      (br_unless $endif
-        (f64.eq
-          (f64.load (i32.const 8))
-          (f64.reinterpret/i64 (i64.const -12345))
-        ))
-        (return (f64.const 0))
-    $endif)
-      (i64.store/1 (i32.const 9) (i64.const 0))
-      (i32.store16/1 (i32.const 15) (i32.const 16453))
-      (return (f64.load/1 (i32.const 9)))
+    (i64.store (i32.const 8) (i64.const -12345))
+    (if
+      (f64.eq
+        (f64.load (i32.const 8))
+        (f64.reinterpret/i64 (i64.const -12345))
+      )
+      (return (f64.const 0))
+    )
+    (i64.store/1 (i32.const 9) (i64.const 0))
+    (i32.store16/1 (i32.const 15) (i32.const 16453))
+    (return (f64.load/1 (i32.const 9)))
   )
 
   ;; Sign and zero extending memory loads
@@ -190,31 +197,31 @@
   (export "i64_load32_u" $i64_load32_u)
 )
 
-(assert_return (invoke "data") (i32.const 1))
-(assert_return (invoke "aligned") (i32.const 1))
-(assert_return (invoke "unaligned") (i32.const 1))
-(assert_return (invoke "cast") (f64.const 42.0))
+(assert_eq (invoke "data") (i32.const 1))
+(assert_eq (invoke "aligned") (i32.const 1))
+(assert_eq (invoke "unaligned") (i32.const 1))
+(assert_eq (invoke "cast") (f64.const 42.0))
 
-(assert_return (invoke "i32_load8_s" (i32.const -1)) (i32.const -1))
-(assert_return (invoke "i32_load8_u" (i32.const -1)) (i32.const 255))
-(assert_return (invoke "i32_load16_s" (i32.const -1)) (i32.const -1))
-(assert_return (invoke "i32_load16_u" (i32.const -1)) (i32.const 65535))
+(assert_eq (invoke "i32_load8_s" (i32.const -1)) (i32.const -1))
+(assert_eq (invoke "i32_load8_u" (i32.const -1)) (i32.const 255))
+(assert_eq (invoke "i32_load16_s" (i32.const -1)) (i32.const -1))
+(assert_eq (invoke "i32_load16_u" (i32.const -1)) (i32.const 65535))
 
-(assert_return (invoke "i32_load8_s" (i32.const 100)) (i32.const 100))
-(assert_return (invoke "i32_load8_u" (i32.const 200)) (i32.const 200))
-(assert_return (invoke "i32_load16_s" (i32.const 20000)) (i32.const 20000))
-(assert_return (invoke "i32_load16_u" (i32.const 40000)) (i32.const 40000))
+(assert_eq (invoke "i32_load8_s" (i32.const 100)) (i32.const 100))
+(assert_eq (invoke "i32_load8_u" (i32.const 200)) (i32.const 200))
+(assert_eq (invoke "i32_load16_s" (i32.const 20000)) (i32.const 20000))
+(assert_eq (invoke "i32_load16_u" (i32.const 40000)) (i32.const 40000))
 
-(assert_return (invoke "i64_load8_s" (i64.const -1)) (i64.const -1))
-(assert_return (invoke "i64_load8_u" (i64.const -1)) (i64.const 255))
-(assert_return (invoke "i64_load16_s" (i64.const -1)) (i64.const -1))
-(assert_return (invoke "i64_load16_u" (i64.const -1)) (i64.const 65535))
-(assert_return (invoke "i64_load32_s" (i64.const -1)) (i64.const -1))
-(assert_return (invoke "i64_load32_u" (i64.const -1)) (i64.const 4294967295))
+(assert_eq (invoke "i64_load8_s" (i64.const -1)) (i64.const -1))
+(assert_eq (invoke "i64_load8_u" (i64.const -1)) (i64.const 255))
+(assert_eq (invoke "i64_load16_s" (i64.const -1)) (i64.const -1))
+(assert_eq (invoke "i64_load16_u" (i64.const -1)) (i64.const 65535))
+(assert_eq (invoke "i64_load32_s" (i64.const -1)) (i64.const -1))
+(assert_eq (invoke "i64_load32_u" (i64.const -1)) (i64.const 4294967295))
 
-(assert_return (invoke "i64_load8_s" (i64.const 100)) (i64.const 100))
-(assert_return (invoke "i64_load8_u" (i64.const 200)) (i64.const 200))
-(assert_return (invoke "i64_load16_s" (i64.const 20000)) (i64.const 20000))
-(assert_return (invoke "i64_load16_u" (i64.const 40000)) (i64.const 40000))
-(assert_return (invoke "i64_load32_s" (i64.const 20000)) (i64.const 20000))
-(assert_return (invoke "i64_load32_u" (i64.const 40000)) (i64.const 40000))
+(assert_eq (invoke "i64_load8_s" (i64.const 100)) (i64.const 100))
+(assert_eq (invoke "i64_load8_u" (i64.const 200)) (i64.const 200))
+(assert_eq (invoke "i64_load16_s" (i64.const 20000)) (i64.const 20000))
+(assert_eq (invoke "i64_load16_u" (i64.const 40000)) (i64.const 40000))
+(assert_eq (invoke "i64_load32_s" (i64.const 20000)) (i64.const 20000))
+(assert_eq (invoke "i64_load32_u" (i64.const 40000)) (i64.const 40000))

--- a/ml-proto/test/sugar-memory.wase
+++ b/ml-proto/test/sugar-memory.wase
@@ -82,21 +82,19 @@
   (func $aligned (result i32)
     (local i32 i32 i32)
     (set_local 0 (i32.const 10))
-    (label
-      (loop
-        (if
-          (i32.eq (get_local 0) (i32.const 0))
-          (break)
-        )
-        (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
-        (i32.store (get_local 2) (get_local 0))
-        (set_local 1 (i32.load (get_local 2)))
-        (if
-          (i32.ne (get_local 0) (get_local 1))
-          (return (i32.const 0))
-        )
-        (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
+    (forever
+      (if
+        (i32.eq (get_local 0) (i32.const 0))
+        (break)
       )
+      (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
+      (i32.store (get_local 2) (get_local 0))
+      (set_local 1 (i32.load (get_local 2)))
+      (if
+        (i32.ne (get_local 0) (get_local 1))
+        (return (i32.const 0))
+      )
+      (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
     )
     (return (i32.const 1))
   )
@@ -105,21 +103,19 @@
   (func $unaligned (result i32)
     (local i32 f64 f64)
     (set_local 0 (i32.const 10))
-    (label
-      (loop
-        (if
-          (i32.eq (get_local 0) (i32.const 0))
-          (break)
-        )
-        (set_local 2 (f64.convert_s/i32 (get_local 0)))
-        (f64.store/1 (get_local 0) (get_local 2))
-        (set_local 1 (f64.load/1 (get_local 0)))
-        (if
-          (f64.ne (get_local 2) (get_local 1))
-          (return (i32.const 0))
-        )
-        (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
+    (forever
+      (if
+        (i32.eq (get_local 0) (i32.const 0))
+        (break)
       )
+      (set_local 2 (f64.convert_s/i32 (get_local 0)))
+      (f64.store/1 (get_local 0) (get_local 2))
+      (set_local 1 (f64.load/1 (get_local 0)))
+      (if
+        (f64.ne (get_local 2) (get_local 1))
+        (return (i32.const 0))
+      )
+      (set_local 0 (i32.sub (get_local 0) (i32.const 1)))
     )
     (return (i32.const 1))
   )

--- a/ml-proto/test/switch.wast
+++ b/ml-proto/test/switch.wast
@@ -5,17 +5,15 @@
   (func $stmt (param $i i32) (result i32)
     (local $j i32)
     (set_local $j (i32.const 100))
-    (label
-      (i32.switch (get_local $i)
-        (case 0 (return (get_local $i)))
-        (case 1 (nop) fallthrough)
-        (case 2)  ;; implicit fallthrough
-        (case 3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (break))
-        (case 4 (break))
-        (case 5 (set_local $j (i32.const 101)))
-        (case 6 (set_local $j (i32.const 101)) fallthrough)
-        (;default;) (set_local $j (i32.const 102))
-      )
+    (i32.switch (get_local $i)
+      (case 0 (return (get_local $i)))
+      (case 1 (nop) fallthrough)
+      (case 2)  ;; implicit fallthrough
+      (case 3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (break))
+      (case 4 (break))
+      (case 5 (set_local $j (i32.const 101)))
+      (case 6 (set_local $j (i32.const 101)) fallthrough)
+      (;default;) (set_local $j (i32.const 102))
     )
     (return (get_local $j))
   )
@@ -25,16 +23,16 @@
     (local $j i64)
     (set_local $j (i64.const 100))
     (return
-      (label $l
+      (block
         (i64.switch (get_local $i)
           (case 0 (return (get_local $i)))
           (case 1 (nop) fallthrough)
           (case 2)  ;; implicit fallthrough
-          (case 3 (break $l (i64.sub (i64.const 0) (get_local $i))))
+          (case 3 (br $l (i64.sub (i64.const 0) (get_local $i))))
           (case 6 (set_local $j (i64.const 101)) fallthrough)
           (;default;) (get_local $j)
         )
-      )
+      $l)
     )
   )
 


### PR DESCRIPTION
This PR is initial work pursuant to the current discussion around https://github.com/WebAssembly/design/pull/299, adding the new low-level operators suggested by the discussion while preserving the existing high-level operators.

I took @rossberg-chromium's [suggestion](https://github.com/WebAssembly/design/pull/299#issuecomment-144059018) to use syntax sugar to keep the core code simple, though I instead implemented `if`/`else`/`forever`/`break` (`forever` was previously `loop` in the spec repo, but it's `forever` in the design repo) as syntax sugar in terms of `br`/`br_if`/`br_unless` because it makes the core spec simpler.

The one exception is `switch`, which is not yet implemented as syntax sugar, but only because I haven't gotten around to it, and wanted feedback first.

I also took the liberty of adding a bit of extra sweetener to the syntax sugar for the high-level opcodes. One can now use `break` on a `forever` loop or `switch` without wrapping it in an explicit `label`/`block`, which more closely resembles the languages this syntax sugar is inspired by.