### PR TITLE
Change parsing to unify indirect call signatures with the same structure

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -113,7 +113,7 @@ expr:
   ( tableswitch <name>? <expr> <switch> ( table <target>* ) <case>* )
   ( call <var> <expr>* )
   ( call_import <var> <expr>* )
-  ( call_indirect <var> <expr> <expr>* )
+  ( call_indirect <func_type> <expr> <expr>* )
   ( get_local <var> )
   ( set_local <var> <expr> )
   ( <type>.load((8|16|32)_<sign>)? <offset>? <align>? <expr> )
@@ -135,15 +135,14 @@ target:
 case:
   ( case <name>? <expr>* )                       ;; = (case <var>? (block <expr>*))
 
-func:   ( func <name>? <type>? <param>* <result>? <local>* <expr>* )
-type:   ( type <var> )
+func:   ( func <name>? <param>* <result>? <local>* <expr>* )
 param:  ( param <type>* ) | ( param <name> <type> )
 result: ( result <type> )
 local:  ( local <type>* ) | ( local <name> <type> )
 
 module:  ( module <type>* <func>* <import>* <export>* <table>* <memory>? )
-type:    ( type <name>? ( func <param>* <result>? ) )
-import:  ( import <name>? "<module_name>" "<func_name>" (param <type>* ) (result <type>)* )
+func_type: ( func_type <param>* <result>? )
+import:  ( import <name>? "<module_name>" "<func_name>" <func_type> )
 export:  ( export "<char>*" <var> )
 table:   ( table <var>* )
 memory:  ( memory <int> <int>? <segment>* )

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -335,8 +335,8 @@ rule token = parse
   | "grow_memory" { GROW_MEMORY }
   | "has_feature" { HAS_FEATURE }
 
-  | "type" { TYPE }
   | "func" { FUNC }
+  | "func_type" { FUNC_TYPE }
   | "param" { PARAM }
   | "result" { RESULT }
   | "local" { LOCAL }

--- a/ml-proto/test/address.wast
+++ b/ml-proto/test/address.wast
@@ -1,6 +1,6 @@
 (module
     (memory 1024 (segment 0 "abcdefghijklmnopqrstuvwxyz"))
-    (import $print "spectest" "print" (param i32))
+    (import $print "spectest" "print" (func_type (param i32)))
 
     (func $good (param $i i32)
         (call_import $print (i32.load8_u offset=0 (get_local $i)))  ;; 97 'a'

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -1,8 +1,8 @@
 (module
-    (import $print_i32 "spectest" "print" (param i32))
-    (import $print_i64 "spectest" "print" (param i64))
-    (import $print_i32_f32 "spectest" "print" (param i32 f32))
-    (import $print_i64_f64 "spectest" "print" (param i64 f64))
+    (import $print_i32 "spectest" "print" (func_type (param i32)))
+    (import $print_i64 "spectest" "print" (func_type (param i64)))
+    (import $print_i32_f32 "spectest" "print" (func_type (param i32 f32)))
+    (import $print_i64_f64 "spectest" "print" (func_type (param i64 f64)))
     (func $print32 (param $i i32)
         (call_import $print_i32 (get_local $i))
         (call_import $print_i32_f32

--- a/ml-proto/test/store_retval.wast
+++ b/ml-proto/test/store_retval.wast
@@ -1,10 +1,10 @@
 (module
     (memory 100)
 
-    (import $print_i32 "spectest" "print" (param i32))
-    (import $print_i64 "spectest" "print" (param i64))
-    (import $print_f32 "spectest" "print" (param f32))
-    (import $print_f64 "spectest" "print" (param f64))
+    (import $print_i32 "spectest" "print" (func_type (param i32)))
+    (import $print_i64 "spectest" "print" (func_type (param i64)))
+    (import $print_f32 "spectest" "print" (func_type (param f32)))
+    (import $print_f64 "spectest" "print" (func_type (param f64)))
 
     (func $run
         (local $i32 i32) (local $i64 i64) (local $f32 f32) (local $f64 f64)


### PR DESCRIPTION
This is meant to implement the changes discussed in https://github.com/WebAssembly/design/issues/452.

This eliminates the need to declare an explicit type reference for indirectly-called functions, so I also tried to eliminate the redundancy and potential mismatch between a function's type reference and its directly declared parameters and result, so I made any function declaration implicitly introduce a type matching its directly declared parameters and result. But this approach makes an explicitly indexed type table much less useful, since you no longer have complete control over its contents. To resolve that, I removed the declarations, and references to, type table entries. The type table is created implicitly from the set of unique types used by `func` and `call_indirect`.

I also made the syntax slightly more uniform by defining a func_type production in the form `(func_type ...)`, and using it in both `call_indirect` and `import`. I did not change `func` to use it, but I will submit another PR if people like this change.