### PR TITLE
Fix a copy+paste error in a test name, and add a new test for symbol names

### DIFF
--- a/ml-proto/test/float_exprs.wast
+++ b/ml-proto/test/float_exprs.wast
@@ -272,29 +272,29 @@
 ;; Test that x/-0 is not folded away.
 
 (module
-  (func $f32.no_fold_div_0 (param $x f32) (result f32)
+  (func $f32.no_fold_div_neg0 (param $x f32) (result f32)
     (f32.div (get_local $x) (f32.const -0.0)))
-  (export "f32.no_fold_div_0" $f32.no_fold_div_0)
+  (export "f32.no_fold_div_neg0" $f32.no_fold_div_neg0)
 
-  (func $f64.no_fold_div_0 (param $x f64) (result f64)
+  (func $f64.no_fold_div_neg0 (param $x f64) (result f64)
     (f64.div (get_local $x) (f64.const -0.0)))
-  (export "f64.no_fold_div_0" $f64.no_fold_div_0)
+  (export "f64.no_fold_div_neg0" $f64.no_fold_div_neg0)
 )
 
-(assert_return (invoke "f32.no_fold_div_0" (f32.const 1.0)) (f32.const -infinity))
-(assert_return (invoke "f32.no_fold_div_0" (f32.const -1.0)) (f32.const infinity))
-(assert_return (invoke "f32.no_fold_div_0" (f32.const infinity)) (f32.const -infinity))
-(assert_return (invoke "f32.no_fold_div_0" (f32.const -infinity)) (f32.const infinity))
-(assert_return_nan (invoke "f32.no_fold_div_0" (f32.const 0)))
-(assert_return_nan (invoke "f32.no_fold_div_0" (f32.const -0)))
-(assert_return_nan (invoke "f32.no_fold_div_0" (f32.const nan)))
-(assert_return (invoke "f64.no_fold_div_0" (f64.const 1.0)) (f64.const -infinity))
-(assert_return (invoke "f64.no_fold_div_0" (f64.const -1.0)) (f64.const infinity))
-(assert_return (invoke "f64.no_fold_div_0" (f64.const infinity)) (f64.const -infinity))
-(assert_return (invoke "f64.no_fold_div_0" (f64.const -infinity)) (f64.const infinity))
-(assert_return_nan (invoke "f64.no_fold_div_0" (f64.const 0)))
-(assert_return_nan (invoke "f64.no_fold_div_0" (f64.const -0)))
-(assert_return_nan (invoke "f64.no_fold_div_0" (f64.const nan)))
+(assert_return (invoke "f32.no_fold_div_neg0" (f32.const 1.0)) (f32.const -infinity))
+(assert_return (invoke "f32.no_fold_div_neg0" (f32.const -1.0)) (f32.const infinity))
+(assert_return (invoke "f32.no_fold_div_neg0" (f32.const infinity)) (f32.const -infinity))
+(assert_return (invoke "f32.no_fold_div_neg0" (f32.const -infinity)) (f32.const infinity))
+(assert_return_nan (invoke "f32.no_fold_div_neg0" (f32.const 0)))
+(assert_return_nan (invoke "f32.no_fold_div_neg0" (f32.const -0)))
+(assert_return_nan (invoke "f32.no_fold_div_neg0" (f32.const nan)))
+(assert_return (invoke "f64.no_fold_div_neg0" (f64.const 1.0)) (f64.const -infinity))
+(assert_return (invoke "f64.no_fold_div_neg0" (f64.const -1.0)) (f64.const infinity))
+(assert_return (invoke "f64.no_fold_div_neg0" (f64.const infinity)) (f64.const -infinity))
+(assert_return (invoke "f64.no_fold_div_neg0" (f64.const -infinity)) (f64.const infinity))
+(assert_return_nan (invoke "f64.no_fold_div_neg0" (f64.const 0)))
+(assert_return_nan (invoke "f64.no_fold_div_neg0" (f64.const -0)))
+(assert_return_nan (invoke "f64.no_fold_div_neg0" (f64.const nan)))
 
 ;; Test that sqrt(x*x+y*y) is not folded to hypot.
 

--- a/ml-proto/test/names.wast
+++ b/ml-proto/test/names.wast
@@ -1,0 +1,66 @@
+;; Test files can define multiple modules. Test that implementations treat
+;; each module independently from the other.
+
+(module
+  (func $foo (result i32) (i32.const 0))
+  (export "foo" $foo)
+)
+
+(assert_return (invoke "foo") (i32.const 0))
+
+;; Another module, same function name, different contents.
+
+(module
+  (func $foo (result i32) (i32.const 1))
+  (export "foo" $foo)
+)
+
+(assert_return (invoke "foo") (i32.const 1))
+
+
+(module
+  ;; Test that we can use the empty string as a symbol.
+  (func (result f32) (f32.const 0x1.91p+2))
+  (export "" 0)
+
+  ;; Test that we can use common libc names without conflict.
+  (func $malloc (result f32) (f32.const 0x1.92p+2))
+  (export "malloc" $malloc)
+
+  ;; Test that we can use some libc hidden names without conflict.
+  (func $_malloc (result f32) (f32.const 0x1.93p+2))
+  (func $__malloc (result f32) (f32.const 0x1.94p+2))
+  (func (result f32) (f32.const 0x1.95p+2))
+  (export "_malloc" $_malloc)
+  (export "__malloc" $__malloc)
+
+  ;; Test that we can use non-alphanumeric names.
+  (func (result f32) (f32.const 0x1.96p+2))
+  (export "~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./ " 5)
+
+  ;; Test that we can use names beginning with a digit.
+  (func (result f32) (f32.const 0x1.97p+2))
+  (export "0" 6)
+
+  ;; Test that we can use names beginning with an underscore.
+  (func $_ (result f32) (f32.const 0x1.98p+2))
+  (export "_" $_)
+
+  ;; Test that we can use names beginning with a dollar sign.
+  (func (result f32) (f32.const 0x1.99p+2))
+  (export "$" 8)
+
+  ;; Test that we can use names beginning with an at sign.
+  (func (result f32) (f32.const 0x2.00p+2))
+  (export "@" 9)
+)
+
+(assert_return (invoke "") (f32.const 0x1.91p+2))
+(assert_return (invoke "malloc") (f32.const 0x1.92p+2))
+(assert_return (invoke "_malloc") (f32.const 0x1.93p+2))
+(assert_return (invoke "__malloc") (f32.const 0x1.94p+2))
+(assert_return (invoke "~!@#$%^&*()_+`-={}|[]\\:\";'<>?,./ ") (f32.const 0x1.96p+2))
+(assert_return (invoke "0") (f32.const 0x1.97p+2))
+(assert_return (invoke "_") (f32.const 0x1.98p+2))
+(assert_return (invoke "$") (f32.const 0x1.99p+2))
+(assert_return (invoke "@") (f32.const 0x2.00p+2))


### PR DESCRIPTION
Inspired by https://github.com/WebAssembly/design/issues/415 here is a PR that fixes the test name in question, and adds a new test for symbol name handling.

This tests a bunch of interesting names, but one thing it doesn't test is for newline characters embedded in names. That doesn't presently appear to with in the spec interpreter; I'll file a separate bug.