### PR TITLE
Do not accept a too-large offset in memory accesses

### DIFF
--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -259,6 +259,7 @@ and check_has_memory c at =
 
 and check_memop memop at =
   require (memop.offset >= 0L) at "negative offset";
+  require (memop.offset <= 0xffffffffL) at "offset too large";
   Lib.Option.app
     (fun a -> require (Lib.Int.is_power_of_two a) at "non-power-of-two alignment")
     memop.align

--- a/ml-proto/test/address.wast
+++ b/ml-proto/test/address.wast
@@ -20,8 +20,6 @@
     )
     (export "good" $good)
 
-    (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_local $i)))
-    (export "bad1" $bad1)
     (func $bad2 (param $i i32) (i32.load offset=4294967295 (get_local $i)))
     (export "bad2" $bad2)
 )
@@ -29,7 +27,7 @@
 (assert_return (invoke "good" (i32.const 0)))
 (assert_return (invoke "good" (i32.const 995)))
 (assert_trap (invoke "good" (i32.const 996)) "out of bounds memory access")
-(assert_trap (invoke "bad1" (i32.const 0)) "out of bounds memory access")
-(assert_trap (invoke "bad1" (i32.const 1)) "out of bounds memory access")
 (assert_trap (invoke "bad2" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "bad2" (i32.const 1)) "out of bounds memory access")
+
+(assert_invalid (module (memory 1024) (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_local $i))) ) "offset too large")


### PR DESCRIPTION
They should be a uint32 value.

This fixes #161.
