### PR TITLE
Use 0 instead of None for alignment

### DIFF
--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -157,34 +157,44 @@ rule token = parse
 
   | (nxx as t)".load"
     { LOAD (fun (o, a, e) ->
-        numop t (I32_load (o, a, e)) (I64_load (o, a, e))
-                (F32_load (o, a, e)) (F64_load (o, a, e))) }
+        numop t (I32_load (o, (Lib.Option.get a 4), e))
+                (I64_load (o, (Lib.Option.get a 8), e))
+                (F32_load (o, (Lib.Option.get a 4), e))
+                (F64_load (o, (Lib.Option.get a 8), e))) }
   | (nxx as t)".store"
     { STORE (fun (o, a, e1, e2) ->
-        numop t (I32_store (o, a, e1, e2)) (I64_store (o, a, e1, e2))
-                (F32_store (o, a, e1, e2)) (F64_store (o, a, e1, e2))) }
+        numop t (I32_store (o, (Lib.Option.get a 4), e1, e2))
+                (I64_store (o, (Lib.Option.get a 8), e1, e2))
+                (F32_store (o, (Lib.Option.get a 4), e1, e2))
+                (F64_store (o, (Lib.Option.get a 8), e1, e2))) }
   | (ixx as t)".load"(mem_size as sz)"_"(sign as s)
     { LOAD (fun (o, a, e) ->
         intop t
           (memsz sz
-            (ext s (I32_load8_s (o, a, e)) (I32_load8_u (o, a, e)))
-            (ext s (I32_load16_s (o, a, e)) (I32_load16_u (o, a, e)))
-            (ext s (I32_load32_s (o, a, e)) (I32_load32_u (o, a, e))))
+            (ext s (I32_load8_s (o, (Lib.Option.get a 1), e))
+                   (I32_load8_u (o, (Lib.Option.get a 1), e)))
+            (ext s (I32_load16_s (o, (Lib.Option.get a 2), e))
+                   (I32_load16_u (o, (Lib.Option.get a 2), e)))
+            (ext s (I32_load32_s (o, (Lib.Option.get a 4), e))
+                   (I32_load32_u (o, (Lib.Option.get a 4), e))))
           (memsz sz
-            (ext s (I64_load8_s (o, a, e)) (I64_load8_u (o, a, e)))
-            (ext s (I64_load16_s (o, a, e)) (I64_load16_u (o, a, e)))
-            (ext s (I64_load32_s (o, a, e)) (I64_load32_u (o, a, e))))) }
+            (ext s (I64_load8_s (o, (Lib.Option.get a 1), e))
+                   (I64_load8_u (o, (Lib.Option.get a 1), e)))
+            (ext s (I64_load16_s (o, (Lib.Option.get a 2), e))
+                   (I64_load16_u (o, (Lib.Option.get a 2), e)))
+            (ext s (I64_load32_s (o, (Lib.Option.get a 4), e))
+                   (I64_load32_u (o, (Lib.Option.get a 4), e))))) }
   | (ixx as t)".store"(mem_size as sz)
     { STORE (fun (o, a, e1, e2) ->
         intop t
           (memsz sz
-            (I32_store8 (o, a, e1, e2))
-            (I32_store16 (o, a, e1, e2))
-            (I32_store32 (o, a, e1, e2)))
+            (I32_store8 (o, (Lib.Option.get a 1), e1, e2))
+            (I32_store16 (o, (Lib.Option.get a 2), e1, e2))
+            (I32_store32 (o, (Lib.Option.get a 4), e1, e2)))
           (memsz sz
-            (I64_store8 (o, a, e1, e2))
-            (I64_store16 (o, a, e1, e2))
-            (I64_store32 (o, a, e1, e2)))
+            (I64_store8 (o, (Lib.Option.get a 1), e1, e2))
+            (I64_store16 (o, (Lib.Option.get a 2), e1, e2))
+            (I64_store32 (o, (Lib.Option.get a 4), e1, e2)))
         ) }
 
   | "offset="(digits as s) { OFFSET (Int64.of_string s) }

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -33,32 +33,32 @@ and expr' =
   | Set_local of var * expr
 
   (* Memory access *)
