### PR TITLE
 Support start, add testcase, and can be executed properly

### DIFF
--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -337,6 +337,7 @@ rule token = parse
 
   | "type" { TYPE }
   | "func" { FUNC }
+  | "start" { START }
   | "param" { PARAM }
   | "result" { RESULT }
   | "local" { LOCAL }

--- a/ml-proto/host/print.ml
+++ b/ml-proto/host/print.ml
@@ -30,7 +30,7 @@ let print_table_elem i x =
 let print_start start =
   match start with
   | Some x -> printf "start = func %d\n" x.it
-  | None -> printf "there is no start\n"
+  | None -> ()
 
 (* Ast *)
 

--- a/ml-proto/host/print.ml
+++ b/ml-proto/host/print.ml
@@ -28,9 +28,7 @@ let print_table_elem i x =
   printf "table [%d] = func %d\n" i x.it
 
 let print_start start =
-  match start with
-  | Some x -> printf "start = func %d\n" x.it
-  | None -> ()
+  Lib.Option.app (fun x -> printf "start = func %d\n" x.it) start
 
 (* Ast *)
 

--- a/ml-proto/host/print.ml
+++ b/ml-proto/host/print.ml
@@ -27,6 +27,10 @@ let print_export_sig m prefix n f =
 let print_table_elem i x =
   printf "table [%d] = func %d\n" i x.it
 
+let print_start start =
+  match start with
+  | Some x -> printf "start = func %d\n" x.it
+  | None -> printf "there is no start\n"
 
 (* Ast *)
 
@@ -37,10 +41,11 @@ let print_export m i ex =
   print_export_sig m "export" ex.it.name (List.nth m.it.funcs ex.it.func.it)
 
 let print_module m =
-  let {funcs; exports; table} = m.it in
+  let {funcs; start; exports; table} = m.it in
   List.iteri (print_func m) funcs;
   List.iteri (print_export m) exports;
   List.iteri print_table_elem table;
+  print_start start;
   flush_all ()
 
 let print_module_sig m =

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -216,6 +216,7 @@ and module' =
   memory : Kernel.memory option;
   types : Types.func_type list;
   funcs : func list;
+  start : var option;
   imports : Kernel.import list;
   exports : Kernel.export list;
   table : var list;

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -295,7 +295,7 @@ let check_export c set ex =
 let check_start c start =
   Lib.Option.app (fun x ->
     let start_type = func c x in
-    require (List.length start_type.ins = 0) x.at
+    require (start_type.ins = []) x.at
       "start function must be nullary";
     require (start_type.out = None) x.at
       "start function must not return anything";

--- a/ml-proto/spec/desugar.ml
+++ b/ml-proto/spec/desugar.ml
@@ -308,7 +308,7 @@ and func' = function
 
 let rec module_ m = module' m.it @@ m.at
 and module' = function
-  | {Ast.funcs = fs; memory; types; imports; exports; table} ->
-    {funcs = List.map func fs; memory; types; imports; exports; table}
+  | {Ast.funcs = fs; start; memory; types; imports; exports; table} ->
+    {funcs = List.map func fs; start; memory; types; imports; exports; table}
 
 let desugar = module_

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -313,7 +313,7 @@ let add_export funcs ex =
 
 let init m imports host =
   assert (List.length imports = List.length m.it.Kernel.imports);
-  let {memory; types; funcs; exports; start; _} = m.it in
+  let {memory; funcs; exports; start; _} = m.it in
   let instance =
     {module_ = m;
      imports;
@@ -321,12 +321,7 @@ let init m imports host =
      memory = Lib.Option.map init_memory memory;
      host}
   in
-  Lib.Option.app (fun x -> 
-    let start_func = lookup "function" funcs x in
-    let start_func_type  = lookup "type" types start_func.it.ftype in
-    assert (List.length start_func_type.ins = 0 && start_func_type.out = None);
-    ignore (eval_func instance start_func [])
-  ) start;
+  Lib.Option.app (fun x -> ignore (eval_func instance (lookup "function" funcs x) [])) start;
   instance
 
 let invoke instance name vs =

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -313,7 +313,7 @@ let add_export funcs ex =
 
 let init m imports host =
   assert (List.length imports = List.length m.it.Kernel.imports);
-  let {memory; funcs; exports; start; _} = m.it in
+  let {memory; types; funcs; exports; start; _} = m.it in
   let instance =
     {module_ = m;
      imports;
@@ -321,7 +321,12 @@ let init m imports host =
      memory = Lib.Option.map init_memory memory;
      host}
   in
-  Lib.Option.app (fun x -> ignore (eval_func instance (lookup "function" funcs x) [])) start;
+  Lib.Option.app (fun x -> 
+    let start_func = lookup "function" funcs x in
+    let start_func_type  = lookup "type" types start_func.it.ftype in
+    assert (List.length start_func_type.ins = 0 && start_func_type.out = None);
+    ignore (eval_func instance start_func [])
+  ) start;
   instance
 
 let invoke instance name vs =

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -313,12 +313,18 @@ let add_export funcs ex =
 
 let init m imports host =
   assert (List.length imports = List.length m.it.Kernel.imports);
-  let {memory; funcs; exports; _} = m.it in
-  {module_ = m;
-   imports;
-   exports = List.fold_right (add_export funcs) exports ExportMap.empty;
-   memory = Lib.Option.map init_memory memory;
-   host}
+  let {memory; funcs; exports; start; _} = m.it in
+  let instance =
+    {module_ = m;
+     imports;
+     exports = List.fold_right (add_export funcs) exports ExportMap.empty;
+     memory = Lib.Option.map init_memory memory;
+     host}
+  in
+  ignore (match start with
+    | Some x -> eval_func instance (lookup "function" funcs x) []
+    | None -> None);
+  instance
 
 let invoke instance name vs =
   try

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -321,9 +321,7 @@ let init m imports host =
      memory = Lib.Option.map init_memory memory;
      host}
   in
