### PR TITLE
Add a test for a loop without a trailing br

### DIFF
--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -34,6 +34,18 @@
     )
   )
 
+  (func $loop3 (result i32)
+    (local $i i32)
+    (set_local $i (i32.const 0))
+    (loop $exit $cont
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if (i32.eq (get_local $i) (i32.const 5))
+        (br $exit (get_local $i))
+      )
+      (get_local $i)
+    )
+  )
+
   (func $switch (param i32) (result i32)
     (label $ret
       (i32.mul (i32.const 10)
@@ -78,6 +90,7 @@
   (export "block" $block)
   (export "loop1" $loop1)
   (export "loop2" $loop2)
+  (export "loop3" $loop3)
   (export "switch" $switch)
   (export "return" $return)
   (export "br_if" $br_if)
@@ -86,6 +99,7 @@
 (assert_return (invoke "block") (i32.const 1))
 (assert_return (invoke "loop1") (i32.const 5))
 (assert_return (invoke "loop2") (i32.const 8))
+(assert_return (invoke "loop3") (i32.const 1))
 (assert_return (invoke "switch" (i32.const 0)) (i32.const 50))
 (assert_return (invoke "switch" (i32.const 1)) (i32.const 20))
 (assert_return (invoke "switch" (i32.const 2)) (i32.const 20))


### PR DESCRIPTION
All loops in the test suite have a trailing `br`, so we didn't have a test yet for loops not automatically looping. I noticed this on binaryen which had this wrong.