### PR TITLE
Experimental interpreter tracing code.

### DIFF
--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -131,6 +131,7 @@ let func_type instance f =
  *)
 
 let rec eval_expr (c : config) (e : expr) =
+  let result_value = (
   match e.it with
   | Nop ->
     None
@@ -249,6 +250,14 @@ let rec eval_expr (c : config) (e : expr) =
     let vs = List.map (eval_expr c) es in
     let mem = some_memory c e.at in
     eval_hostop c.instance.host mem hostop vs e.at
+
+  ) in
+
+  let value_str = match result_value with
+                  | Some v -> string_of_value v
+                  | None   -> "no value" in
+  Printf.printf "trace: %s: %s\n" (string_of_region e.at) value_str;
+  result_value
 
 and eval_expr_opt c = function
   | Some e -> eval_expr c e


### PR DESCRIPTION
This PR isn't ready as-is; I'm just looking for feedback.

I've found this debugging feature, which which prints out all values of all operations as they are executed, to be quite handy. The patch here could be prettier, and it'd be nice to print the opcode too, but my main question is: This patch breaks the "tail call" property of eval_expr, which was mentioned a while ago as an important property; is there a convenient way to do what this patch is doing with doing that?