### PR TITLE
Allow subtyping on optional operands

### DIFF
--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -230,10 +230,9 @@ and check_exprs c ts es at =
   with Invalid_argument _ -> error at "arity mismatch"
 
 and check_expr_opt c et eo at =
-  match et, eo with
-  | Some t, Some e -> check_expr c et e
-  | None, None -> ()
-  | _ -> error at "arity mismatch"
+  match eo with
+  | Some e -> check_expr c et e
+  | None -> check_type None et at
 
 and check_literal c et l =
   check_type (Some (type_value l.it)) et l.at

--- a/ml-proto/test/break-drop.wast
+++ b/ml-proto/test/break-drop.wast
@@ -1,0 +1,64 @@
+(module
+  (func $br (block (br 0)))
+  (export "br" $br)
+
+  (func $br-nop (block (br 0 (nop))))
+  (export "br-nop" $br-nop)
+
+  (func $br-drop (block (br 0 (i32.const 1))))
+  (export "br-drop" $br-drop)
+
+  (func $br-block-nop (block (br 0 (block (i32.const 1) (nop)))))
+  (export "br-block-nop" $br-block-nop)
+
+  (func $br-block-drop (block (br 0 (block (nop) (i32.const 1)))))
+  (export "br-block-drop" $br-block-drop)
+
+  (func $br_if (block (br_if 0 (i32.const 1))))
+  (export "br_if" $br_if)
+
+  (func $br_if-nop (block (br_if 0 (nop) (i32.const 1))))
+  (export "br_if-nop" $br_if-nop)
+
+  (func $br_if-drop (block (br_if 0 (i32.const 1) (i32.const 1))))
+  (export "br_if-drop" $br_if-drop)
+
+  (func $br_if-block-nop (block (br_if 0 (block (i32.const 1) (nop)) (i32.const 1))))
+  (export "br_if-block-nop" $br_if-block-nop)
+
+  (func $br_if-block-drop (block (br_if 0 (block (nop) (i32.const 1)) (i32.const 1))))
+  (export "br_if-block-drop" $br_if-block-drop)
+
+  (func $br_table (block (br_table 0 (i32.const 0))))
+  (export "br_table" $br_table)
+
+  (func $br_table-nop (block (br_table 0 (nop) (i32.const 0))))
+  (export "br_table-nop" $br_table-nop)
+
+  (func $br_table-drop (block (br_table 0 (i32.const 1) (i32.const 0))))
+  (export "br_table-drop" $br_table-drop)
+
+  (func $br_table-block-nop (block (br_table 0 (block (i32.const 1) (nop)) (i32.const 0))))
+  (export "br_table-block-nop" $br_table-block-nop)
+
+  (func $br_table-block-drop (block (br_table 0 (block (nop) (i32.const 1)) (i32.const 0))))
+  (export "br_table-block-drop" $br_table-block-drop)
+)
+
+(assert_return (invoke "br"))
+(assert_return (invoke "br-nop"))
+(assert_return (invoke "br-drop"))
+(assert_return (invoke "br-block-nop"))
+(assert_return (invoke "br-block-drop"))
+
+(assert_return (invoke "br_if"))
+(assert_return (invoke "br_if-nop"))
+(assert_return (invoke "br_if-drop"))
+(assert_return (invoke "br_if-block-nop"))
+(assert_return (invoke "br_if-block-drop"))
+
+(assert_return (invoke "br_table"))
+(assert_return (invoke "br_table-nop"))
+(assert_return (invoke "br_table-drop"))
+(assert_return (invoke "br_table-block-nop"))
+(assert_return (invoke "br_table-block-drop"))

--- a/ml-proto/test/functions.wast
+++ b/ml-proto/test/functions.wast
@@ -1,10 +1,44 @@
 (module
-  (func $return-none (i32.const 1))
-  (export "return-none" $return-none)
-
   (func $empty)
   (export "empty" $empty)
+
+  (func $result-nop (nop))
+  (export "result-nop" $result-nop)
+
+  (func $result-drop (i32.const 1))
+  (export "result-drop" $result-drop)
+
+  (func $result-block-nop (block (i32.const 1) (nop)))
+  (export "result-block-nop" $result-block-nop)
+
+  (func $result-block-drop (block (nop) (i32.const 1)))
+  (export "result-block-drop" $result-block-drop)
+
+  (func $return (return))
+  (export "return" $return)
+
+  (func $return-nop (return (nop)))
+  (export "return-nop" $return-nop)
+
+  (func $return-drop (return (i32.const 1)))
+  (export "return-drop" $return-drop)
+
+  (func $return-block-nop (return (block (i32.const 1) (nop))))
+  (export "return-block-nop" $return-block-nop)
+
+  (func $return-block-drop (return (block (nop) (i32.const 1))))
+  (export "return-block-drop" $return-block-drop)
 )
 
-(assert_return (invoke "return-none"))
 (assert_return (invoke "empty"))
