### PR TITLE
Remove the AUTHORS file and revert to a standard LICENSE.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,0 @@
-# Below is a list of people and organizations that have contributed
-# to the project.  Names should be added to the list like so:
-#
-#   Name/Organization <email address>
-
-Andreas Rossberg <rossberg@chromium.org>
-Katelyn Gadd <kg@luminance.org>
-

--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2015 repository authors, see AUTHORS file.
-
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The AUTHORS file claims to be a list of people and their organizations who have contributed to the repository, but it isn't complete in that it doesn't list many of the people who have contributed, and it doesn't list the organizations of the people it does list. 

And, the LICENSE file was modified from the original Apache text in an apparent attempt to connect it with the AUTHORS file, however the change was made in the appendix section, which only contains suggested boilerplate text for use with the license, and we aren't currently using the boilerplate.

This PR proposes to rectify these issues by reverting the LICENSE to the original text and removing the AUTHORS file for now. If there is a future need for an AUTHORS file, we can start a new one, in a deliberate way.