### PR TITLE
Allow binary modules in text format

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -147,21 +147,23 @@ param:  ( param <type>* ) | ( param <name> <type> )
 result: ( result <type> )
 local:  ( local <type>* ) | ( local <name> <type> )
 
-module:  ( module <type>* <func>* <import>* <export>* <table>* <memory>? <start>? )
+module:  ( module <type>* <func>* <import>* <export>* <table>* <memory>? <start>? ) | (module <string>+)
 type:    ( type <name>? ( func <param>* <result>? ) )
 import:  ( import <name>? <string> <string> (param <type>* ) (result <type>)* )
 export:  ( export <string> <var> ) | ( export <string> memory)
 start:   ( start <var> )
 table:   ( table <var>* )
 memory:  ( memory <int> <int>? <segment>* )
-segment: ( segment <int> <string> )
+segment: ( segment <int> <string>+ )
 ```
 
 Here, productions marked with respective comments are abbreviation forms for equivalent expansions (see the explanation of the kernel AST below).
 
 Any form of naming via `<name>` and `<var>` (including expression labels) is merely notational convenience of this text format. The actual AST has no names, and all bindings are referred to via ordered numeric indices; consequently, names are immediately resolved in the parser and replaced by indices. Indices can also be used directly in the text format.
 
-The segment string in the memory field is used to initialize the memory at the given offset.
+A module of the form `(module <string>+)` is given in binary form and will be decoded from the (concatenation of the) strings.
+
+The segment strings in the memory field are used to initialize the consecutive memory at the given offset.
 
 Comments can be written in one of two ways:
 
@@ -189,7 +191,7 @@ cmd:
   ( assert_trap (invoke <name> <expr>* ) <failure> )   ;; assert invocation traps with given failure string
   ( assert_invalid <module> <failure> )                ;; assert invalid module with given failure string
   ( input <string> )                                   ;; read script or module from file
-  ( output <string> )                                  ;; output module to file
+  ( output <string>? )                                 ;; output module to stout or file
 ```
 
 Commands are executed in sequence. Invocation, assertions, and output apply to the most recently defined module (the _current_ module), and are only possible after a module has been defined. Note that there only ever is one current module, the different module definitions cannot interact.

--- a/ml-proto/given/lib.ml
+++ b/ml-proto/given/lib.ml
@@ -64,3 +64,12 @@ struct
     if x < 0L then failwith "is_power_of_two";
     x <> 0L && (Int64.logand x (Int64.sub x 1L)) = 0L
 end
+
+module String =
+struct
+  let breakup s n =
+    let rec loop i =
+      let len = min n (String.length s - i) in
+      if len = 0 then [] else String.sub s i len :: loop (i + len)
+    in loop 0
+end

--- a/ml-proto/given/lib.mli
+++ b/ml-proto/given/lib.mli
@@ -28,3 +28,8 @@ module Int64 :
 sig
   val is_power_of_two : int64 -> bool
 end
+
+module String :
+sig
+  val breakup : string -> int -> string list
+end

--- a/ml-proto/host/format.ml
+++ b/ml-proto/host/format.ml
@@ -29,6 +29,7 @@ let string s =
 let list_of_opt = function None -> [] | Some x -> [x]
 
 let list f xs = List.map f xs
+let listi f xs = List.mapi f xs
 let opt f xo = list f (list_of_opt xo)
 
 let tab head f xs = if xs = [] then [] else [Node (head, list f xs)]
@@ -235,9 +236,9 @@ and block e =
 
 (* Functions *)
 
-let func f =
+let func i f =
   let {ftype; locals; body} = f.it in
