### PR TITLE
Tighter typing of Break

### DIFF
--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -228,9 +228,10 @@ and check_exprs c ts es =
   with Invalid_argument _ -> error (Source.ats es) "arity mismatch"
 
 and check_expr_opt c et eo at =
-  match eo with
-  | Some e -> check_expr c et e
-  | None -> check_type None et at
+  match et, eo with
+  | Some t, Some e -> check_expr c et e
+  | None, None -> ()
+  | _ -> error at "arity mismatch"
 
 and check_literal c et l =
   check_type (Some (type_value l.it)) et l.at

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -78,3 +78,4 @@
 (assert_return (invoke "return" (i32.const 1)) (i32.const 2))
 (assert_return (invoke "return" (i32.const 2)) (i32.const 2))
 
+(assert_invalid (module (func (loop $l (br $l (i32.const 0))))) "arity mismatch")

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -24,7 +24,7 @@
     (loop $exit $cont
       (set_local $i (i32.add (get_local $i) (i32.const 1)))
       (if (i32.eq (get_local $i) (i32.const 5))
-        (br $cont (i32.const -1))
+        (br $cont)
       )
       (if (i32.eq (get_local $i) (i32.const 8))
         (br $exit (get_local $i))

--- a/ml-proto/test/switch.wast
+++ b/ml-proto/test/switch.wast
@@ -12,7 +12,7 @@
         (case $2)  ;; fallthrough
         (case $3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (br 0))
         (case $4 (br 0))
-        (case $5 (br 0 (set_local $j (i32.const 101))))
+        (case $5 (set_local $j (i32.const 101)) (br 0))
         (case $6 (set_local $j (i32.const 101)))  ;; fallthrough
         (case $default (set_local $j (i32.const 102)))
         (case $7)


### PR DESCRIPTION
Disallows redundant arguments to a break targeting a label of type `None` (addresses #179).

Conceptually, there is no specific harm in allowing this, but it also is not useful. Rather be consistent with the checking for calls.