### PR TITLE
Add a prettier module-summary-mode

### DIFF
--- a/ml-proto/host/main.ml
+++ b/ml-proto/host/main.ml
@@ -1,5 +1,4 @@
-let name = "wasm"
-let version = "0.2"
+open Flags
 
 let configure () =
   Import.register "spectest" Spectest.lookup;
@@ -23,6 +22,7 @@ let error at category msg =
   false
 
 let process file lexbuf start =
+  if !Flags.print_sig then print_endline ("File: " ^ file ^ "\n");
   try
     let script = parse file lexbuf start in
     Script.trace "Desugaring...";
@@ -84,7 +84,7 @@ let argspec = Arg.align
 [
   "-", Arg.Set Flags.interactive,
     " run interactively (default if no files given)";
-  "-s", Arg.Set Flags.print_sig, " show module signatures";
+  "-s", Arg.Set Flags.print_sig, " print module summary";
   "-d", Arg.Set Flags.dry, " dry, do not run program";
   "-t", Arg.Set Flags.trace, " trace execution";
   "-v", Arg.Unit banner, " show version"

--- a/ml-proto/host/print.mli
+++ b/ml-proto/host/print.mli
@@ -1,4 +1,2 @@
 val print_module : Kernel.module_ -> unit
-val print_module_sig : Kernel.module_ -> unit
 val print_value : Values.value option -> unit
-

--- a/ml-proto/host/script.ml
+++ b/ml-proto/host/script.ml
@@ -54,7 +54,7 @@ let run_cmd cmd =
     Check.check_module m;
     if !Flags.print_sig then begin
       trace "Signature:";
-      Print.print_module_sig m
+      Print.print_module m
     end;
     trace "Initializing...";
     let imports = Import.link m in
@@ -125,7 +125,7 @@ let dry_cmd cmd =
   match cmd.it with
   | Define m ->
     Check.check_module m;
-    if !Flags.print_sig then Print.print_module_sig m
+    if !Flags.print_sig then Print.print_module m
   | Invoke _
   | AssertInvalid _
   | AssertReturn _


### PR DESCRIPTION
I tried to tidy up the "show module signatures" mode since it wasn't indented at all and was lacking information about the memory size and (probably more important) information about imported functions.
Since we seem to get support for the binary format in the near future, it seemed to me, that some little summarizing functionality could come in handy.

This is what its output looks like:
```
File: test/testfile1.wast

Module #0
  Memory:
    Initial: 1
    Maximum: 1
  Functions:
    "inc" : () -> ()
    "get" : () -> i32
    $2 : () -> () [ENTRY]

File: test/testfile2.wast

Module #1
  Functions:
    "print32" : i32 -> ()
    "print64" : i64 -> ()
  Imports:
    spectest
      print : i32 -> ()
      print : i64 -> ()
      print : (i32 f32) -> ()
      print : (i64 f64) -> ()
```
