### PR TITLE
Adjust `if` to match post-order format.

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -97,10 +97,10 @@ cvtop: trunc_s | trunc_u | extend_s | extend_u | ...
 
 expr:
   ( nop )
-  ( block <name>? <expr>+ )
-  ( if_else <expr> <expr> <expr> )
-  ( if <expr> <expr> )                           ;; = (if_else <expr> <expr> (nop))
-  ( br_if <expr> <var> <expr>?)                  ;; = (if_else <expr> (br <var> <expr>?) (block <expr>? (nop)))
+  ( block <name>? <expr>* )
+  ( if <expr> ( then <name>? <expr>* ) ( else <name>? <expr>* )? )
+  ( if <expr1> <expr2> <expr3>? )                ;; = (if <expr1> (then <expr2>) (else <expr3>))
+  ( br_if <expr> <var> <expr>? )
   ( loop <name1>? <name2>? <expr>* )             ;; = (block <name1>? (loop <name2>? (block <expr>*)))
   ( br <var> <expr>? )
   ( return <expr>? )                             ;; = (br <current_depth> <expr>?)

--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -99,7 +99,7 @@ expr:
   ( nop )
   ( block <name>? <expr>* )
   ( if <expr> ( then <name>? <expr>* ) ( else <name>? <expr>* )? )
-  ( if <expr1> <expr2> <expr3>? )                ;; = (if <expr1> (then <expr2>) (else <expr3>))
+  ( if <expr1> <expr2> <expr3>? )                ;; = (if <expr1> (then <expr2>) (else <expr3>?))
   ( br_if <expr> <var> <expr>? )
   ( loop <name1>? <name2>? <expr>* )             ;; = (block <name1>? (loop <name2>? (block <expr>*)))
   ( br <var> <expr>? )

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -145,7 +145,8 @@ rule token = parse
   | "br_if" { BR_IF }
   | "return" { RETURN }
   | "if" { IF }
-  | "if_else" { IF_ELSE }
+  | "then" { THEN }
+  | "else" { ELSE }
   | "tableswitch" { TABLESWITCH }
   | "case" { CASE }
   | "call" { CALL }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -131,7 +131,7 @@ let implicit_decl c t at =
 %}
 
 %token INT FLOAT TEXT VAR VALUE_TYPE LPAR RPAR
-%token NOP BLOCK IF IF_ELSE LOOP BR BR_IF TABLESWITCH CASE
+%token NOP BLOCK IF THEN ELSE LOOP BR BR_IF TABLESWITCH CASE
 %token CALL CALL_IMPORT CALL_INDIRECT RETURN
 %token GET_LOCAL SET_LOCAL LOAD STORE OFFSET ALIGN
 %token CONST UNARY BINARY COMPARE CONVERT
@@ -236,8 +236,13 @@ expr1 :
   | BR_IF var expr { fun c -> Br_if ($2 c label, None, $3 c) }
   | BR_IF var expr expr { fun c -> Br_if ($2 c label, Some ($3 c), $4 c) }
   | RETURN expr_opt { fun c -> Return ($2 c) }
