### PR TITLE
Rename the 'stdio' module to 'spectest'.

### DIFF
--- a/ml-proto/host/builtins.ml
+++ b/ml-proto/host/builtins.ml
@@ -12,15 +12,15 @@ let print vs =
 let match_import m i =
   let {module_name; func_name; itype} = i.it in
   let {ins; out} = List.nth m.it.types itype.it in
-  if module_name <> "stdio" then
+  if module_name <> "spectest" then
     Unknown.error i.at ("no module \"" ^ module_name ^ "\"");
   match func_name with
   | "print" ->
     if out <> None then
-      Unknown.error i.at "stdio.print has no result";
+      Unknown.error i.at "spectest.print has no result";
     print
   | _ ->
-    Unknown.error i.at ("no function \"stdio." ^ func_name ^ "\"")
+    Unknown.error i.at ("no function \"spectest." ^ func_name ^ "\"")
 
 let match_imports m =
   List.map (match_import m) m.it.imports

--- a/ml-proto/test/address.wast
+++ b/ml-proto/test/address.wast
@@ -1,6 +1,6 @@
 (module
     (memory 1024 (segment 0 "abcdefghijklmnopqrstuvwxyz"))
-    (import $print "stdio" "print" (param i32))
+    (import $print "spectest" "print" (param i32))
 
     (func $good (param $i i32)
         (call_import $print (i32.load8_u offset=0 (get_local $i)))  ;; 97 'a'

--- a/ml-proto/test/func_ptrs.wast
+++ b/ml-proto/test/func_ptrs.wast
@@ -21,7 +21,7 @@
     (func $three (type $T) (param $a i32) (result i32) (i32.sub (get_local 0) (i32.const 2)))
     (export "three" $three)
 
-    (import $print "stdio" "print" (type 6))
+    (import $print "spectest" "print" (type 6))
     (func $four (type $U) (call_import $print (get_local 0)))
     (export "four" $four)
 )
@@ -31,7 +31,7 @@
 (invoke "four" (i32.const 83))
 
 (assert_invalid (module (func (type 42))) "unknown function type 42")
-(assert_invalid (module (import "stdio" "print" (type 43))) "unknown function type 43")
+(assert_invalid (module (import "spectest" "print" (type 43))) "unknown function type 43")
 
 (module
     (type $T (func (param) (result i32)))

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -1,8 +1,8 @@
 (module
-    (import $print_i32 "stdio" "print" (param i32))
-    (import $print_i64 "stdio" "print" (param i64))
-    (import $print_i32_f32 "stdio" "print" (param i32 f32))
-    (import $print_i64_f64 "stdio" "print" (param i64 f64))
+    (import $print_i32 "spectest" "print" (param i32))
+    (import $print_i64 "spectest" "print" (param i64))
+    (import $print_i32_f32 "spectest" "print" (param i32 f32))
+    (import $print_i64_f64 "spectest" "print" (param i64 f64))
     (func $print32 (param $i i32)
         (call_import $print_i32 (get_local $i))
         (call_import $print_i32_f32

--- a/ml-proto/test/store_retval.wast
+++ b/ml-proto/test/store_retval.wast
@@ -1,10 +1,10 @@
 (module
     (memory 100)
 
-    (import $print_i32 "stdio" "print" (param i32))
-    (import $print_i64 "stdio" "print" (param i64))
-    (import $print_f32 "stdio" "print" (param f32))
-    (import $print_f64 "stdio" "print" (param f64))
+    (import $print_i32 "spectest" "print" (param i32))
+    (import $print_i64 "spectest" "print" (param i64))
+    (import $print_f32 "spectest" "print" (param f32))
+    (import $print_f64 "spectest" "print" (param f64))
 
     (func $run
         (local $i32 i32) (local $i64 i64) (local $f32 f32) (local $f64 f64)


### PR DESCRIPTION
'stdio' is confusing because it's a set of functions with the main purpose being to support spec conformance tests, so this PR proposes naming it 'spectest'.