### PR TITLE
Test a few more f32.demote_f64 edge cases.

### DIFF
--- a/ml-proto/test/conversions.wast
+++ b/ml-proto/test/conversions.wast
@@ -341,6 +341,8 @@
 (assert_return (invoke "f32.demote_f64" (f64.const 0x1p-149)) (f32.const 0x1p-149))
 (assert_return (invoke "f32.demote_f64" (f64.const 0x1.fffffep+127)) (f32.const 0x1.fffffep+127))
 (assert_return (invoke "f32.demote_f64" (f64.const -0x1.fffffep+127)) (f32.const -0x1.fffffep+127))
+(assert_return (invoke "f32.demote_f64" (f64.const 0x1.ffffffp+127)) (f32.const infinity))
+(assert_return (invoke "f32.demote_f64" (f64.const -0x1.ffffffp+127)) (f32.const -infinity))
 (assert_return (invoke "f32.demote_f64" (f64.const 0x1p-119)) (f32.const 0x1p-119))
 (assert_return (invoke "f32.demote_f64" (f64.const 0x1.8f867ep+125)) (f32.const 0x1.8f867ep+125))
 (assert_return (invoke "f32.demote_f64" (f64.const infinity)) (f32.const infinity))

--- a/ml-proto/test/conversions.wast
+++ b/ml-proto/test/conversions.wast
@@ -361,6 +361,10 @@
 (assert_return (invoke "f32.demote_f64" (f64.const -0x1p-1022)) (f32.const -0.0))
 (assert_return (invoke "f32.demote_f64" (f64.const 0x0.0000000000001p-1022)) (f32.const 0.0))
 (assert_return (invoke "f32.demote_f64" (f64.const -0x0.0000000000001p-1022)) (f32.const -0.0))
+(assert_return (invoke "f32.demote_f64" (f64.const 0x0.8p-149)) (f32.const 0.0))
+(assert_return (invoke "f32.demote_f64" (f64.const -0x0.8p-149)) (f32.const -0.0))
+(assert_return (invoke "f32.demote_f64" (f64.const 0x1.0000000000001p-150)) (f32.const 0x1p-149))
+(assert_return (invoke "f32.demote_f64" (f64.const -0x1.0000000000001p-150)) (f32.const -0x1p-149))
 
 (assert_return (invoke "f32.reinterpret_i32" (i32.const 0)) (f32.const 0.0))
 (assert_return (invoke "f32.reinterpret_i32" (i32.const 0x80000000)) (f32.const -0.0))


### PR DESCRIPTION
The test in 203a50b92478714bace87e8166b081cd7e1aed11 prompted me to notice a few more interesting cases for `f32.demote_f64`.