### PR TITLE
Use page aligned memory sizes in the tests.

### DIFF
--- a/ml-proto/TestingTodo.md
+++ b/ml-proto/TestingTodo.md
@@ -12,7 +12,6 @@ Misc semantics:
  - test that too-big linear memory initial allocation fails
  - test that function addresses are monotonic indices, and not actual addresses.
  - ~~test that non-pagesize `grow_memory` fails~~
- - test that non-pagesize initial linear memory allocation fails
  - test that one can clobber the entire contents of the linear memory without corrupting: call stack, local variables, program execution.
 
 Operator semantics:

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -299,22 +299,22 @@ let check_start c start =
       "start function must not return anything";
   ) start
 
-let check_segment size prev_end seg =
+let check_segment pages prev_end seg =
   let seg_len = Int64.of_int (String.length seg.it.Memory.data) in
   let seg_end = Int64.add seg.it.Memory.addr seg_len in
   require (seg.it.Memory.addr >= prev_end) seg.at
     "data segment not disjoint and ordered";
-  require (size >= seg_end) seg.at
+  require (Int64.mul pages Memory.page_size >= seg_end) seg.at
     "data segment does not fit memory";
   seg_end
 
 let check_memory memory =
   let mem = memory.it in
   require (mem.initial <= mem.max) memory.at
-    "initial memory size must be less than maximum";
-  require (mem.max <= 4294967296L) memory.at
-    "linear memory size must be less or equal to 4GiB";
-  ignore (List.fold_left (check_segment mem.initial) Int64.zero mem.segments)
+    "initial memory pages must be less than or equal to the maximum";
+  require (mem.max <= 65535L) memory.at
+    "linear memory pages must be less or equal to 65535 (4GiB)";
+  ignore (List.fold_left (check_segment mem.initial) 0L mem.segments)
 
 let check_module m =
   let {memory; types; funcs; start; imports; exports; table} = m.it in

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -289,7 +289,7 @@ and eval_hostop c hostop vs at =
      * Since we currently only support i32, just test that. *)
     if I64.gt_u new_size (Int64.of_int32 Int32.max_int) then
       Trap.error at "memory size exceeds implementation limit";
-    Memory.grow mem delta;
+    Memory.grow mem (Int64.div delta Memory.page_size);
     Some (Int32 (Int64.to_int32 old_size))
 
   | _, _ ->

--- a/ml-proto/spec/memory.ml
+++ b/ml-proto/spec/memory.ml
@@ -46,7 +46,7 @@ let host_index_of_int64 a n =
 
 
 let create' n =
-  let sz = host_size_of_int64 n in
+  let sz = host_size_of_int64 (Int64.mul n page_size) in
   let mem = Array1.create Int8_unsigned C_layout sz in
   Array1.fill mem 0;
   mem
@@ -68,9 +68,9 @@ let init mem segs =
 let size mem =
   int64_of_host_size (Array1.dim !mem)
 
-let grow mem n =
-  let old_size = size mem in
-  let new_size = Int64.add old_size n in
+let grow mem pages =
+  let old_size = Int64.div (size mem) page_size in
+  let new_size = Int64.add old_size pages in
   if I64.gt_u old_size new_size then raise SizeOverflow else
   let after = create' new_size in
   let host_old_size = host_size_of_int64 old_size in

--- a/ml-proto/test/address.wast
+++ b/ml-proto/test/address.wast
@@ -1,5 +1,5 @@
 (module
-    (memory 1024 (segment 0 "abcdefghijklmnopqrstuvwxyz"))
+    (memory 1 (segment 0 "abcdefghijklmnopqrstuvwxyz"))
     (import $print "spectest" "print" (param i32))
 
     (func $good (param $i i32)
@@ -26,9 +26,9 @@
 )
 
 (invoke "good" (i32.const 0))
-(invoke "good" (i32.const 995))
-(assert_trap (invoke "good" (i32.const 996)) "out of bounds memory access")
+(invoke "good" (i32.const 65507))
+(assert_trap (invoke "good" (i32.const 65508)) "out of bounds memory access")
 (assert_trap (invoke "bad2" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "bad2" (i32.const 1)) "out of bounds memory access")
 
-(assert_invalid (module (memory 1024) (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_local $i))) ) "offset too large")
+(assert_invalid (module (memory 1) (func $bad1 (param $i i32) (i32.load offset=4294967296 (get_local $i))) ) "offset too large")