+(assert_return (invoke "result-nop"))
+(assert_return (invoke "result-drop"))
+(assert_return (invoke "result-block-nop"))
+(assert_return (invoke "result-block-drop"))
+
+(assert_return (invoke "return"))
+(assert_return (invoke "return-nop"))
+(assert_return (invoke "return-drop"))
+(assert_return (invoke "return-block-nop"))
+(assert_return (invoke "return-block-drop"))
+

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -178,13 +178,29 @@
 
   (func $br_if3 (result i32)
     (local $i1 i32)
-    (i32.add (block $l0
-               (br_if $l0
-                      (set_local $i1 (i32.const 1))
-                      (set_local $i1 (i32.const 2)))
-               (i32.const 0))
-             (i32.const 0))
-    (get_local $i1))
+    (i32.add
+      (block $l0
+        (br_if $l0 (set_local $i1 (i32.const 1)) (set_local $i1 (i32.const 2)))
+        (i32.const 0)
+      )
+      (i32.const 0)
+    )
+    (get_local $i1)
+  )
+
+  (func $br_if4
+    (block $l0 (br_if $l0 (nop) (i32.const 1)))
+  )
+
+  (func $br (result i32)
+    (block $l0
+      (if (i32.const 1)
+        (br $l0 (block $l1 (br $l1 (i32.const 1))))
+        (block (block $l1 (br $l1 (i32.const 1))) (nop))
+      )
+      (i32.const 1)
+    )
+  )
 
   (func $misc1 (result i32)
    (block $l1 (i32.xor (br $l1 (i32.const 1)) (i32.const 2)))
@@ -215,6 +231,8 @@
   (export "br_if1" $br_if1)
   (export "br_if2" $br_if2)
   (export "br_if3" $br_if3)
+  (export "br_if4" $br_if4)
+  (export "br" $br)
   (export "misc1" $misc1)
   (export "misc2" $misc2)
   (export "redefinition" $redefinition)
@@ -240,26 +258,41 @@
 (assert_return (invoke "br_if1") (i32.const 1))
 (assert_return (invoke "br_if2") (i32.const 1))
 (assert_return (invoke "br_if3") (i32.const 2))
+(assert_return (invoke "br_if4"))
+(assert_return (invoke "br") (i32.const 1))
 (assert_return (invoke "misc1") (i32.const 1))
 (assert_return (invoke "misc2") (i32.const 1))
 (assert_return (invoke "redefinition") (i32.const 5))
 
-(assert_invalid (module (func (loop $l (br $l (i32.const 0))))) "arity mismatch")
-(assert_invalid (module (func (block $l (f32.neg (br_if $l (i32.const 1))) (nop)))) "type mismatch")
-
-(assert_invalid (module (func (result f32) (block $l (br_if $l (f32.const 0) (i32.const 1))))) "type mismatch")
-(assert_invalid (module (func (result i32) (block $l (br_if $l (f32.const 0) (i32.const 1))))) "type mismatch")
-(assert_invalid (module (func (block $l (f32.neg (br_if $l (f32.const 0) (i32.const 1)))))) "arity mismatch")
-(assert_invalid (module (func (param i32) (result i32) (block $l (f32.neg (br_if $l (f32.const 0) (get_local 0)))))) "type mismatch")
-(assert_invalid (module (func (param i32) (result f32)
-  (block $l (f32.neg (block $i (br_if $l (f32.const 3) (get_local 0)))))))
-  "type mismatch")
-(assert_invalid (module (func (block $l0 (br_if $l0 (nop) (i32.const 1)))))
-  "arity mismatch")
-(assert_invalid (module (func (result i32)
-  (block $l0
-    (if (i32.const 1)
-      (br $l0 (block $l1 (br $l1 (i32.const 1))))
-      (block (block $l1 (br $l1 (i32.const 1))) (nop))
+(assert_invalid
+  (module (func (block $l (f32.neg (br_if $l (i32.const 1))) (nop))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func (result f32) (block $l (br_if $l (f32.const 0) (i32.const 1)))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func (result i32) (block $l (br_if $l (f32.const 0) (i32.const 1)))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func (block $l (f32.neg (br_if $l (f32.const 0) (i32.const 1))))))
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (param i32) (result i32)
+      (block $l (f32.neg (br_if $l (f32.const 0) (get_local 0))))
     )
-  (i32.const 1)))) "arity mismatch")
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (param i32) (result f32)
+      (block $l (f32.neg (block $i (br_if $l (f32.const 3) (get_local 0)))))
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
This reverses #180, and adds a number of corresponding tests.

Motivation: not allowing optional operands to be implicitly dropped (1) reduced the compositionality of the language, (2) made it harder to allow multiple targets (like with a br_if also returning its operand), and (3) put an extra burden on bottom-up type checkers, where the arity might not be known upfront. And with multiple value, we eventually would want to lift this restriction again anyway.

This should address issues #227, and enable WebAssembly/design#539.

@jcbeyler, you filed #179, which lead to #180. Are you okay with reverting to status ante quo?