### PR TITLE
Remove parsing support for `(; ... ;)` comments.

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -149,7 +149,6 @@ Comments can be written in one of two ways:
 ```
 comment:
   ;; <character>* <eol>
-  (; (<character> | <comment>)* ;)
 ```
 
 In particular, comments of the latter form nest properly.

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -357,15 +357,12 @@ rule token = parse
 
   | ";;"[^'\n']*eof { EOF }
   | ";;"[^'\n']*'\n' { Lexing.new_line lexbuf; token lexbuf }
-  | "(;" { comment (Lexing.lexeme_start_p lexbuf) lexbuf; token lexbuf }
   | space { token lexbuf }
   | '\n' { Lexing.new_line lexbuf; token lexbuf }
   | eof { EOF }
   | _ { error lexbuf "unknown opcode" }
 
 and comment start = parse
-  | ";)" { () }
-  | "(;" { comment (Lexing.lexeme_start_p lexbuf) lexbuf; comment start lexbuf }
   | '\n' { Lexing.new_line lexbuf; comment start lexbuf }
   | eof { error_nest start lexbuf "unclosed comment" }
   | _ { comment start lexbuf }


### PR DESCRIPTION
Accompanying https://github.com/WebAssembly/spec/pull/228 removing the tests for `(; ... ;)` comments, this is a PR removing lexing support for them from the interpreter.