--- a/ml-proto/test/endianness.wast
+++ b/ml-proto/test/endianness.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 8)
+  (memory 1)
 
   ;; Stores an i16 value in little-endian-format
   (func $i16_store_little (param $address i32) (param $value i32)

--- a/ml-proto/test/float_memory.wast
+++ b/ml-proto/test/float_memory.wast
@@ -2,7 +2,7 @@
 ;; stores don't do this.
 
 (module
-  (memory 4 4)
+  (memory 1 1)
 
   (func $store_i32 (param $x i32) (result i32)
     (i32.store (i32.const 0) (get_local $x)))
@@ -33,7 +33,7 @@
 (assert_return (invoke "load_i32") (i32.const 0x80000000))
 
 (module
-  (memory 8 8)
+  (memory 1 1)
 
   (func $store_i64 (param $x i64) (result i64)
     (i64.store (i32.const 0) (get_local $x)))

--- a/ml-proto/test/left-to-right.wast
+++ b/ml-proto/test/left-to-right.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 12)
+  (memory 1)
 
   (type $i32_T (func (param i32 i32) (result i32)))
   (type $i64_T (func (param i64 i64) (result i32)))

--- a/ml-proto/test/memory.wast
+++ b/ml-proto/test/memory.wast
@@ -1,34 +1,34 @@
 ;; Test memory section structure
 (module (memory 0 0))
 (module (memory 0 1))
-(module (memory 4096 16777216))
+(module (memory 1 256))
 (module (memory 0 0 (segment 0 "")))
 (module (memory 1 1 (segment 0 "a")))
-(module (memory 100 1000 (segment 0 "a") (segment 99 "b")))
-(module (memory 100 1000 (segment 0 "a") (segment 1 "b") (segment 2 "c")))
+(module (memory 1 2 (segment 0 "a") (segment 65535 "b")))
+(module (memory 1 2 (segment 0 "a") (segment 1 "b") (segment 2 "c")))
 
 (assert_invalid
   (module (memory 1 0))
-  "initial memory size must be less than maximum"
+  "initial memory pages must be less than or equal to the maximum"
 )
 (assert_invalid
   (module (memory 0 0 (segment 0 "a")))
   "data segment does not fit memory"
 )
 (assert_invalid
-  (module (memory 100 1000 (segment 0 "a") (segment 500 "b")))
+  (module (memory 1 2 (segment 0 "a") (segment 98304 "b")))
   "data segment does not fit memory"
 )
 (assert_invalid
-  (module (memory 100 1000 (segment 0 "abc") (segment 0 "def")))
+  (module (memory 1 2 (segment 0 "abc") (segment 0 "def")))
   "data segment not disjoint and ordered"
 )
 (assert_invalid
-  (module (memory 100 1000 (segment 3 "ab") (segment 0 "de")))
+  (module (memory 1 2 (segment 3 "ab") (segment 0 "de")))
   "data segment not disjoint and ordered"
 )
 (assert_invalid
-  (module (memory 100 1000 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
+  (module (memory 1 2 (segment 0 "a") (segment 2 "b") (segment 1 "c")))
   "data segment not disjoint and ordered"
 )
 
@@ -60,7 +60,7 @@
 )
 
 (module
-  (memory 1024 (segment 0 "ABC\a7D") (segment 20 "WASM"))
+  (memory 1 (segment 0 "ABC\a7D") (segment 20 "WASM"))
 
   ;; Data section
   (func $data (result i32)

--- a/ml-proto/test/memory_redundancy.wast
+++ b/ml-proto/test/memory_redundancy.wast
@@ -3,7 +3,7 @@
 ;; and to non-identical addresses.
 
 (module
-  (memory 16 16)
+  (memory 1 1)
 
   (export "zero_everything" $zero_everything)
   (func $zero_everything

--- a/ml-proto/test/memory_trap.wast
+++ b/ml-proto/test/memory_trap.wast
@@ -1,5 +1,5 @@
 (module
-    (memory 100)
+    (memory 1)
 
     (export "store" $store)
     (func $store (param $i i32) (param $v i32) (result i32) (i32.store (i32.add (memory_size) (get_local $i)) (get_local $v)))

--- a/ml-proto/test/start.wast
+++ b/ml-proto/test/start.wast
@@ -17,7 +17,7 @@
   "start function must be nullary"
 )
 (module
-  (memory 1024 (segment 0 "A"))
+  (memory 1 (segment 0 "A"))
   (func $inc
     (i32.store8
       (i32.const 0)
@@ -46,7 +46,7 @@
 (assert_return (invoke "get") (i32.const 70))
 
 (module
-  (memory 1024 (segment 0 "A"))
+  (memory 1 (segment 0 "A"))
   (func $inc
     (i32.store8
       (i32.const 0)

--- a/ml-proto/test/store_retval.wast
+++ b/ml-proto/test/store_retval.wast
@@ -1,5 +1,5 @@
 (module
-    (memory 100)
+    (memory 1)
 
     (import $print_i32 "spectest" "print" (param i32))
     (import $print_i64 "spectest" "print" (param i64))

--- a/ml-proto/test/traps.wast
+++ b/ml-proto/test/traps.wast
@@ -72,7 +72,7 @@
 (assert_trap (invoke "no_dce.i64.trunc_u_f64" (f64.const nan)) "invalid conversion to integer")
 
 (module
-    (memory 8)
+    (memory 1)
 
     (export "no_dce.i32.load" $no_dce.i32.load)
     (func $no_dce.i32.load (param $i i32) (i32.load (get_local $i)))
@@ -84,7 +84,7 @@
     (func $no_dce.f64.load (param $i i32) (f64.load (get_local $i)))
 )
 
-(assert_trap (invoke "no_dce.i32.load" (i32.const 8)) "out of bounds memory access")
-(assert_trap (invoke "no_dce.i64.load" (i32.const 8)) "out of bounds memory access")
-(assert_trap (invoke "no_dce.f32.load" (i32.const 8)) "out of bounds memory access")
-(assert_trap (invoke "no_dce.f64.load" (i32.const 8)) "out of bounds memory access")
+(assert_trap (invoke "no_dce.i32.load" (i32.const 65536)) "out of bounds memory access")
+(assert_trap (invoke "no_dce.i64.load" (i32.const 65536)) "out of bounds memory access")
+(assert_trap (invoke "no_dce.f32.load" (i32.const 65536)) "out of bounds memory access")
+(assert_trap (invoke "no_dce.f64.load" (i32.const 65536)) "out of bounds memory access")


### PR DESCRIPTION
Otherwise the tests will not be consistent when run on an implementation that rounds up the memory sizes in bytes to the page size units, and impossible for the runtime to check given that the binary encoding does not store the memory sizes in bytes.