### PR TITLE
Make label indexing independent of whether loop and switch have explicit label names

### DIFF
--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -229,8 +229,8 @@ bind_var :
 ;
 
 labeling :
-  | /* empty */ %prec LOW { let at = at () in fun c -> c, Unlabelled @@ at }
-  | bind_var { let at = at () in fun c -> bind_label c $1, Labelled @@ at }
+  | /* empty */ %prec LOW { let at = at () in fun c -> anon_label c, () @@ at }
+  | bind_var { let at = at () in fun c -> bind_label c $1, () @@ at }
 ;
 
 offset :
@@ -254,12 +254,10 @@ expr1 :
   | BR_IF expr var expr_opt { fun c -> Br_if ($2 c, $3 c label, $4 c) }
   | LOOP labeling labeling expr_list
     { fun c -> let c', l1 = $2 c in let c'', l2 = $3 c' in
-      let c''' = if l1.it = Unlabelled then anon_label c'' else c'' in
-      Loop (l1, l2, $4 c''') }
+      Loop (l1, l2, $4 c'') }
   | LABEL labeling expr
     { fun c -> let c', l = $2 c in
-      let c'' = if l.it = Unlabelled then anon_label c' else c' in
-      Label ($3 c'') }
+      Label ($3 c') }
   | BR var expr_opt { fun c -> Br ($2 c label, $3 c) }
   | RETURN expr_opt
     { let at1 = ati 1 in

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -2,8 +2,7 @@
 
 type var = Kernel.var
 
-type labeling = labeling' Source.phrase
-and labeling' = Unlabelled | Labelled
+type labeling = unit Source.phrase
 
 type target = target' Source.phrase
 and target' = Case of var | Case_br of var

--- a/ml-proto/spec/desugar.ml
+++ b/ml-proto/spec/desugar.ml
@@ -6,11 +6,7 @@ module K = Kernel
 
 (* Expressions *)
 
-let labeling l e' =
-  match l.it with
-  | A.Unlabelled -> e'
-  | A.Labelled -> K.Label (e' @@ l.at)
-
+let labeling l e' = K.Label (e' @@ l.at)
 
 let rec expr e = expr' e.it @@ e.at
 and expr' = function
@@ -20,7 +16,6 @@ and expr' = function
   | A.If_else (e1, e2, e3) -> K.If (expr e1, expr e2, expr e3)
   | A.Br_if (e, x, eo) ->
     K.If (expr e, K.Break (x, Lib.Option.map expr eo) @@ x.at, opt eo)
-  | A.Loop (l1, l2, es) when l2.it = A.Unlabelled -> K.Loop (seq es)
   | A.Loop (l1, l2, es) -> labeling l1 (K.Loop (seq es))
   | A.Label e -> K.Label (expr e)
   | A.Br (x, eo) -> K.Break (x, Lib.Option.map expr eo)

--- a/ml-proto/test/fac.wast
+++ b/ml-proto/test/fac.wast
@@ -23,18 +23,16 @@
     (local i64 i64)
     (set_local 1 (get_local 0))
     (set_local 2 (i64.const 1))
-    (label
-      (loop
-        (if_else
-          (i64.eq (get_local 1) (i64.const 0))
-          (br 1)
-          (block
-            (set_local 2 (i64.mul (get_local 1) (get_local 2)))
-            (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
-          )
+    (loop
+      (if_else
+        (i64.eq (get_local 1) (i64.const 0))
+        (br 1)
+        (block
+          (set_local 2 (i64.mul (get_local 1) (get_local 2)))
+          (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
         )
-        (br 0)
       )
+      (br 0)
     )
     (return (get_local 2))
   )
@@ -45,18 +43,16 @@
     (local $res i64)
     (set_local $i (get_local $n))
     (set_local $res (i64.const 1))
-    (label $done
-      (loop $loop
-        (if_else
-          (i64.eq (get_local $i) (i64.const 0))
-          (br $done)
-          (block
-            (set_local $res (i64.mul (get_local $i) (get_local $res)))
-            (set_local $i (i64.sub (get_local $i) (i64.const 1)))
-          )
+    (loop $done $loop
+      (if_else
+        (i64.eq (get_local $i) (i64.const 0))
+        (br $done)
+        (block
+          (set_local $res (i64.mul (get_local $i) (get_local $res)))
+          (set_local $i (i64.sub (get_local $i) (i64.const 1)))
         )
-        (br $loop)
       )
+      (br $loop)
     )
     (return (get_local $res))
   )

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -21,6 +21,22 @@
   (func $loop2 (result i32)
     (local $i i32)
     (set_local $i (i32.const 0))
+    (loop
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if (i32.eq (get_local $i) (i32.const 5))
+        (br 0)
+      )
+      (if (i32.eq (get_local $i) (i32.const 8))
+        (br 1 (get_local $i))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (br 0)
+    )
+  )
+  
+  (func $loop2-named (result i32)
+    (local $i i32)
+    (set_local $i (i32.const 0))
     (loop $exit $cont
       (set_local $i (i32.add (get_local $i) (i32.const 1)))
       (if (i32.eq (get_local $i) (i32.const 5))
@@ -33,7 +49,7 @@
       (br $cont)
     )
   )
-
+  
   (func $switch (param i32) (result i32)
     (label $ret
       (i32.mul (i32.const 10)
@@ -78,6 +94,7 @@
   (export "block" $block)
   (export "loop1" $loop1)
   (export "loop2" $loop2)
+  (export "loop2-named" $loop2-named)
   (export "switch" $switch)
   (export "return" $return)
   (export "br_if" $br_if)
@@ -86,6 +103,7 @@
 (assert_return (invoke "block") (i32.const 1))
 (assert_return (invoke "loop1") (i32.const 5))
 (assert_return (invoke "loop2") (i32.const 8))
+(assert_return (invoke "loop2-named") (i32.const 8))
 (assert_return (invoke "switch" (i32.const 0)) (i32.const 50))
 (assert_return (invoke "switch" (i32.const 1)) (i32.const 20))
 (assert_return (invoke "switch" (i32.const 2)) (i32.const 20))

--- a/ml-proto/test/switch.wast
+++ b/ml-proto/test/switch.wast
@@ -3,20 +3,18 @@
   (func $stmt (param $i i32) (result i32)
     (local $j i32)
     (set_local $j (i32.const 100))
-    (label
-      (tableswitch (get_local $i)
-        (table (case $0) (case $1) (case $2) (case $3) (case $4)
-               (case $5) (case $6) (case $7)) (case $default)
-        (case $0 (return (get_local $i)))
-        (case $1 (nop))  ;; fallthrough
-        (case $2)  ;; fallthrough
-        (case $3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (br 0))
-        (case $4 (br 0))
-        (case $5 (set_local $j (i32.const 101)) (br 0))
-        (case $6 (set_local $j (i32.const 101)))  ;; fallthrough
-        (case $default (set_local $j (i32.const 102)))
-        (case $7)
-      )
+    (tableswitch (get_local $i)
+      (table (case $0) (case $1) (case $2) (case $3) (case $4)
+             (case $5) (case $6) (case $7)) (case $default)
+      (case $0 (return (get_local $i)))
+      (case $1 (nop))  ;; fallthrough
+      (case $2)  ;; fallthrough
+      (case $3 (set_local $j (i32.sub (i32.const 0) (get_local $i))) (br 0))
+      (case $4 (br 0))
+      (case $5 (set_local $j (i32.const 101)) (br 0))
+      (case $6 (set_local $j (i32.const 101)))  ;; fallthrough
+      (case $default (set_local $j (i32.const 102)))
+      (case $7)
     )
     (return (get_local $j))
   )
@@ -26,20 +24,18 @@
     (local $j i64)
     (set_local $j (i64.const 100))
     (return
-      (label $l
-        (tableswitch (i32.wrap/i64 (get_local $i))
-          (table (case $0) (case $1) (case $2) (case $3) (case $4)
-                 (case $5) (case $6) (case $7)) (case $default)
-          (case $0 (return (get_local $i)))
-          (case $1 (nop))  ;; fallthrough
-          (case $2)  ;; fallthrough
-          (case $3 (br $l (i64.sub (i64.const 0) (get_local $i))))
-          (case $6 (set_local $j (i64.const 101)))  ;; fallthrough
-          (case $4)  ;; fallthrough
-          (case $5)  ;; fallthrough
-          (case $default (br $l (get_local $j)))
-          (case $7 (i64.const -5))
-        )
+      (tableswitch $l (i32.wrap/i64 (get_local $i))
+        (table (case $0) (case $1) (case $2) (case $3) (case $4)
+               (case $5) (case $6) (case $7)) (case $default)
+        (case $0 (return (get_local $i)))
+        (case $1 (nop))  ;; fallthrough
+        (case $2)  ;; fallthrough
+        (case $3 (br $l (i64.sub (i64.const 0) (get_local $i))))
+        (case $6 (set_local $j (i64.const 101)))  ;; fallthrough
+        (case $4)  ;; fallthrough
+        (case $5)  ;; fallthrough
+        (case $default (br $l (get_local $j)))
+        (case $7 (i64.const -5))
       )
     )
   )


### PR DESCRIPTION
Without this change, the label indices are different depending on whether the `loop` and `switch` nodes have named labels (and how many labels for `loop`).

Since the label names are syntax sugar, I assume the this change is closer to the desired binary format semantics, as well as being generally easier to understand.