-  | IF expr expr { fun c -> If ($2 c, $3 c) }
-  | IF_ELSE expr expr expr { fun c -> If_else ($2 c, $3 c, $4 c) }
+  | IF expr expr { fun c -> let c' = anon_label c in If ($2 c, [$3 c'], []) }
+  | IF expr expr expr
+    { fun c -> let c' = anon_label c in If ($2 c, [$3 c'], [$4 c']) }
+  | IF expr LPAR THEN labeling expr_list RPAR
+    { fun c -> let c' = $5 c in If ($2 c, $6 c', []) }
+  | IF expr LPAR THEN labeling expr_list RPAR LPAR ELSE labeling expr_list RPAR
+    { fun c -> let c1 = $5 c in let c2 = $10 c in If ($2 c, $6 c1, $11 c2) }
   | TABLESWITCH labeling expr LPAR TABLE target_list RPAR target case_list
     { fun c -> let c' = $2 c in let e = $3 c' in
       let c'' = enter_switch c' in let es = $9 c'' in

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -21,8 +21,7 @@ and expr' =
   | Br of var * expr option
   | Br_if of var * expr option * expr
   | Return of expr option
-  | If of expr * expr
-  | If_else of expr * expr * expr
+  | If of expr * expr list * expr list
   | Tableswitch of expr * target list * target * expr list list
   | Call of var * expr list
   | Call_import of var * expr list

--- a/ml-proto/test/fac.wast
+++ b/ml-proto/test/fac.wast
@@ -1,7 +1,7 @@
 (module
   ;; Recursive factorial
   (func (param i64) (result i64)
-    (if_else (i64.eq (get_local 0) (i64.const 0))
+    (if (i64.eq (get_local 0) (i64.const 0))
       (i64.const 1)
       (i64.mul (get_local 0) (call 0 (i64.sub (get_local 0) (i64.const 1))))
     )
@@ -9,7 +9,7 @@
 
   ;; Recursive factorial named
   (func $fac-rec (param $n i64) (result i64)
-    (if_else (i64.eq (get_local $n) (i64.const 0))
+    (if (i64.eq (get_local $n) (i64.const 0))
       (i64.const 1)
       (i64.mul
         (get_local $n)
@@ -24,9 +24,9 @@
     (set_local 1 (get_local 0))
     (set_local 2 (i64.const 1))
     (loop
-      (if_else
+      (if
         (i64.eq (get_local 1) (i64.const 0))
-        (br 1)
+        (br 2)
         (block
           (set_local 2 (i64.mul (get_local 1) (get_local 2)))
           (set_local 1 (i64.sub (get_local 1) (i64.const 1)))
@@ -44,7 +44,7 @@
     (set_local $i (get_local $n))
     (set_local $res (i64.const 1))
     (loop $done $loop
-      (if_else
+      (if
         (i64.eq (get_local $i) (i64.const 0))
         (br $done)
         (block

--- a/ml-proto/test/forward.wast
+++ b/ml-proto/test/forward.wast
@@ -3,14 +3,14 @@
   (export "odd" $odd)
 
   (func $even (param $n i32) (result i32)
-    (if_else (i32.eq (get_local $n) (i32.const 0))
+    (if (i32.eq (get_local $n) (i32.const 0))
       (i32.const 1)
       (call $odd (i32.sub (get_local $n) (i32.const 1)))
     )
   )
 
   (func $odd (param $n i32) (result i32)
-    (if_else (i32.eq (get_local $n) (i32.const 0))
+    (if (i32.eq (get_local $n) (i32.const 0))
       (i32.const 0)
       (call $even (i32.sub (get_local $n) (i32.const 1)))
     )

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -66,6 +66,43 @@
     )
   )
 
+  (func $if (result i32)
+    (local $i i32)
+    (set_local $i (i32.const 0))
+    (block
+      (if
+        (i32.const 1)
+        (then $l (br $l) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 1)
+        (then $l (br $l) (set_local $i (i32.const 666)))
+        (else (set_local $i (i32.const 888)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 1)
+        (then $l (br $l) (set_local $i (i32.const 666)))
+        (else $l (set_local $i (i32.const 888)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 0)
+        (then (set_local $i (i32.const 888)))
+        (else $l (br $l) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 0)
+        (then $l (set_local $i (i32.const 888)))
+        (else $l (br $l) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+    )
+    (get_local $i)
+  )
+
   (func $switch (param i32) (result i32)
     (block $ret
       (i32.mul (i32.const 10)
@@ -100,9 +137,13 @@
         (br_if $inner (i32.const 1))
         (set_local $i (i32.or (get_local $i) (i32.const 0x2)))
       )
-      (br_if $outer (set_local $i (i32.or (get_local $i) (i32.const 0x4))) (i32.const 0))
+      (br_if $outer
+        (set_local $i (i32.or (get_local $i) (i32.const 0x4))) (i32.const 0)
+      )
       (set_local $i (i32.or (get_local $i) (i32.const 0x8)))
-      (br_if $outer (set_local $i (i32.or (get_local $i) (i32.const 0x10))) (i32.const 1))
+      (br_if $outer
+        (set_local $i (i32.or (get_local $i) (i32.const 0x10))) (i32.const 1)
+      )
       (set_local $i (i32.or (get_local $i) (i32.const 0x20)))
     )
   )
@@ -152,6 +193,7 @@
   (export "loop3" $loop3)
   (export "loop4" $loop4)
   (export "loop5" $loop5)
+  (export "if" $if)
   (export "switch" $switch)
   (export "return" $return)
   (export "br_if0" $br_if0)
@@ -169,6 +211,7 @@
 (assert_return (invoke "loop3") (i32.const 1))
 (assert_return (invoke "loop4" (i32.const 8)) (i32.const 16))
 (assert_return (invoke "loop5") (i32.const 2))
+(assert_return (invoke "if") (i32.const 5))
 (assert_return (invoke "switch" (i32.const 0)) (i32.const 50))
 (assert_return (invoke "switch" (i32.const 1)) (i32.const 20))
 (assert_return (invoke "switch" (i32.const 2)) (i32.const 20))
@@ -200,7 +243,7 @@
   "arity mismatch")
 (assert_invalid (module (func (result i32)
   (block $l0
-    (if_else (i32.const 1)
+    (if (i32.const 1)
       (br $l0 (block $l1 (br $l1 (i32.const 1))))
       (block (block $l1 (br $l1 (i32.const 1))) (nop))
     )

--- a/ml-proto/test/memory.wast
+++ b/ml-proto/test/memory.wast
@@ -95,7 +95,7 @@
     (loop
       (if
         (i32.eq (get_local 0) (i32.const 0))
-        (br 1)
+        (br 2)
       )
       (set_local 2 (i32.mul (get_local 0) (i32.const 4)))
       (i32.store (get_local 2) (get_local 0))
@@ -117,7 +117,7 @@
     (loop
       (if
         (i32.eq (get_local 0) (i32.const 0))
-        (br 1)
+        (br 2)
       )
       (set_local 2 (f64.convert_s/i32 (get_local 0)))
       (f64.store align=1 (get_local 0) (get_local 2))

--- a/ml-proto/test/unreachable.wast
+++ b/ml-proto/test/unreachable.wast
@@ -5,7 +5,7 @@
     (unreachable))
 
   (func $if (param i32) (result f32)
-   (if_else (get_local 0) (unreachable) (f32.const 0)))
+   (if (get_local 0) (unreachable) (f32.const 0)))
 
   (func $block
    (block (i32.const 1) (unreachable) (i32.const 2)))


### PR DESCRIPTION
The post-order binary format induces minor changes to `if`:

- There is only one opcode for `if`, with and without else-branch.
- The branches can have sequences of expressions (they are effectively blocks).

This PR reflects these generalisations in the AST and the S-expression format. Unfortunately, this required tagging the branch blocks in the S-expression syntax, so that the both lists can be distinguished. The tags can be omitted if the sequence consists of exactly one expression, thereby keeping the previous concrete syntax valid. See README for details.