### PR TITLE
Avoid (; for comments, use ;;

### DIFF
--- a/ml-proto/test/i32.wast
+++ b/ml-proto/test/i32.wast
@@ -1,4 +1,4 @@
-(; i32 operations ;)
+;; i32 operations
 
 (module
   (func $add (param $x i32) (param $y i32) (result i32) (i32.add (get_local $x) (get_local $y)))

--- a/ml-proto/test/i64.wast
+++ b/ml-proto/test/i64.wast
@@ -1,4 +1,4 @@
-(; i64 operations ;)
+;; i64 operations
 
 (module
   (func $add (param $x i64) (param $y i64) (result i64) (i64.add (get_local $x) (get_local $y)))


### PR DESCRIPTION
The leading brace would confuse generic s-exp parsers.