-  Node ("func",
+  Node ("func $" ^ string_of_int i,
     [Node ("type " ^ var ftype, [])] @
     decls "local" locals @
     block body
@@ -262,13 +263,15 @@ let memory mem =
 
 (* Modules *)
 
-let typedef t =
-  Node ("type", [struct_type t])
+let typedef i t =
+  Node ("type $" ^ string_of_int i, [struct_type t])
 
-let import im =
+let import i im =
   let {itype; module_name; func_name} = im.it in
   let ty = Node ("type " ^ var itype, []) in
-  Node ("import", [atom string module_name; atom string func_name; ty])
+  Node ("import $" ^ string_of_int i,
+    [atom string module_name; atom string func_name; ty]
+  )
 
 let export ex =
   let {name; kind} = ex.it in
@@ -280,9 +283,9 @@ let export ex =
 
 let module_ m =
   Node ("module",
-    list typedef m.it.types @
-    list import m.it.imports @
-    list func m.it.funcs @
+    listi typedef m.it.types @
+    listi import m.it.imports @
+    listi func m.it.funcs @
     table m.it.table @
     opt memory m.it.memory @
     list export m.it.exports @

--- a/ml-proto/host/parse.ml
+++ b/ml-proto/host/parse.ml
@@ -1,5 +1,5 @@
 type 'a start =
-  | Module : Ast.module_ start
+  | Module : Script.definition start
   | Script : Script.script start
   | Script1 : Script.script start
 

--- a/ml-proto/host/parse.mli
+++ b/ml-proto/host/parse.mli
@@ -1,5 +1,5 @@
 type 'a start =
-  | Module : Ast.module_ start
+  | Module : Script.definition start
   | Script : Script.script start
   | Script1 : Script.script start
 
@@ -8,4 +8,4 @@ exception Syntax of Source.region * string
 val parse : string -> Lexing.lexbuf -> 'a start -> 'a (* raise Syntax *)
 
 val string_to_script : string -> Script.script (* raise Syntax *)
-val string_to_module : string -> Ast.module_ (* raise Syntax *)
+val string_to_module : string -> Script.definition (* raise Syntax *)

--- a/ml-proto/host/run.ml
+++ b/ml-proto/host/run.ml
@@ -42,7 +42,9 @@ let run_sexpr name lexbuf start =
 let run_binary name buf =
   let open Source in
   run_from
-    (fun _ -> let m = Decode.decode name buf in [Script.Define m @@ m.at])
+    (fun _ ->
+      let m = Decode.decode name buf in
+      [Script.Define (Script.Textual m @@ m.at) @@ m.at])
 
 let run_sexpr_file file =
   Script.trace ("Loading (" ^ file ^ ")...");
@@ -113,6 +115,12 @@ let rec run_stdin () =
 
 (* Output *)
 
+let print_stdout m =
+  Script.trace "Formatting...";
+  let sexpr = Format.module_ (Desugar.desugar m) in
+  Script.trace "Printing...";
+  Sexpr.output stdout !Flags.width sexpr
+
 let create_sexpr_file file m =
   Script.trace ("Formatting (" ^ file ^ ")...");
   let sexpr = Format.module_ (Desugar.desugar m) in
@@ -134,4 +142,6 @@ let create_binary_file file m =
   with exn -> close_out oc; raise exn
 
 let create_file = dispatch_file_ext create_sexpr_file create_binary_file
+
 let () = Script.output_file := create_file
+let () = Script.output_stdout := print_stdout

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -1,13 +1,18 @@
+type definition = definition' Source.phrase
+and definition' =
+  | Textual of Ast.module_
+  | Binary of string
+
 type command = command' Source.phrase
 and command' =
-  | Define of Ast.module_
+  | Define of definition
   | Invoke of string * Kernel.literal list
-  | AssertInvalid of Ast.module_ * string
+  | AssertInvalid of definition * string
   | AssertReturn of string * Kernel.literal list * Kernel.literal option
   | AssertReturnNaN of string * Kernel.literal list
   | AssertTrap of string * Kernel.literal list * string
   | Input of string
-  | Output of string
+  | Output of string option
 
 type script = command list
 
@@ -23,3 +28,4 @@ val trace : string -> unit
 
 val input_file : (string -> bool) ref
 val output_file : (string -> Ast.module_ -> unit) ref
+val output_stdout : (Ast.module_ -> unit) ref

--- a/ml-proto/spec/decode.mli
+++ b/ml-proto/spec/decode.mli
@@ -1,3 +1,3 @@
 exception Code of Source.region * string
 
-val decode : string -> bytes -> Ast.module_ (* raise Code *)
+val decode : string -> string -> Ast.module_ (* raise Code *)

--- a/ml-proto/test/binary.wast
+++ b/ml-proto/test/binary.wast
@@ -1,0 +1,14 @@
+(module "\00asm\0b\00\00\00")
+(module "\00asm" "\0b\00\00\00")
+
+(assert_invalid (module "") "unexpected end")
+(assert_invalid (module "\01") "unexpected end")
+(assert_invalid (module "\00as") "unexpected end")
+(assert_invalid (module "\01") "unexpected end")
+(assert_invalid (module "asm\00") "magic header not detected")
+
+(assert_invalid (module "\00asm") "unexpected end")
+(assert_invalid (module "\00asm\0b") "unexpected end")
+(assert_invalid (module "\00asm\0b\00\00") "unexpected end")
+(assert_invalid (module "\00asm\10\00\00\00") "unknown binary version")
+


### PR DESCRIPTION
This PR adds support for defining modules directly in terms of a binary string in the text format:
```
(module "\00asm\0b\00\00\00")
(assert_invalid (module "\00as") "unexpected end")
```
To ease formatting, strings can be split up into several literals, which are simply concatenated:
```
(module
  "\00asm"  ;; magic header
  "\0b\00\00\00"  ;; version
)
```
The same string splitting is now allowed in `segment` nodes.

Further changes:

- Correct string escaping in S-expr output.
- Tweaked S-expr output to match binary section order.
- Type and function definitions are named with their index, for easier reference.
- Functions are now formatted literally using the `(type i)` syntax for their signature, in order to not implicitly change the content of the type section. (One step closer to (parse o format) being an identity.)
- The `output` command can now be used without an argument, which just dumps the current module to stdout.