### PR TITLE
Add tests for if/then/else with indices + unknown label;

### DIFF
--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -15,9 +15,14 @@ def auxFile(path):
     return path
 
 class RunTests(unittest.TestCase):
-  def _runCommand(self, command):
-    exitCode = subprocess.call(command, shell=True)
-    self.assertEqual(0, exitCode, "test runner failed with exit code %i" % exitCode)
+  def _runCommand(self, command, logPath = None, expectedExitCode = 0):
+    out = None if logPath is None else file(logPath, 'w+')
+
+    exitCode = subprocess.call(command, shell=True, stdout=out, stderr=subprocess.STDOUT)
+    self.assertEqual(expectedExitCode, exitCode, "test runner failed with exit code %i, expected %i" % (exitCode, expectedExitCode))
+
+    if logPath is not None:
+      out.close()
 
   def _compareFile(self, expectedFile, actualFile):
     with open(expectedFile) as expected:
@@ -33,28 +38,34 @@ class RunTests(unittest.TestCase):
       pass
 
   def _runTestFile(self, shortName, fileName, interpreterPath):
+
+    expectedExitCode = 1 if ".fail." in fileName else 0
+
     # Run original file
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.log"))
-    self._runCommand(("%s %s > %s") % (interpreterPath, fileName, logPath))
+    self._runCommand(("%s %s") % (interpreterPath, fileName), logPath, expectedExitCode)
     self._compareLog(fileName, logPath)
+
+    if expectedExitCode != 0:
+      return
 
     # Convert to binary and run again
     wasmPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.log"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, fileName, wasmPath))
-    self._runCommand(("%s %s > %s") % (interpreterPath, wasmPath, logPath))
+    self._runCommand(("%s %s") % (interpreterPath, wasmPath), logPath)
 
     # Convert back to text and run again
     wastPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.log"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, wasmPath, wastPath))
-    self._runCommand(("%s %s > %s") % (interpreterPath, wastPath, logPath))
+    self._runCommand(("%s %s ") % (interpreterPath, wastPath), logPath)
 
     #return
     # Convert back to binary once more and compare
     wasm2Path = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.wasm"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, wastPath, wasm2Path))
-    self._runCommand(("%s %s > %s") % (interpreterPath, wasm2Path, logPath))
+    self._runCommand(("%s %s") % (interpreterPath, wasm2Path), logPath)
     # TODO: Ultimately, the binary should stay the same, but currently desugaring gets in the way.
     # self._compareFile(wasmPath, wasm2Path)
 

--- a/ml-proto/test/expected-output/if_label_scope.fail.wast.log
+++ b/ml-proto/test/expected-output/if_label_scope.fail.wast.log
@@ -1,0 +1,1 @@
+test/if_label_scope.fail.wast:6.19-6.21: unknown label $l

--- a/ml-proto/test/if_label_scope.fail.wast
+++ b/ml-proto/test/if_label_scope.fail.wast
@@ -1,0 +1,10 @@
+(module
+  (func
+    (block
+      (if (i32.const 0)
+        (then $l (br $l (i32.const 1)))
+        (else (br $l (i32.const 42)))
+      )
+    )
+  )
+)

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -335,17 +335,3 @@
   )
   "type mismatch"
 )
-
-(assert_invalid
-  (module
-    (func
-      (block
-        (if (i32.const 0)
-          (then $l (br $l (i32.const 1)))
-          (else (br $l (i32.const 42)))
-        )
-      )
-    )
-  )
-  "unknown label"
-)

--- a/ml-proto/test/labels.wast
+++ b/ml-proto/test/labels.wast
@@ -103,6 +103,43 @@
     (get_local $i)
   )
 
+  (func $if2 (result i32)
+    (local $i i32)
+    (set_local $i (i32.const 0))
+    (block
+      (if
+        (i32.const 1)
+        (then (br 0) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 1)
+        (then (br 0) (set_local $i (i32.const 666)))
+        (else (set_local $i (i32.const 888)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 1)
+        (then (br 0) (set_local $i (i32.const 666)))
+        (else (set_local $i (i32.const 888)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 0)
+        (then (set_local $i (i32.const 888)))
+        (else (br 0) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+      (if
+        (i32.const 0)
+        (then (set_local $i (i32.const 888)))
+        (else (br 0) (set_local $i (i32.const 666)))
+      )
+      (set_local $i (i32.add (get_local $i) (i32.const 1)))
+    )
+    (get_local $i)
+  )
+
   (func $switch (param i32) (result i32)
     (block $ret
       (i32.mul (i32.const 10)
@@ -225,6 +262,7 @@
   (export "loop4" $loop4)
   (export "loop5" $loop5)
   (export "if" $if)
+  (export "if2" $if2)
   (export "switch" $switch)
   (export "return" $return)
   (export "br_if0" $br_if0)
@@ -245,6 +283,7 @@
 (assert_return (invoke "loop4" (i32.const 8)) (i32.const 16))
 (assert_return (invoke "loop5") (i32.const 2))
 (assert_return (invoke "if") (i32.const 5))
+(assert_return (invoke "if2") (i32.const 5))
 (assert_return (invoke "switch" (i32.const 0)) (i32.const 50))
 (assert_return (invoke "switch" (i32.const 1)) (i32.const 20))
 (assert_return (invoke "switch" (i32.const 2)) (i32.const 20))
@@ -295,4 +334,18 @@
     )
   )
   "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (func
+      (block
+        (if (i32.const 0)
+          (then $l (br $l (i32.const 1)))
+          (else (br $l (i32.const 42)))
+        )
+      )
+    )
+  )
+  "unknown label"
 )


### PR DESCRIPTION
Hi! I'd like to add test cases we ran into in our implementation and which could be useful for others:

- a test for if/then/else where the depths are not labels, but raw integer indices.
- a test for if/then/else where the label target of a `br` in the `else` is the label of the `then` block.

Unfortunately, the second test (at the end of the file) doesn't work: the parser complains that the label `$l` is unknown, which is exactly what we are testing here. The correct behavior would be to silently swallow the error and consider the test as passed. Am I missing something here?