-  ignore (match start with
-    | Some x -> eval_func instance (lookup "function" funcs x) []
-    | None -> None);
+  Lib.Option.app (fun x -> ignore (eval_func instance (lookup "function" funcs x) [])) start;
   instance
 
 let invoke instance name vs =

--- a/ml-proto/spec/kernel.ml
+++ b/ml-proto/spec/kernel.ml
@@ -141,6 +141,7 @@ and module_' =
   memory : memory option;
   types : Types.func_type list;
   funcs : func list;
+  start : var option;
   imports : import list;
   exports : export list;
   table : var list;

--- a/ml-proto/test/start.wast
+++ b/ml-proto/test/start.wast
@@ -1,0 +1,29 @@
+(module
+  (memory 1024 (segment 0 "A"))
+  (func $inc
+    (i32.store8
+      (i32.const 0)
+      (i32.add
+        (i32.load8_u (i32.const 0))
+        (i32.const 1)
+      )
+    )
+  )
+  (func $get (result i32)
+    (return (i32.load8_u (i32.const 0)))
+  )
+  (func $main
+    (call $inc)
+    (call $inc)
+    (call $inc)
+  )
+  (start $main)
+  (export "inc" $inc)
+  (export "get" $get)
+)
+(assert_return (invoke "get") (i32.const 68))
+(invoke "inc")
+(assert_return (invoke "get") (i32.const 69))
+(invoke "inc")
+(assert_return (invoke "get") (i32.const 70))
+

--- a/ml-proto/test/start.wast
+++ b/ml-proto/test/start.wast
@@ -1,3 +1,21 @@
+(assert_invalid
+  (module (func (i32.const 1)) (start 1))
+  "unknown function 1"
+)
+(assert_invalid
+  (module
+    (func $main (result i32) (return (i32.const 0)))
+    (start $main)
+  )
+  "start function must not return anything"
+)
+(assert_invalid
+  (module
+    (func $main (param $a i32))
+    (start $main)
+  )
+  "start function must be nullary"
+)
 (module
   (memory 1024 (segment 0 "A"))
   (func $inc
@@ -27,3 +45,31 @@
 (invoke "inc")
 (assert_return (invoke "get") (i32.const 70))
 
+(module
+  (memory 1024 (segment 0 "A"))
+  (func $inc
+    (i32.store8
+      (i32.const 0)
+      (i32.add
+        (i32.load8_u (i32.const 0))
+        (i32.const 1)
+      )
+    )
+  )
+  (func $get (result i32)
+    (return (i32.load8_u (i32.const 0)))
+  )
+  (func $main
+    (call $inc)
+    (call $inc)
+    (call $inc)
+  )
+  (start 2)
+  (export "inc" $inc)
+  (export "get" $get)
+)
+(assert_return (invoke "get") (i32.const 68))
+(invoke "inc")
+(assert_return (invoke "get") (i32.const 69))
+(invoke "inc")
+(assert_return (invoke "get") (i32.const 70))


### PR DESCRIPTION
The following is the list of what I have done to add start functionality

- I have changed the Ast module and Kernel module to include the start function index.
- Have the start function run as soon as the module is loaded.
- In the print_module function in host/print.ml, I have added the start function to be the output to the screen
- Add test/start.wast to test the start function

Please consider if we should add this feature to the main repo