### PR TITLE
Remove the "nop" operator.

### DIFF
--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -131,7 +131,6 @@ rule token = parse
   | "f32" { VALUE_TYPE Types.Float32Type }
   | "f64" { VALUE_TYPE Types.Float64Type }
 
-  | "nop" { NOP }
   | "block" { BLOCK }
   | "if" { IF }
   | "if_else" { IF_ELSE }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -159,7 +159,7 @@ let implicit_decl c t at =
 %}
 
 %token INT FLOAT TEXT VAR VALUE_TYPE LPAR RPAR
-%token NOP BLOCK IF IF_ELSE LOOP LABEL BR BR_IF TABLESWITCH CASE
+%token BLOCK IF IF_ELSE LOOP LABEL BR BR_IF TABLESWITCH CASE
 %token CALL CALL_IMPORT CALL_INDIRECT RETURN
 %token GET_LOCAL SET_LOCAL LOAD STORE LOAD_EXTEND STORE_WRAP OFFSET ALIGN
 %token CONST UNARY BINARY COMPARE CONVERT
@@ -250,7 +250,6 @@ expr :
   | LPAR expr1 RPAR { let at = at () in fun c -> $2 c @@ at }
 ;
 expr1 :
-  | NOP { fun c -> nop }
   | BLOCK labeling expr expr_list
     { fun c -> let c', l = $2 c in block (l, $3 c' :: $4 c') }
   | IF_ELSE expr expr expr { fun c -> if_else ($2 c, $3 c, $4 c) }

--- a/ml-proto/spec/sugar.ml
+++ b/ml-proto/spec/sugar.ml
@@ -21,9 +21,6 @@ let expr_seq es =
   | es -> Block es @@@ List.map Source.at es
 
 
-let nop =
-  Nop
-
 let block (l, es) =
  labeling l (Block es)
 

--- a/ml-proto/spec/sugar.mli
+++ b/ml-proto/spec/sugar.mli
@@ -6,7 +6,6 @@ and labeling' = Unlabelled | Labelled
 type case = case' Source.phrase
 and case' = Case of var | Case_br of var
 
-val nop : expr'
 val block : labeling * expr list -> expr'
 val if_else : expr * expr * expr -> expr'
 val if_ : expr * expr -> expr'

--- a/ml-proto/test/switch.wast
+++ b/ml-proto/test/switch.wast
@@ -7,10 +7,9 @@
     (set_local $j (i32.const 100))
     (label
       (tableswitch (get_local $i)
-        (table (case $0) (case $1) (case $2) (case $3) (case $4)
+        (table (case $0) (case $2) (case $2) (case $3) (case $4)
                (case $5) (case $6) (case $7)) (case $default)
         (case $0 (return (get_local $i)))
-        (case $1 (nop))  ;; fallthrough
         (case $2)  ;; fallthrough
         (case $3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (br 0))
         (case $4 (br 0))
@@ -30,10 +29,9 @@
     (return
       (label $l
         (tableswitch (i32.wrap/i64 (get_local $i))
-          (table (case $0) (case $1) (case $2) (case $3) (case $4)
+          (table (case $0) (case $2) (case $2) (case $3) (case $4)
                  (case $5) (case $6) (case $7)) (case $default)
           (case $0 (return (get_local $i)))
-          (case $1 (nop))  ;; fallthrough
           (case $2)  ;; fallthrough
           (case $3 (br $l (i64.sub (i64.const 0) (get_local $i))))
           (case $6 (set_local $j (i64.const 101)))  ;; fallthrough


### PR DESCRIPTION
The design repo has no "nop", and with the separation of `if_else` from `if`, it no longer serves an obvious purpose.