-  | I32_load of Memory.offset * int option * expr
-  | I64_load of Memory.offset * int option * expr
-  | F32_load of Memory.offset * int option * expr
-  | F64_load of Memory.offset * int option * expr
-  | I32_store of Memory.offset * int option * expr * expr
-  | I64_store of Memory.offset * int option * expr * expr
-  | F32_store of Memory.offset * int option * expr * expr
-  | F64_store of Memory.offset * int option * expr * expr
-  | I32_load8_s of Memory.offset * int option * expr
-  | I32_load8_u of Memory.offset * int option * expr
-  | I32_load16_s of Memory.offset * int option * expr
-  | I32_load16_u of Memory.offset * int option * expr
-  | I32_load32_s of Memory.offset * int option * expr
-  | I32_load32_u of Memory.offset * int option * expr
-  | I64_load8_s of Memory.offset * int option * expr
-  | I64_load8_u of Memory.offset * int option * expr
-  | I64_load16_s of Memory.offset * int option * expr
-  | I64_load16_u of Memory.offset * int option * expr
-  | I64_load32_s of Memory.offset * int option * expr
-  | I64_load32_u of Memory.offset * int option * expr
-  | I32_store8 of Memory.offset * int option * expr * expr
-  | I32_store16 of Memory.offset * int option * expr * expr
-  | I32_store32 of Memory.offset * int option * expr * expr
-  | I64_store8 of Memory.offset * int option * expr * expr
-  | I64_store16 of Memory.offset * int option * expr * expr
-  | I64_store32 of Memory.offset * int option * expr * expr
+  | I32_load of Memory.offset * int * expr
+  | I64_load of Memory.offset * int * expr
+  | F32_load of Memory.offset * int * expr
+  | F64_load of Memory.offset * int * expr
+  | I32_store of Memory.offset * int * expr * expr
+  | I64_store of Memory.offset * int * expr * expr
+  | F32_store of Memory.offset * int * expr * expr
+  | F64_store of Memory.offset * int * expr * expr
+  | I32_load8_s of Memory.offset * int * expr
+  | I32_load8_u of Memory.offset * int * expr
+  | I32_load16_s of Memory.offset * int * expr
+  | I32_load16_u of Memory.offset * int * expr
+  | I32_load32_s of Memory.offset * int * expr
+  | I32_load32_u of Memory.offset * int * expr
+  | I64_load8_s of Memory.offset * int * expr
+  | I64_load8_u of Memory.offset * int * expr
+  | I64_load16_s of Memory.offset * int * expr
+  | I64_load16_u of Memory.offset * int * expr
+  | I64_load32_s of Memory.offset * int * expr
+  | I64_load32_u of Memory.offset * int * expr
+  | I32_store8 of Memory.offset * int * expr * expr
+  | I32_store16 of Memory.offset * int * expr * expr
+  | I32_store32 of Memory.offset * int * expr * expr
+  | I64_store8 of Memory.offset * int * expr * expr
+  | I64_store16 of Memory.offset * int * expr * expr
+  | I64_store32 of Memory.offset * int * expr * expr
 
   (* Unary arithmetic *)
   | I32_clz of expr

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -252,9 +252,7 @@ and check_has_memory c at =
 and check_memop memop at =
   require (memop.offset >= 0L) at "negative offset";
   require (memop.offset <= 0xffffffffL) at "offset too large";
-  Lib.Option.app
-    (fun a -> require (Lib.Int.is_power_of_two a) at "non-power-of-two alignment")
-    memop.align
+  require (Lib.Int.is_power_of_two memop.align) at "non-power-of-two alignment";
 
 and check_mem_type ty sz at =
   require (ty = Int64Type || sz <> Memory.Mem32) at "memory size too big"

--- a/ml-proto/spec/kernel.ml
+++ b/ml-proto/spec/kernel.ml
@@ -61,7 +61,7 @@ type selop = (I32Op.selop, I64Op.selop, F32Op.selop, F64Op.selop) op
 type relop = (I32Op.relop, I64Op.relop, F32Op.relop, F64Op.relop) op
 type cvtop = (I32Op.cvtop, I64Op.cvtop, F32Op.cvtop, F64Op.cvtop) op
 
-type memop = {ty : value_type; offset : Memory.offset; align : int option}
+type memop = {ty : value_type; offset : Memory.offset; align : int}
 type extop = {memop : memop; sz : Memory.mem_size; ext : Memory.extension}
 type wrapop = {memop : memop; sz : Memory.mem_size}
 type hostop =


### PR DESCRIPTION
I realized that since `0` is already an invalid alignment (currently fails the "is a power of 2" check) we don't need alignment to be an `int option`, we can simply use an `int`; no reason to have two sentinel cases.  This also makes it an epsilon simpler when talking about binary encoding.