### PR TITLE
New test format

### DIFF
--- a/ml-proto/test/has_feature.wast
+++ b/ml-proto/test/has_feature.wast
@@ -1,12 +1,9 @@
 (module
-  (func $has_wasm (result i32)
-    (has_feature "wasm"))
-  (export "has_wasm" $has_wasm)
-
-  (func $has_simd128 (result i32)
-    (has_feature "simd128"))
-  (export "has_simd128" $has_simd128)
+  (import $assert_eq "assert" "eq_i32" (param i32) (param i32))
+  (fund $init
+    (call_import $assert_eq (has_feature "simd128") (i32.const 1))
+    (call_import $assert_eq (has_feature "wasm") (i32.const 0))
+  )
 )
 
-(assert_return (invoke "has_wasm") (i32.const 1))
-(assert_return (invoke "has_simd128") (i32.const 0))
+

--- a/ml-proto/test/has_feature.wast
+++ b/ml-proto/test/has_feature.wast
@@ -1,6 +1,6 @@
 (module
   (import $assert_eq "assert" "eq_i32" (param i32) (param i32))
-  (fund $init
+  (fund $main
     (call_import $assert_eq (has_feature "simd128") (i32.const 1))
     (call_import $assert_eq (has_feature "wasm") (i32.const 0))
   )

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -17,7 +17,7 @@
             (f64.const 53)
         )
     )
-    (func main
+    (func $init
         (invoke "print32" (i32.const 13))
         (invoke "print64" (i64.const 24))
     )

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -18,8 +18,8 @@
         )
     )
     (func $init
-        (invoke "print32" (i32.const 13))
-        (invoke "print64" (i64.const 24))
+        (call $print32 (i32.const 13))
+        (call $print64 (i64.const 24))
     )
 )
 

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -17,7 +17,7 @@
             (f64.const 53)
         )
     )
-    (func $init
+    (func $main
         (call $print32 (i32.const 13))
         (call $print64 (i64.const 24))
     )

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -17,9 +17,9 @@
             (f64.const 53)
         )
     )
-    (export "print32" $print32)
-    (export "print64" $print64)
+    (func main
+        (invoke "print32" (i32.const 13))
+        (invoke "print64" (i64.const 24))
+    )
 )
 
-(invoke "print32" (i32.const 13))
-(invoke "print64" (i64.const 24))


### PR DESCRIPTION
As discussed with @sunfishcode a small example how the test would be more confirming to the design document.

Notes:

* The `$init` function is the placeholder name for a function that is called after the module is loaded (same idea as behind ES6 main or .init_array sections. See https://github.com/WebAssembly/design/issues/398 ). All test code  (e.g. `invoke ...`) that was previously floating around without a related module can be moved there. 

* (assert_invalid ...) is unchanged.