### PR TITLE
md-proto: a specification written in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ which is currently serving as the official specification. Eventually, we expect
 to produce a specification either written in human-readable prose or in a formal
 specification language.
 
+It also holds a prototype which may eventually satisfy the need for a
+human-readable prose specification
+[here](https://github.com/WebAssembly/spec/tree/master/md-proto).
+
 It also holds the WebAssembly testsuite, which tests numerous aspects of
 conformance to the spec.
 

--- a/md-proto/Addenda.md
+++ b/md-proto/Addenda.md
@@ -1,4 +1,4 @@
-WebAssembly Addenda
+WebAssembly Specification Addenda
 ================================================================================
 
 0. [Introduction](#introduction)

--- a/md-proto/Addenda.md
+++ b/md-proto/Addenda.md
@@ -1,0 +1,163 @@
+WebAssembly Addenda
+================================================================================
+
+0. [Introduction](#introduction)
+0. [Stack-Based Function-Body Validation Algorithm](#stack-based-function-body-validation-algorithm)
+
+
+Introduction
+--------------------------------------------------------------------------------
+
+A WebAssembly module can be validated in a single linear pass. This is fairly
+straightforward for most sections, but things get interesting in function
+bodies. The [stack-based function-body validation algorithm] describes one
+approach by which this can be accomplished.
+
+
+Stack-Based Function-Body Validation Algorithm
+--------------------------------------------------------------------------------
+
+Function-body validation can be performed in a single linear pass as follows:
+
+The following data structures are created:
+ - A *type stack*, with entries each containing a [type], for tracking the
+   sequence of values that will be on the value stack at execution time.
+ - A *control-flow stack*, with entries each containing:
+    - A *limit* integer value, which is an index into the type stack indicating
+      the boundary between values pushed before the current region and values
+      pushed inside the current region.
+    - An optional [type] sequence, which is used to check that all exits from
+      the current region leave the same sequence of types on the type stack.
+    - An *isThisAnIf* flag, indicating whether the entry was pushed for an `if`.
+
+The following invariants are required to be preserved:
+ - Whenever an element of either stack is to be popped, that stack is required
+   to be non-empty.
+ - Whenever an element of either stack is to be accessed by index, the index is
+   required to be within the bounds of that stack.
+ - Whenever the control-flow stack is non-empty, as it is everywhere except
+   after the `end` at the end of the function, the type stack must be longer
+   than the control-flow stack top's limit value.
+
+The type stack begins empty. The control-flow stack begins with one entry, with
+the [type] sequence consisting of the return types of the function, with the
+limit value being zero, and the isThisAnIf flag being false.
+
+For each instruction in the body, in sequence order:
+ - For each construct in the instruction's signature's operands in reverse
+   order:
+    - If the construct is a [type], a type is popped from the type stack and
+      required to be the same.
+    - If the construct is a list of type parameters:
+        - If the parameters are not yet bound, a type for each type parameter in
+          the list in reverse order is popped from the type stack and bound to
+          it.
+        - Otherwise, a type for each type in the list in reverse order is popped
+          from the type stack and required to be the same.
+        - References to `$any` in the signature are resolved to the difference
+          between the length of the type stack and the control-flow stack top's
+          limit value.
+   The popped types in reverse (again) order form the *operand sequence*.
+ - Unless the instruction is a [control-flow barrier][Q], then for each
+   construct in the instruction's signature's returns:
+    - If the construct is a [type], a type is pushed onto the type stack.
+    - If the construct is a list of type parameters, they are required to be
+      bound, and the type bound to each type parameter is pushed onto the type
+      stack.
+ - If the instruction has a **Validation** clause, its requirements are
+   required.
+ - If the instruction has an associated
+   [validation algorithm)[#instruction-specific-validation-algorithm], its
+   contents are performed.
+ - If the instruction's signature has no return types, or it is a
+   [control-flow barrier][Q], the new length of the type stack is required to be
+   at most the control-flow stack top's limit value.
+
+Finally, for each type in the function's return list, a type is popped from the
+type stack and required be the same. The type stack and the control-flow stack
+are then both required to be empty. If all requirements were met, function-body
+validation is successful.
+
+> Implementations need not perform this exact algorithm; they need only validate
+that the [requirements](WebAssembly.md#function-body-validation-requirements)
+are met.
+
+> The control-flow stack's limit values effectively mark region boundaries in
+the type stack. Regions are required to be nested, and each region's limit value
+is greater than those of the regions that enclose it. Types pushed onto the type
+stack outside a region cannot be popped from within the region.
+
+### Type-Sequence Merge
+
+To merge a new type sequence into a control flow stack entry:
+ - If the entry's optional type sequence is absent, it is set to be the new
+   sequence.
+ - Otherwise, the entry's type sequence is required to be the same as the new
+   sequence.
+
+### Instruction-Specific Validation Algorithm
+
+0. [Block Validation Algorithm](#block-validation-algorithm)
+0. [Loop Validation Algorithm](#loop-validation-algorithm)
+0. [Unconditional-Branch Validation Algorithm](#unconditional-branch-validation-algorithm)
+0. [Conditional-Branch Validation Algorithm](#conditional-branch-validation-algorithm)
+0. [Table-Branch Validation Algorithm](#table-branch-validation-algorithm)
+0. [If Validation Algorithm](#if-validation-algorithm)
+0. [Else Validation Algorithm](#else-validation-algorithm)
+0. [End Validation Algorithm](#end-validation-algorithm)
+0. [Return Validation Algorithm](#return-validation-algorithm)
+
+#### Block Validation Algorithm
+
+An entry is pushed onto the control-flow stack containing no type sequence, a
+limit value of the current length of the type stack, and an isThisAnIf value of
+false.
+
+#### Loop Validation Algorithm
+
+An entry is pushed onto the control-flow stack containing an empty type
+sequence, a limit value of the current length of the type stack, and an
+isThisAnIf value of false.
+
+#### Unconditional-Branch Validation Algorithm
+
+The operand sequence is [merged] into the control-flow stack entry `$depth` from
+the top.
+
+#### Conditional-Branch Validation Algorithm
+
+The sequence of the all but the last type in the operand sequence is [merged]
+into the control-flow stack entry `$depth` from the top.
+
+#### Table-Branch Validation Algorithm
+
+For each depth in the table and `$default`, the sequence of all but the last
+type in the operand sequence is [merged] into the control-flow stack entry that
+depth from the top.
+
+#### If Validation Algorithm
+
+An entry is pushed onto the control-flow stack containing no type sequence, a
+limit value of the current length of the type stack, and an isThisAnIf value of
+true.
+
+#### Else Validation Algorithm
+
+The operand sequence is [merged] into the control-flow stack top. The
+control-flow stack top's isThisAnIf value is required to be true. An entry is
+popped off the control-flow stack. A new entry is pushed onto the control-flow
+stack containing the operand sequence as its type sequence, a limit value of the
+current length of the type stack, and an isThisAnIf value of true.
+
+#### End Validation Algorithm
+
+The operand sequence is [merged] into the control-flow stack top. The
+control-flow stack top entry is popped.
+
+#### Return Validation Algorithm
+
+The operand sequence is [merged] into the control-flow stack bottom.
+
+
+[Q]: #q-control-flow-barrier-instruction-family
+[type]: WebAssembly.md#types

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -25,7 +25,7 @@ These types describe various data structures present in WebAssembly modules:
 0. [Array](#array)
 0. [String](#string)
 
-> These types are not used to describe values at runtime.
+> These types aren't used to describe values at runtime.
 
 #### Index
 
@@ -38,13 +38,13 @@ An *index* is a 32-bit unsigned integer value.
 An *array* is an [index] indicating a number of elements, plus a sequence of
 that many elements.
 
-> Array elements need not all be the same size in some representations.
+> Array elements needn't all be the same size in some representations.
 
 #### String
 
 A *string* is an [array] of bytes.
 
-> Strings in this context may contain arbitrary bytes and are not required to be
+> Strings in this context may contain arbitrary bytes and aren't required to be
 valid UTF-8 or any other format.
 
 ### Module Contents
@@ -61,7 +61,7 @@ and associated data.
  - Present known sections are checked to be ordered in the section sequence as
    they are ordered in the [enumeration of the Known Sections](#known-sections).
 
-> Some representations do not represent some of the known sections literally;
+> Some representations don't represent some of the known sections literally;
 they may be combined with other sections or implied by specialized syntax.
 
 > The initial release of WebAssembly will use an expected version of `0x0`.
@@ -141,6 +141,8 @@ The Memory Section contains:
 
 **Validation:**
  - The maximum size is checked to be at least the initial size.
+ - If the maximum size multiplied by the [page size](#pages) would be
+   unrepresentable in an unsigned `iPTR`, validation fails.
 
 #### Export Section
 
@@ -156,6 +158,9 @@ An export contains:
 **Validation:**
  - The function index of each array element is checked to be within the bounds
    of the [Code Section](#code-section) array.
+ - If any two exports have the same function string, validation fails.
+
+TODO: Memory exports (which require the presence of a Memory Section).
 
 #### Start Section
 
@@ -167,6 +172,8 @@ The Start Section contains a function [index]. See
 **Validation:**
  - The index is checked to be within the bounds of the
    [Code Section](#code-section) array.
+ - The function signature indexed in the [Type Section](#type-section) is
+   checked to have an empty parameter list and an empty return list.
 
 #### Code Section
 
@@ -190,22 +197,26 @@ format, positions are represented with a special syntax.
 
 **Name:** `data`
 
-The Data Section contains an [array] of [string] and offset pairs describing
-data to be loaded into linear memory as part of
+The Data Section contains an [array] of data initializers.
+
+A *data initializer* consists of a [string] and an offset. It describes data to
+be loaded into linear memory as part of
 [linear memory instantiation](#linear-memory-instantiation).
 
 **Validation:**
  - For each element of the array, the sum of the offset and the length of the
    string is checked to be less than the initial size declared in the
    [Memory Section](#memory-section).
+ - If any byte of linear memory would be initialized by more than one data
+   initializer, validation fails.
 
 #### Name Section
 
 **Name:** `name`
 
-The Names Section does not change execution semantics and malformed constructs,
+The Names Section doesn't change execution semantics and malformed constructs,
 such as out-of-bounds indices, in this section cause the section to be ignored,
-and do not trigger validation failures.
+and don't trigger validation failures.
 
 The Names Section contains an [array] of function name descriptors, which each
 describe names for the function with the corresponding index in the module, and
@@ -276,7 +287,7 @@ To merge two validation types:
 #### Function Validation Initialization
 
 If the instruction sequence is empty, or if the last instruction in the sequence
-is not an `end`, validation fails.
+isn't an `end`, validation fails.
 
 The current position starts at the first position. The type stack begins empty.
 The control-flow stack starts with one entry. This entry's [validation type] is
@@ -313,7 +324,10 @@ If the instruction's signature has no return types:
    limit value, validation fails.
  - `void` is pushed onto the type stack.
 
-TODO: Handle unused `void` values left behind on the stack.
+TODO: Handle unused `void` values left behind on the stack. Or, eliminate `void`
+values from the type stack altogether.
+
+> There are no implicit type conversions in WebAssembly.
 
 #### Function Return Validation
 
@@ -332,7 +346,7 @@ WebAssembly code execution requires an *instance* of a module, which contains a
 reference to the module plus additional information added during instantiation,
 which consists of the following steps:
  - The entire module is first [validated](#validation). If there are any
-   failures, instantiation aborts and does not produce an instance.
+   failures, instantiation aborts and doesn't produce an instance.
  - If a [Memory Section](#memory-section) is present,
    [Linear memory is instantiated](#linear-memory-instantiation).
  - [A recursion limit is selected](#recursion-limit).
@@ -380,8 +394,8 @@ are created:
    function.
  - A *current position*.
 
-> Implementations need not create a literal array to store the locals, or
-literal stacks to manage values at runtime.
+> Implementations needn't create a literal array to store the locals, or literal
+stacks to manage values at runtime.
 
 #### Function Execution Initialization
 
@@ -454,12 +468,12 @@ Types
 | `i32` | 32
 | `i64` | 64
 
-Integer types are not inherently signed or unsigned. They may be interpreted as
+Integer types aren't inherently signed or unsigned. They may be interpreted as
 signed or unsigned by individual instructions. When interpreted as signed, a
 [two's complement] interpretation is used.
 
 > The [minimum signed integer value] is supported; consequently, two's
-complement signed integers are not symmetric around zero.
+complement signed integers aren't symmetric around zero.
 
 #### Booleans
 
@@ -551,11 +565,12 @@ are the addressing unit of linear memory spaces.
 #### Effective Address
 
 The *effective address* of a linear memory access is computed by adding `$base`
-and `$offset` at infinite precision, so that there is no overflow.
+and `$offset`, both interpreted as unsigned, at infinite precision, so that
+there is no overflow.
 
 #### Alignment
 
-**Slow:** If the effective address is not a multiple of `$align`, the access is
+**Slow:** If the effective address isn't a multiple of `$align`, the access is
 *misaligned*, and the instruction may execute very slowly.
 
 > When `$align` is greater than or equal to the size of the access, the access
@@ -641,10 +656,10 @@ The called function &mdash; the *callee* &mdash; is
 recursion depth value plus one as its recursion depth value. The return value of
 the call is defined by the execution.
 
-**Trap:** Call stack overflow, if the recursion depth value is greater than the
+**Trap:** Call Stack Overflow, if the recursion depth value is greater than the
 [recursion limit](#recursion-limit).
 
-> This means that implementations are not permitted to perform implicit
+> This means that implementations aren't permitted to perform implicit
 opportunistic tail-call elimination.
 
 > The execution state of the function currently being executed remains live
@@ -652,7 +667,7 @@ during the call, and the execution of the called function is performed
 independently. In this way, calls form a stack-like data structure called the
 *call stack*.
 
-> Implementations need not pass a literal argument to represent the recursion
+> Implementations needn't pass a literal argument to represent the recursion
 depth.
 
 #### Call Validation
@@ -672,8 +687,8 @@ WebAssembly comparison instructions compare two values and return a [boolean]
 result value.
 
 > In accordance with IEEE 754-2008, for the comparison instructions, negative
-zero is considered equal to zero, and NaN values are not less than, greater
-than, or equal to any other values, including themselves.
+zero is considered equal to zero, and NaN values aren't less than, greater than,
+or equal to any other values, including themselves.
 
 ### T: Shift Instruction Family
 
@@ -695,37 +710,37 @@ instructions such as [`shr_s`](#integer-shift-right-signed).
 
 ### G: Generic Integer Instruction Family
 
-Except where otherwise specified, these instructions do not specifically
-interpret their operands as explicitly signed or unsigned, and therefore do not
+Except where otherwise specified, these instructions don't specifically
+interpret their operands as explicitly signed or unsigned, and therefore don't
 have an inherent concept of overflow.
 
 ### S: Signed Integer Instruction Family
 
 Except where otherwise specified, these instructions interpret their operand
 values as signed, return result values interpreted as signed, and [trap] when
-the result value can not be represented as such.
+the result value can't be represented as such.
 
 ### U: Unsigned Integer Instruction Family
 
 Except where otherwise specified, these instructions interpret their operand
 values as unsigned, return result values interpreted as unsigned, and [trap]
-when the result value can not be represented as such.
+when the result value can't be represented as such.
 
 ### F: Floating-Point Instruction Family
 
 Instructions in this family follow the [IEEE 754-2008] standard, except that:
 
- - They support only "non-stop" mode, and floating-point exceptions are not
+ - They support only "non-stop" mode, and floating-point exceptions aren't
    otherwise observable. In particular, neither alternate floating-point
    exception handling attributes nor the non-computational operations on status
    flags are supported.
 
  - They use the IEEE 754-2008 `roundTiesToEven` rounding attribute, except where
-   otherwise specified. Non-default directed rounding attributes are not
+   otherwise specified. Non-default directed rounding attributes aren't
    supported.
 
 When the result of any instruction in this family (which excludes `neg`, `abs`,
-and `copysign`) is a NaN, the sign bit and the significand field (which does not
+and `copysign`) is a NaN, the sign bit and the significand field (which doesn't
 include the implicit leading digit of the significand) of the NaN are computed
 by one of the following rules, selected [nondeterministically]:
 
@@ -733,7 +748,7 @@ by one of the following rules, selected [nondeterministically]:
    may [nondeterministically] select any of them to be the result value, but
    with the most significant bit of the significand field overwritten to be `1`.
 
- - If the implementation does not choose to use an input NaN as a result value,
+ - If the implementation doesn't choose to use an input NaN as a result value,
    or if there are no input NaNs, the result value has a [nondeterministic] sign
    bit, a significand field with `1` in the most significant bit and `0` in the
    remaining bits.
@@ -742,7 +757,7 @@ TODO: Monitor https://github.com/WebAssembly/design/pull/713.
 
 Implementations are permitted to further implement the IEEE 754-2008 section
 "Operations with NaNs" recommendation that operations propagate NaN bits from
-their operands, however it is not required.
+their operands, however it isn't required.
 
 > All computations are correctly rounded, subnormal values are fully supported,
 and negative zero, NaNs, and infinities are all produced as result values to
@@ -906,7 +921,7 @@ stack bottom. Its return value is the value of its operand, if it has one.
    control-flow stack bottom.
  - `any` is pushed onto the type stack.
 
-> Implementations need not literally perform a branch before performing the
+> Implementations needn't literally perform a branch before performing the
 actual function return.
 
 #### Unreachable
@@ -920,7 +935,7 @@ actual function return.
 **Validation:**
  - `any` is pushed onto the type stack.
 
-> The `unreachable` instruction is meant to represent code that is not meant to
+> The `unreachable` instruction is meant to represent code that isn't meant to
 be executed except in the case of a bug in the application.
 
 #### End
@@ -1012,7 +1027,7 @@ the value given in the operand.
 | `tee_local` | `<$id: i32> (T) : (T)`      |          | 0x19
 
 The `tee_local` instruction sets the value in the locals array at index `$id` to
-to the value given in the operand. Its return value is the value of its operand.
+the value given in the operand. Its return value is the value of its operand.
 
 #### Select
 
@@ -1128,10 +1143,11 @@ this instruction can be used to multiply either signed or unsigned values.
 The `div_s` instruction returns the signed quotient of its operands, interpreted
 as signed. The quotient is silently rounded to the nearest integer toward zero.
 
-**Trap:** Signed overflow, when the [minimum signed integer value] is divided by
-`-1`.
+**Trap:** Signed Integer Overflow, when the [minimum signed integer value] is
+divided by `-1`.
 
-**Trap:** Division by zero, when the second operand (the divisor) is zero.
+**Trap:** Integer Division By Zero, when the second operand (the divisor) is
+zero.
 
 #### Integer Divide, Unsigned
 
@@ -1144,7 +1160,8 @@ The `div_u` instruction returns the unsigned quotient of its operands,
 interpreted as unsigned. The quotient is silently rounded to the nearest integer
 toward zero.
 
-**Trap:** Division by zero, when the second operand (the divisor) is zero.
+**Trap:** Integer Division By Zero, when the second operand (the divisor) is
+zero.
 
 #### Integer Remainder, Signed
 
@@ -1157,9 +1174,10 @@ The `rem_s` instruction returns the signed remainder from a division of its
 operand values interpreted as signed, with the result having the same sign as
 the first operand (the dividend).
 
-**Trap:** Division by zero, when the second operand (the divisor) is zero.
+**Trap:** Integer Division By Zero, when the second operand (the divisor) is
+zero.
 
-> This instruction does not trap when the [minimum signed integer value] is
+> This instruction doesn't trap when the [minimum signed integer value] is
 divided by `-1`; it returns `0` which is the correct remainder (even though the
 same operands to `div_s` do cause a trap).
 
@@ -1177,7 +1195,8 @@ handling of negative numbers.
 The `rem_u` instruction returns the unsigned remainder from a division of its
 operand values interpreted as unsigned.
 
-**Trap:** Division by zero, when the second operand (the divisor) is zero.
+**Trap:** Integer Division By Zero, when the second operand (the divisor) is
+zero.
 
 > This instruction corresponds to what is sometimes called "modulo" in other
 languages.
@@ -1817,9 +1836,9 @@ The `trunc_s` instruction performs the IEEE 754-2008
 `convertToIntegerTowardZero` operation, with the result value interpreted as
 signed, according to the [general floating-point rules][F].
 
-**Trap:** Invalid Conversion, when a floating-point Invalid condition occurs,
-due to the operand being outside the range that can be converted (including NaN
-values and infinities).
+**Trap:** Invalid Conversion To Integer, when a floating-point Invalid condition
+occurs, due to the operand being outside the range that can be converted
+(including NaN values and infinities).
 
 #### Truncate Floating-Point to Integer, Unsigned
 
@@ -1834,9 +1853,9 @@ The `trunc_u` instruction performs the IEEE 754-2008
 `convertToIntegerTowardZero` operation, with the result value interpreted as
 unsigned, according to the [general floating-point rules][F].
 
-**Trap:** Invalid Conversion, when an Invalid condition occurs, due to the
-operand being outside the range that can be converted (including NaN values and
-infinities).
+**Trap:** Invalid Conversion To Integer, when an Invalid condition occurs, due
+to the operand being outside the range that can be converted (including NaN
+values and infinities).
 
 > This instruction's result is unsigned, so it almost always rounds down,
 however it does round up in one place: negative values greater than negative one
@@ -2030,17 +2049,24 @@ the name "wrap".
 | `grow_memory` | `(iPTR) : (iPTR)`         | [R]      | 0x39
 
 The `grow_memory` instruction increases the size of the referenced linear memory
-space by a given unsigned delta, in units of [pages]. It returns the previous
-linear memory size, also as an unsigned value in units of pages, or `-1` on
-failure.
+space by a given unsigned delta, in units of [pages]. If the resulting size of
+the referenced linear memory space would be unrepresentable in an unsigned iPTR,
+or if allocation fails due to insufficient dynamic resources, it returns `-1`;
+otherwise it returns the previous linear memory size, also as an unsigned value
+in units of [pages].
 
 When a maximum memory size is declared in the referenced linear memory space,
 `grow_memory` fails if it would grow past the maximum. However, `grow_memory`
-may still fail before the maximum if it was not possible to reserve the space up
+may still fail before the maximum if it wasn't possible to reserve the space up
 front or if enabling the reserved memory fails.
 
-> Since the return value is in units of pages, `-1` is not otherwise a valid
-memory size.
+**Validation**:
+ - If the module doesn't contain a [Memory Section](#memory-section), validation
+   fails.
+ - [Generic validation](#generic-instruction-validation) is also performed.
+
+> Since the return value is in units of pages, `-1` isn't otherwise a valid
+linear memory size.
 
 #### Current Memory
 
@@ -2050,6 +2076,11 @@ memory size.
 
 The `current_memory` instruction returns the size of the referenced linear
 memory space, as an unsigned value in units of [pages].
+
+**Validation**:
+ - If the module doesn't contain a [Memory Section](#memory-section), validation
+   fails.
+ - [Generic validation](#generic-instruction-validation) is also performed.
 
 [M]: #m-memory-access-instruction-family
 [R]: #r-memory-resize-instruction-family

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -34,25 +34,25 @@ which, for example, allows decoders to ensure that program state is consistent
 at all control flow merge points without having to see the entire function body
 first. For more information, see the [Validation section](#validation).
 
-A WebAssembly module is *instantiated* to produce a WebAssembly *instance*,
-which contains all the data structures required by the module's code.
-Instances can include [linear memory](#memory-section) to serve the purpose of
-an address space for program data. For security and determinism, linear memory
-is *sandboxed*, and the other data structures in an instance, such as the call
+A WebAssembly module can be *instantiated* to produce a WebAssembly *instance*,
+which contains all the data structures required by the module's code. Instances
+can include [linear memory](#memory-section) to serve the purpose of an address
+space for program data. For security and determinism, linear memory is
+*sandboxed*, and the other data structures in an instance, such as the call
 stack, are allocated outside of linear memory so that they cannot be corrupted
 by errant linear memory accesses. An instance can then be executed, either by
 execution of its [start function](#start-section) or by calls to its exported
 functions. For more information, see the [Execution section](#execution).
 
-Along with their other contents, functions contain sequences of *instructions*.
-WebAssembly instructions conceptually communicate with each other via pushing
-and popping values on a stack, which allows them to have a very compact
-encoding. Use of the stack is constrained to allow implementations to statically
-verify the number and types of all entries on the stack at all times, which
-allows them to efficiently translate the code into other forms that may not use
-an actual dynamic stack. There are instructions for performing integer and
-floating-point arithmetic, coordinating control flow, marshalling data, calling
-functions, and so on. For more information, see the
+Along with their other contents, each function contains a sequence of
+*instructions*. WebAssembly instructions conceptually communicate with each
+other primarily via pushing and popping values on a stack, which allows them to
+have a very compact encoding. Use of the stack is constrained to allow
+implementations to statically verify the number and types of all entries on the
+stack at all times, which allows them to efficiently translate the code into
+other forms that may not use an actual dynamic stack. There are instructions for
+performing integer and floating-point arithmetic, coordinating control flow,
+marshalling data, calling functions, and so on. For more information, see the
 [Instructions section](#instructions).
 
 Implementations of WebAssembly [validation](#validation) and
@@ -62,6 +62,7 @@ here; they need only behave ["as if"] they did so in all observable respects.
 [ISA]: https://en.wikipedia.org/wiki/Instruction_set
 [*functions*]: https://en.wikipedia.org/wiki/Subroutine
 ["as if"]: https://en.wikipedia.org/wiki/As-if_rule
+
 
 Module
 --------------------------------------------------------------------------------
@@ -623,6 +624,7 @@ are usually unimportant).
 [Numbers in ECMAScript]: https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type
 [NaN]: https://en.wikipedia.org/wiki/NaN
 
+
 Instruction Signatures
 --------------------------------------------------------------------------------
 
@@ -750,7 +752,7 @@ resizing.
 #### Branching
 
 In a branch according to a given control-flow stack entry, first the value stack
-is resized to the entry's limit value.
+is resized down to the entry's limit value.
 
 Then, if the entry's [label] is bound, the current position is set to the bound
 position. Otherwise, the position to bind the label to is found by scanning
@@ -1722,15 +1724,14 @@ The `nearest` instruction performs the IEEE 754-2008
 [general floating-point rules][F].
 
 > "Nearest" describes the rounding method used here; the value is
-[rounded to the nearest integer], with ties rounded toward the value with an
-even least-significant digit.
+[rounded to the nearest integer], with
+[ties rounded toward the value with an even least-significant digit].
 
 > This instruction differs from [`Math.round` in ECMAScript] which rounds ties
-up.
-
-> This instruction differs from [`round` in C] which rounds ties away from zero.
+up, and it differs from [`round` in C] which rounds ties away from zero.
 
 [rounded to the nearest integer]: https://en.wikipedia.org/wiki/Nearest_integer_function
+[ties rounded toward the value with an even least-significant digit]: https://en.wikipedia.org/wiki/Rounding#Round_half_to_even
 [`Math.round` in ECMAScript]: https://tc39.github.io/ecma262/#sec-math.round
 [`round` in C]: http://en.cppreference.com/w/c/numeric/math/round
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -1,6 +1,7 @@
 WebAssembly Specification
 ================================================================================
 
+0. [Introduction](#introduction)
 0. [Module](#module)
 0. [Validation](#validation)
 0. [Execution](#execution)
@@ -8,6 +9,16 @@ WebAssembly Specification
 0. [Instruction Signatures](#instruction-signatures)
 0. [Instruction Families](#instruction-families)
 0. [Instructions](#instructions)
+
+
+Introduction
+--------------------------------------------------------------------------------
+
+> This document specifies the structure and interpretation of WebAssembly code.
+Implementations of WebAssembly [validation](#validation) and
+[execution](#execution) need not perform all the steps literally as described
+here; they need only behave ["as if"](https://en.wikipedia.org/wiki/As-if_rule)
+they did so in all observable respects.
 
 
 Module
@@ -136,13 +147,16 @@ The Memory Section contains:
  - A *maximum size*, which is an unsigned `iPTR` value, in units of [pages]. See
    the [`grow_memory`](#grow-memory) instruction for further information on this
    field.
- - An *exported* flag, which is a boolean value indicating whether the memory is
-   visible outside the module.
+ - An *exported* flag, which is a boolean value indicating whether the linear
+   memory space is to be visible outside the module.
 
 **Validation:**
  - The maximum size is checked to be at least the initial size.
  - If the maximum size multiplied by the [page size](#pages) would be
    unrepresentable in an unsigned `iPTR`, validation fails.
+
+TODO: Define `iPTR` in this context. Should Memory Sections have a wasm32 vs
+wasm64 flag?
 
 #### Export Section
 
@@ -440,6 +454,9 @@ may perform any one of the specified alternatives.
 
 > There is no requirement that a given implementation make the same choice every
 time, even within the same program.
+
+> There is no "undefined behavior" in WebAssembly where the semantics become
+completely unspecified.
 
 #### Instruction Traps
 
@@ -826,6 +843,9 @@ onto the control-flow stack.
 **Validation:**
  - An entry is pushed onto the control-flow stack containing `any` and a limit
    value of the current length of the type stack.
+
+> There is no requirement that loops eventually terminate or contain observable
+side effects.
 
 #### If
 
@@ -1949,8 +1969,8 @@ Floating-point loads preserve all the bits of the value, performing an
 IEEE 754-2008 `copy` operation.
 
 **Validation:**
- - [Linear memory access validation](#linear-memory-access-validation)
-   is performed.
+ - [Linear memory access validation](#linear-memory-access-validation) is
+   performed.
 
 #### Store
 
@@ -1968,8 +1988,8 @@ Floating-point stores preserve all the bits of the value, performing an
 IEEE 754-2008 `copy` operation.
 
 **Validation:**
- - [Linear memory access validation](#linear-memory-access-validation)
-   is performed.
+ - [Linear memory access validation](#linear-memory-access-validation) is
+   performed.
 
 #### Extending Load, Signed
 
@@ -2031,8 +2051,8 @@ silently wrapped to a narrower width.
  - `store32` stores a 32-bit value.
 
 **Validation:**
- - [Linear memory access validation](#linear-memory-access-validation)
-   is performed.
+ - [Linear memory access validation](#linear-memory-access-validation) is
+   performed.
 
 > See the comment in the [wrap instruction](#integer-wrap) about the meaning of
 the name "wrap".

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -375,13 +375,13 @@ respective [module index spaces](#module-index-spaces).
  - All global imports must be immutable.
  - Each global import with an initializer is required to be mutable.
  - Each import is required to be resolved by the embedder.
- - A linear-memory import's initial size is required to be at least the imported
+ - A linear-memory import's initial size is required to be at most the imported
    linear-memory space's initial size.
- - A linear-memory import's maximum size is required to be at most the imported
+ - A linear-memory import's maximum size is required to be at least the imported
    linear-memory space's maximum size.
- - A table import's initial length is required to be at least the imported
+ - A table import's initial length is required to be at most the imported
    table's initial length.
- - A table import's maximum length is required to be at most the imported
+ - A table import's maximum length is required to be at least the imported
    table's maximum length.
  - Embedding-specific validation may be performed on each import.
 
@@ -827,18 +827,11 @@ instantiated as follows:
 For a linear-memory definition in the [Linear-Memory Section], as opposed to a
 [linear-memory import](#import-section), an array of [bytes] with the length
 being the value of the linear-memory space's initial size field is created,
-added to the instance, and initialized to all zeros.
-
-For a linear-memory import, storage for the array is already allocated. It is
-resized up to the import's initial size, with any additional bytes initialized
-to all zeros, and its maximum size is set to the lesser of its existing maximum
-size and the import's maximum size.
+added to the instance, and initialized to all zeros. For a linear-memory import,
+storage for the array is already allocated.
 
 The contents of the [Data Section] are loaded into the byte array. Each [string]
 is loaded into linear memory starting at its associated start offset value.
-
-**Trap:** Incompatible Import, if a linear-memory import's maximum size is less
-than the size of the imported linear-memory space.
 
 **Trap:** Dynamic Resource Exhaustion, if dynamic resources are insufficient to
 support creation of the array.
@@ -850,12 +843,8 @@ A table declared in the [table index space] may be instantiated as follows:
 For a table definition in the [Table Section], as opposed to a
 [table import](#import-section), an array of elements is created with the
 table's initial length, with elements of the table's element type, and
-initialized to all special "null" values specific to the element type.
-
-For a table import, storage for the table is already allocated. It is resized up
-to the import's initial length, with any additional elements initialized to the
-element type's "null" value, and its maximum length is set to the lesser of its
-existing maximum length and the import's maximum length.
+initialized to all special "null" values specific to the element type. For a
+table import, storage for the table is already allocated.
 
 For each table initializer in the [Element Section], for the table identified by
 the table index in the [table index space]:
@@ -863,9 +852,6 @@ the table index in the [table index space]:
    start offset is initialized according to the elements of the table element
    initializers array, which specify an indexed element in their selected index
    space.
-
-**Trap:** Incompatible Import, if a table import's maximum length is less than
-the size of the imported table.
 
 **Trap:** Dynamic Resource Exhaustion, if dynamic resources are insufficient to
 support creation of any of the tables.

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -1294,11 +1294,11 @@ Instructions
 | ----------- | --------------------------- | -------- | ------ |
 | `block`     | `() : ()`                   |          | 0x01   |
 
-The `block` instruction pushes an entry onto the control-flow stack containing
-an unbound [label] and a limit value of the current length of the value stack.
+The `block` instruction pushes an entry onto the control-flow stack. The entry
+contains an unbound [label] and the current length of the value stack.
 
-> Each `block` needs a corresponding [`end`](#end) to pop its label from the
-stack.
+> Each `block` needs a corresponding [`end`](#end) to bind its label and pop
+its control-flow stack entry.
 
 #### Loop
 
@@ -1307,8 +1307,8 @@ stack.
 | `loop`      | `() : ()`                   |          | 0x02   |
 
 The `loop` instruction binds a [label] to the current position, and pushes an
-entry onto the control-flow stack containing that label and a limit value of the
-current length of the value stack.
+entry onto the control-flow stack. The entry contains that label and the current
+length of the value stack.
 
 > The `loop` instruction does not perform a loop by itself. It merely introduces
 a label that may be used by a branch to form an actual loop.
@@ -1316,8 +1316,8 @@ a label that may be used by a branch to form an actual loop.
 > Since `loop`'s control-flow stack entry starts with an empty type sequence,
 branches to the top of the loop must not have any result values.
 
-> Each `loop` needs a corresponding [`end`](#end) to pop its label from the
-stack.
+> Each `loop` needs a corresponding [`end`](#end) to pop its control-flow stack
+entry.
 
 > There is no requirement that loops eventually terminate or contain observable
 side effects.
@@ -1331,7 +1331,7 @@ https://github.com/WebAssembly/design/pull/710
 | ----------- | -------------------------- | ----------------------------- | -------- | ------ |
 | `br`        | `$arity: i32, $depth: i32` | `($T[$arity]) : ($T[$arity])` | [B] [Q]  | 0x06   |
 
-The `br` instruction [branches](#branching) according to the control flow stack
+The `br` instruction [branches](#branching) according to the control-flow stack
 entry `$depth` from the top. It returns the values of its operands.
 
 **Validation:**
@@ -1347,7 +1347,7 @@ TODO: This anticipates a proposal to make `br`, `br_table`, `return`, and
 | `br_if`     | `$arity: i32, $depth: i32` | `($T[$arity], $condition: i32) : ($T[$arity])` | [B]      | 0x07   |
 
 If `$condition` is [true], the `br_if` instruction [branches](#branching)
-according to the control flow stack entry `$depth` from the top. Otherwise, it
+according to the control-flow stack entry `$depth` from the top. Otherwise, it
 does nothing. It returns the values of its operands, except `$condition`.
 
 **Validation:**
@@ -1387,14 +1387,15 @@ with the other branch instructions.
 | ----------- | --------------------------- | -------- | ------ |
 | `if`        | `($condition: i32) : ()`    | [B]      | 0x03   |
 
-The `if` instruction pushes an entry onto the control-flow stack containing an
-unbound [label] and a limit value of the current length of the value stack. If
+The `if` instruction pushes an entry onto the control-flow stack. The entry
+contains an unbound [label] and the current length of the value stack. If
 `$condition` is [false], it then [branches](#branching) to this label.
 
 TODO: Do `if` and `else` have labels? Monitor at least
 https://github.com/WebAssembly/design/pull/710
 
-> Each `if` needs either a corresponding [`else`](#else) or [`end`](#end).
+> Each `if` needs either a corresponding [`else`](#else) or [`end`](#end) to
+bind its label and pop its control-flow stack entry.
 
 #### Else
 
@@ -1408,7 +1409,8 @@ control-flow stack containing an unbound [label] and the length of the current
 value stack, and then [branches](#branching) to the new label. It returns the
 values of its operands.
 
-> Each `else` needs a corresponding [`end`](#end).
+> Each `else` needs a corresponding [`end`](#end) to bind its label and pop its
+control-flow stack entry.
 
 #### End
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -484,7 +484,6 @@ Function execution can be prompted by a [call-family instruction][L], by
 The input to execution of a function consists of:
  - the function to be executed.
  - the incoming argument values, one for each parameter [type] of the function.
- - a *recursion depth* value.
 
 For the duration of the execution of a function body, several data structures
 are created:
@@ -501,9 +500,6 @@ stacks to manage values at runtime.
 
 > These data structures are all allocated outside any linear address space and
 are not any accessible to applications.
-
-TODO: Track the recursion depth across calls to imported functions that reenter
-the module via calls to its exports.
 
 #### Function Execution Initialization
 
@@ -807,9 +803,6 @@ opportunistic tail-call elimination.
 during the call, and the execution of the called function is performed
 independently. In this way, calls form a stack-like data structure called the
 *call stack*.
-
-> Implementations needn't pass a literal argument to represent the recursion
-depth.
 
 > Data associated with the call stack is stored outside any linear address space
 and is not directly accessible to applications.

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -1,0 +1,1693 @@
+# WebAssembly Specification
+
+0. [Module](#module)
+0. [Validation](#validation)
+0. [Execution](#execution)
+0. [Types](#types)
+0. [Signatures](#signatures)
+0. [Instruction Families](#instruction-families)
+0. [Instructions](#instructions)
+
+
+## Module
+
+TODO: describe the contents of a module
+
+### Positions within a function body
+
+Function bodies contain a sequence of instructions. A *position* within a
+function refers to an element of the sequence, or to an additional
+*return position* which is sequenced after the end of the function body.
+
+
+## Validation
+
+### Module Validation
+
+TODO: describe module validation
+
+### Function Validation
+
+For the duration of the validation of a function body, several data structures
+are created:
+ - A *control flow stack*, with entries containing:
+      - Either a [type](#types), `any` which satisfies any type check, or `void`
+        which satisfies no type check.
+      - A *depth* value.
+ - A *type stack*.
+ - A *current position*.
+
+During validation, if either stack is empty when an element is to be popped
+from it, validation fails.
+
+> `any` is effectively serving as a kind of bottom type, and `void` is
+effectively serving as a kind of top type. Note that in some type theory
+contexts, it's common to use these names for exactly opposite purposes.
+
+#### Type Stack Pop
+
+To perform a pop from the type stack:
+ - If the type stack's size is less than the control flow stack's top's depth
+   value, return `void`.
+ - Otherwise pop a valid from the type stack and return that.
+
+#### Control Flow Stack Type Merge
+
+To merge two control-flow stack type values:
+ - If either type is `any`, the result is the other type.
+ - Otherwise, if the types are the same, the result is that type.
+ - Otherwise, validation fails with a type error.
+
+#### Function Validation Initialization
+
+The current position starts at the first position. The type stack begins empty.
+The control flow stack starts with one entry. This entry's type is the first
+return type of the function, if there are any, or `void` otherwise. Its block
+depth is zero.
+
+#### Function Body Validation
+
+If the current position is the return position, function return validation is
+prompted and validation of the function is thereafter complete.
+
+Otherwise, the instruction at the current position is remembered, the current
+position is incremented to point to the instruction following it, or if there
+are no instructions following it, to the return position. Then the remembered
+instruction is validated as follows.
+
+If the instruction has a **Validation** clause, that clause describes its
+validation. Otherwise, the following generic validation is performed:
+
+For each operand type in the instruction's signature, a type is popped from the
+type stack and checked to be the same as the corresponding operand type. Each
+return type of the instruction's signature is then pushed onto the type stack.
+
+Then, [validation](#function-body-validation) is resumed.
+
+#### Function Return Validation
+
+When a *return* is prompted, one type for each type in the function signature's
+return type is popped from the type stack and type-checked against its
+corresponding return type. The type stack is then checked to be empty. If there
+are sufficient stack elements and all checks have passed, function validation is
+successful.
+
+
+## Execution
+
+Before any code in a module can be executed, the whole module must first be
+[validated](#validation).
+
+### Module Execution
+
+If the module contains a `start` declaration, the referenced function is
+[executed](#function-execution).
+
+### Function Execution
+
+Function execution can be prompted by a call instruction, by module execution,
+or by the embedding environment.
+
+The input to execution of a function consists of:
+ - The function to be executed.
+ - The incoming argument values, one for each argument type of the function.
+ - A *depth* value.
+
+For the duration of the execution of a function body, several data structures
+are created:
+ - A *control flow stack*, which holds label identifiers for reference from
+   branch instructions.
+ - A *value stack*, which carries values between instructions.
+ - A *locals* array, containing an element for each argument of the function in
+   the argument's type, as well as an element for each local declaration in the
+   function.
+ - A *current position*.
+
+TODO: define labels and binding
+
+#### Function Execution Initialization
+
+The current position starts at the first instruction in the function body. The
+value stack begins empty. The control-flow stack begins with an entry holding a
+label bound to the return position.
+
+The value of each incoming argument is copied to the local with the
+corresponding index, and the rest of the locals are initialized to all-zeros
+bit-pattern values.
+
+#### Function Body Execution
+
+If the current position is the return position, a function return is prompted.
+
+Otherwise, the instruction at the current position is remembered, the current
+position is incremented to point to the instruction following it, or if there
+are no instructions following it, to the return position. Then the remembered
+instruction is executed as follows.
+
+For each operand type in the instruction's signature, a value is popped from the
+value stack and provided as the corresponding operand value. The instruction is
+then executed as described in [the Instructions section](#instructions) entry
+describing it. Instructions may inspect and/or modify the current position, the
+label stack, the locals or other state. They may evoke side effects or trigger a
+trap (see below).
+
+If they don't trap or otherwise terminate execution of the module, they produce
+a value for each return type in the instruction's signature. Each return value
+is then pushed onto the value stack, and [execution](#function-body-execution)
+is resumed.
+
+#### Instruction Traps
+
+Instructions may also *trap*, in which case execution of the current module is
+immediately terminated and abnormal termination is reported to the embedding
+environment.
+
+#### Function Return Execution
+
+When a *return* is prompted, one value for each type in the function signature's
+return type is popped from the value stack. If the function execution was
+prompted by a call instruction, these values are provided as the call's return
+value. Otherwise, they are provided to the embedding environment.
+
+
+## Types
+
+0. [Integer Types](#integer-types)
+0. [Floating-Point Types](#floating-point-types)
+
+### Integer Types
+
+| Name  | Bits
+| ----  | ----
+| `i32` | 32
+| `i64` | 64
+
+Integer types are not inherently signed or unsigned. They may be interpreted as
+signed or unsigned by individual instructions. When interpreted as signed, a
+[two's complement] interpretation is used.
+
+> The [minimum signed integer value] is supported; consequently, two's
+complement signed integers are not symmetric around zero.
+
+#### Booleans
+
+[Boolean](https://en.wikipedia.org/wiki/Boolean_data_type) values are
+represented as values of type `i32`. In a boolean context, any non-zero value is
+interpreted as true and `0` is interpreted as false.
+
+Any instruction that produces a boolean value, such as a comparison, produces
+the values `0` and `1` for false and true.
+
+### Floating-Point Types
+
+| Name  | Bits
+| ----  | ----
+| `f32` | 32
+| `f64` | 64
+
+`f32` is the IEEE 754-2008
+[`binary32`](https://en.wikipedia.org/wiki/Single-precision_floating-point_format)
+type, commonly known as "Single Precision".
+
+`f64` is the IEEE 754-2008
+[`binary64`](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
+type, commonly known as "Double Precision".
+
+> Unlike with
+[Numbers in ECMAScript](https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type),
+[NaN](https://en.wikipedia.org/wiki/NaN) values in WebAssembly have sign bits
+and payloads which may be observed and manipulated (though most instructions
+ignore them).
+
+## Signatures
+
+Signatures describe the explicit inputs and outputs to an instruction. In this
+document they are described in the following form:
+
+`(` arguments `)` `:` `(` returns `)`
+
+or
+
+`<` immediates `>` `(` arguments `)` `:` `(` returns `)`
+
+TODO: describe signatures, and shorthand: iPTR, "...", <immediates>, TABLE, T,
+*args*, and *returns*.
+
+
+## Instruction Families
+
+WebAssembly instructions may belong to several families:
+
+0. M: [Memory-Access Instruction Family][M]
+0. R: [Memory-Resize Instruction Family][R]
+0. B: [Branch Instruction Family][B]
+0. L: [Call Instruction Family][L]
+0. C: [Comparison Instruction Family][C]
+0. T: [Shift Instruction Family][T]
+0. G: [Generic Integer Instruction Family][G]
+0. S: [Signed Integer Instruction Family][S]
+0. U: [Unsigned Integer Instruction Family][U]
+0. F: [Floating-Point Instruction Family][F]
+0. Z: [Floating-Point Bitwise Instruction Family][Z]
+
+### M: Memory-Access Instruction Family
+
+These instructions load from and store to a linear memory space.
+
+#### Bytes
+
+[*Bytes*](https://en.wikipedia.org/wiki/Byte) in WebAssembly are 8-[bit], and
+are the addressing unit of linear memory spaces.
+
+#### Effective Address
+
+The *effective address* of a memory access is computed by adding `$base` with
+`$offset` immediate at infinite precision, so that there is no need for
+wrapping.
+
+#### Alignment
+
+If the effective address is not a multiple of `$align`, the access is
+*misaligned*, and the instruction may execute very slowly.
+
+> When the `$align` value is equal to the size of the access, the access has
+*natural alignment*. When it is less, the access is *unaligned*.
+
+> There is no other semantic effect associated with `$align`; misaligned and
+unaligned loads and stores still function normally.
+
+#### Accessed Bytes
+
+The *accessed bytes* consist of a contiguous sequence of [bytes] starting at
+the [effective address], with a length implied by the accessing instruction.
+
+**Trap:** Out Of Bounds, if any of the [bytes] of a linear memory access are
+beyond the end of the accessed linear memory space.
+
+#### Loading
+
+For a load access, a value with the bit pattern of the [accessed bytes],
+interpreted in [little-endian byte order], is returned.
+
+#### Storing
+
+For a store access, the value to store is written to the [accessed bytes], in
+[little-endian byte order].
+
+### R: Memory-Resize Instruction Family
+
+#### Pages
+
+*Pages* in WebAssembly are 64 [KiB], and are the units used in linear memory
+resizing.
+
+### B: Branch Instruction Family
+
+#### Branching
+
+When a label is to be branched to, if it is bound to a position, the current
+position is set to that position.
+
+Otherwise, the position to bind the label to is found by scanning forward
+through the instructions, executing just `block`, `loop`, and `end`
+instructions, until the label is bound. Then the current position to that
+position.
+
+> In practice, implementations may precompute the destinations of branches so
+that they don't literally need to scan in this manner.
+
+### L: Call Instruction Family
+
+#### Calling
+
+The called function &mdash; the *callee* &mdash; is
+[executed](#function-execution), with the `*args*` operands passed to it as its
+incoming arguments, and the current depth plus some implementation-defined
+finite amount as its depth value. The return value of the call is defined by the
+execution.
+
+**Trap:** Call stack overflow, if the depth value is greater than some
+implementation-defined limit,
+
+> This means that implementations are not permitted to perform implicit
+opportunistic tail-call elimination.
+
+> The execution state of the function currently being executed remains live
+during the call, and the execution of the called function is performed
+independently. In this way, calls form a stack-like data structure called the
+*call stack*.
+
+### C: Comparison Instruction Family
+
+WebAssembly comparison instructions compare two values and return a
+[boolean](#booleans) result value.
+
+> In accordance with IEEE 754-2008, for the comparison instructions, negative
+zero is considered equal to zero.
+
+### T: Shift Instruction Family
+
+In the shift and rotate instructions, "left" means in the direction of greater
+significance, and "right" means in the direction of lesser significance.
+
+#### Shift Count
+
+The second operand in shift and rotate instructions specifies a *shift count*,
+which is interpreted as an unsigned quantity modulo the number of bits in the
+first operand.
+
+> As a result of the modulo, in `i32` instructions, only the least-significant
+5 bits of the second operand affect the result, and in `i64` instructions only
+the least-significant 6 bits of the second operand affect the result.
+
+### G: Generic Integer Instruction Family
+
+Except where otherwise specified, these instructions do not specifically
+interpret their operands as explicitly signed or unsigned, and therefore
+do not have an inherent concept of overflow.
+
+### S: Signed Integer Instruction Family
+
+Except where otherwise specified, these instructions interpret their operands as
+signed, return result values interpreted as signed, and trap when the result
+value can not be represented as such.
+
+### U: Unsigned Integer Instruction Family
+
+Except where otherwise specified, these instructions interpret their operands as
+unsigned, return result values interpreted as unsigned, and trap when the result
+value can not be represented as such.
+
+### F: Floating-Point Instruction Family
+
+Instructions in this family follow the [IEEE 754-2008] standard, except that:
+
+ - They support only "non-stop" mode, and floating-point exceptions are not
+   otherwise observable. In particular, neither alternate floating-point
+   exception handling attributes nor the non-computational operators on status
+   flags are supported. There is no observable difference between quiet and
+   signalling NaN. However, positive infinity, negative infinity, and NaN are
+   still always produced as result values to indicate overflow, invalid, and
+   divide-by-zero conditions, as specified by IEEE 754-2008.
+ - They use the round-to-nearest ties-to-even rounding attribute, except where
+   otherwise specified. Non-default directed rounding attributes are not
+   supported.
+
+When the result of any instruction in this family (which excludes `neg`, `abs`,
+and `copysign`) is a NaN, the sign bit and the significand field (which does not
+include the implicit leading digit of the significand) of the NaN are computed
+as follows:
+
+ - If the instructions has any NaN non-immediate operand values, implementations
+   may select any of them to be the result value, but with the most significant
+   bit of the significand field overwritten to be 1.
+
+ - If the implementation does not choose to use an input NaN as a result value,
+   or if there are no input NaNs, the result value has a nondeterministic sign
+   bit, a significand field with 1 in the most significant bit and 0 in the
+   remaining bits.
+
+Implementations are permitted to further implement the IEEE 754-2008 section
+"Operations with NaNs" recommendation that operations propagate NaN bits from
+their operands, however it is not required.
+
+> All computations are correctly rounded, subnormal values are fully supported,
+and negative zero, NaNs, and infinities all have their standard behavior. All
+numeric results are deterministic.
+
+### Z: Floating-Point Bitwise Instruction Family
+
+These instructions operate on floating-point values, but do so in purely bitwise
+ways, including in how they operate on NaN values.
+
+They correspond to the "Sign bit operations" in IEEE 754-2008.
+
+
+## Instructions
+
+0. [Control Flow Instructions](#control-flow-instructions)
+0. [Basic Instructions](#basic-instructions)
+0. [Integer Instructions](#integer-instructions)
+0. [Floating-Point Instructions](#floating-point-instructions)
+0. [Integer Comparison Instructions](#integer-comparison-instructions)
+0. [Floating-Point Comparison Instructions](#floating-point-comparison-instructions)
+0. [Conversion Instructions](#conversion-instructions)
+0. [Load And Store Instructions](#load-and-store-instructions)
+0. [Additional Memory-Related Instructions](#additional-memory-related-instructions)
+
+### Control Flow Instructions
+
+0. [Block](#block)
+0. [Loop](#loop)
+0. [If](#if)
+0. [Else](#else)
+0. [Unconditional Branch](#unconditional-branch)
+0. [Conditional Branch](#conditional-branch)
+0. [Branch Table](#branch-table)
+0. [Return](#return)
+0. [Unreachable](#unreachable)
+0. [End](#end)
+
+#### Block
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `block`     | () : ()                     |          | 0x01
+
+The `block` instruction pushes an unbound label onto the control-flow stack.
+
+**Validation:**
+ - An entry is pushed onto the control flow stack containing the type `any`
+   and a depth of the current size of the type stack.
+
+#### Loop
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `loop`      | () : ()                     |          | 0x02
+
+The `loop` instruction binds a label to the current position and pushes
+it onto the control-flow stack.
+
+**Validation:**
+ - An entry is pushed onto the control flow stack containing the type `any`
+   and a depth of the current size of the type stack.
+
+#### If
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `if`        | (i32) : ()                  |          | 0x03
+
+TODO: Describe `if`.
+
+#### Else
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `else`      | () : ()                     |          | 0x04
+
+TODO: Describe `else`.
+
+#### Unconditional Branch
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `br`        | <$depth: i32> (T?) : (T?)   | [B]      | 0x06
+
+The `br` instruction performs an unconditional branch. It reads the control flow
+stack entry at depth `$depth` in the stack and [branches](#branching) to it.
+Its return value is the values of its operand.
+
+**Validation**:
+ - [Pop] a type from the type stack. [Merge] it with with the type of the
+   control flow stack at entry at depth `$depth`.
+
+#### Conditional Branch
+
+| Name        | Signature                                    | Families | Opcode
+| ----        | ---------                                    | -------- | ------
+| `br_if`     | <$depth: i32> (T?, $condition: i32) : (T?)   | [B]      | 0x07
+
+The `br_if` instruction performs a conditional branch. If `$condition` is
+[true], it reads the control flow stack entry at depth `$depth` in the stack and
+[branches](#branching) to it. Otherwise, it does nothing. Its return value is
+the values of its first operand.
+
+**Validation**:
+ - [Pop] a type from the type stack. If it is not `void`, push it back onto
+   the type stack. [Merge] it with with the type of the control flow stack at
+   entry at depth `$depth`.
+
+#### Branch Table
+
+| Name        | Signature                                         | Families | Opcode
+| ----        | ---------                                         | -------- | ------
+| `br_table`  | <TABLE, $default: i32> (T?, $index: i32) : (T?)   | [B]      | 0x08
+
+The `br_table` instruction branches to a destination indexed in a table.
+
+First, `br_table` selects a depth to use. If `$index` is within the bounds of
+the table, the depth is the value of the indexed table element. Otherwise, the
+depth is `$default`.
+
+Then, `br_table` reads the control flow stack at that depth in the stack and
+[branches](#branching) to it. Its return value is the value of its first
+operand.
+
+**Validation**:
+ - [Pop] a type from the type stack. For each depth in the table and `$default`,
+   [Merge] it with with the type of the control flow stack at that depth.
+
+> This instruction serves the role of what is sometimes called a "jump table" in
+other languages. "Branch" is used here instead to emphasize the commonality with
+the other branch instructions.
+
+#### Return
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `return`    | (...) : (...)               | [B]      | 0x09
+
+The `return` instruction sets the current position to the return position. Its
+return values are the values of its operands.
+
+**Validation**:
+ - [Pop] a type from the type stack. [Merge] it with with the type of the control
+   flow type stack at entry at depth zero.
+
+#### Unreachable
+
+| Name          | Signature                 | Families | Opcode
+| ----          | ---------                 | -------- | ------
+| `unreachable` | () : ()                   |          | 0x0a
+
+The `unreachable` instruction is meant to represent code that is not meant
+to be executed except in the case of a bug in the application.
+
+**Trap:** Unreachable, always.
+
+TODO: In other variants of the spec, this, `br`, `return`, and `br_table`
+return `any`.
+
+#### End
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `end`       | (T?) : (T?)                 |          | 0x0f
+
+The `end` instruction pops an entry from the control-flow stack. If it is an
+unbound label, the label is bound to the current location. Its return value
+is the value of its operand.
+
+**Validation**:
+ - [Pop] a type from the type stack. [Merge] it with with the type of the [top]
+   of the control flow stack. If the result is not `void`, push it onto the type
+   stack.
+
+### Basic Instructions
+
+0. [Nop](#nop)
+0. [Drop](#drop)
+0. [Constant](#constant)
+0. [Get Local](#get-local)
+0. [Set Local](#set-local)
+0. [Select](#select)
+0. [Call](#call)
+0. [Indirect Call](#indirect-call)
+
+#### Nop
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `nop`       | () : ()                     |          | 0x00
+
+The `nop` instruction does nothing.
+
+#### Drop
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `drop`      | (T) : ()                    |          | TODO
+
+The `drop` instruction has no effect.
+
+> This can be used to effectively unneeded values from the value stack.
+
+#### Constant
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `i32.const` | `<i32> () : (i32)`          | [G]      | 0x10
+| `i64.const` | `<i64> () : (i64)`          | [G]      | 0x11
+| `f32.const` | `<f32> () : (f32)`          | [F]      | 0x12
+| `f64.const` | `<f64> () : (f64)`          | [F]      | 0x13
+
+These instructions return the value of their immediate.
+
+#### Get Local
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `get_local` | <i32> () : (T)              |          | 0x14
+
+The `get_local` instruction returns the value in the locals array at the
+index given in the immediate operand.
+
+#### Set Local
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `set_local` | <i32> (T) : ()              |          | 0x15
+
+The `set_local` instruction sets the value in the locals array at the
+index given in the immediate operand to the value given in the
+non-immediate operand.
+
+#### Select
+
+| Name        | Signature                       | Families | Opcode
+| ----        | ---------                       | -------- | ------
+| `select`    | `(T, T, $condition: i32) : (T)` |          | 0x05
+
+The `select` instruction returns its first operand if `$condition` is
+[true], or its second operand otherwise.
+
+#### Call
+
+| Name        | Signature                               | Families | Opcode
+| ----        | ---------                               | -------- | ------
+| `call`      | <$callee: i32> `(*args*) : (*returns*)` | [L]      | 0x16
+
+The `call` instruction performs a [call](#calling) to the function with
+index `$callee`.
+
+#### Indirect Call
+
+| Name            | Signature                              | Families | Opcode
+| ----            | ---------                              | -------- | ------
+| `call_indirect` | `($callee: i32, *args*) : (*returns*)` | [L]      | 0x17
+
+The `call_indirect` instruction performs a [call](#calling) to the
+function with index `$callee`.
+
+TODO: call_table
+
+### Integer Instructions
+
+0. [Integer Add](#integer-add)
+0. [Integer Subtract](#integer-subtract)
+0. [Integer Multiply](#integer-multiply)
+0. [Integer Divide, Signed](#integer-divide-signed)
+0. [Integer Divide, Unsigned](#integer-divide-unsigned)
+0. [Integer Remainder, Signed](#integer-remainder-signed)
+0. [Integer Remainder, Unsigned](#integer-remainder-unsigned)
+0. [Integer Bitwise And](#integer-bitwise-and)
+0. [Integer Bitwise Or](#integer-bitwise-or)
+0. [Integer Bitwise Exclusive-Or](#integer-exclusive-bitwise-or)
+0. [Integer Shift Left](#integer-shift-left)
+0. [Integer Shift Right, Signed](#integer-shift-right-signed)
+0. [Integer Shift Right, Unsigned](#integer-shift-right-unsigned)
+0. [Integer Rotate Left](#integer-rotate-left)
+0. [Integer Rotate Right](#integer-rotate-right)
+0. [Integer Count Leading Zeros](#integer-count-leading-zeros)
+0. [Integer Count Trailing Zeros](#integer-count-trailing-zeros)
+0. [Integer Population Count](#integer-population-count)
+0. [Integer Equal To Zero](#integer-equal-to-zero)
+
+#### Integer Add
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.add`   | `(i32, i32) : (i32)`        | [G]      | 0x40   | `+` (13)
+| `i64.add`   | `(i64, i64) : (i64)`        | [G]      | 0x5b   | `+` (13)
+
+The `add` instruction returns the [two's complement sum] of its operands. On
+overflow, the result is silently wrapped.
+
+> Due to WebAssembly's use of [two's complement] to represent signed values,
+this instruction can be used to add either signed or unsigned values.
+
+#### Integer Subtract
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.sub`   | `(i32, i32) : (i32)`        | [G]      | 0x41   | `-` (13)
+| `i64.sub`   | `(i64, i64) : (i64)`        | [G]      | 0x5c   | `-` (13)
+
+The `sub` instruction returns the [two's complement difference] of its operands.
+On overflow, the result is silently wrapped.
+
+> Due to WebAssembly's use of [two's complement] to represent signed values,
+this instruction can be used to subtract either signed or unsigned values.
+
+> An integer negate operation can be performed by a `sub` instruction with zero
+as the first operand.
+
+#### Integer Multiply
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.mul`   | `(i32, i32) : (i32)`        | [G]      | 0x42   | `*` (14)
+| `i64.mul`   | `(i64, i64) : (i64)`        | [G]      | 0x5d   | `*` (14)
+
+The `mul` instruction returns the [two's complement product] its operands. On
+overflow, the result is silently wrapped.
+
+> Due to WebAssembly's use of [two's complement] to represent signed values,
+this instruction can be used to multiply either signed or unsigned values.
+
+#### Integer Divide, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.div_s` | `(i32, i32) : (i32)`        | [S]      | 0x43   | `/s` (14)
+| `i64.div_s` | `(i64, i64) : (i64)`        | [S]      | 0x5e   | `/s` (14)
+
+The `div_s` instruction returns the signed quotient of its operands, interpreted
+as signed integers. The quotient is silently rounded to the nearest integer
+toward zero.
+
+**Trap:** Signed overflow, when the [minimum signed integer value] is divided by
+`-1`.
+
+**Trap:** Division by zero, when the right operand (the divisor) is zero.
+
+#### Integer Divide, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.div_u` | `(i32, i32) : (i32)`        | [U]      | 0x44   | `/u` (14)
+| `i64.div_u` | `(i64, i64) : (i64)`        | [U]      | 0x5f   | `/u` (14)
+
+The `div_u` instruction returns the unsigned quotient of its operands,
+interpreted as unsigned integers. The quotient is silently rounded to the
+nearest integer toward zero.
+
+**Trap:** Division by zero, when the right operand (the divisor) is zero.
+
+#### Integer Remainder, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.rem_s` | `(i32, i32) : (i32)`        | [S]      | 0x45   | `%s` (14)
+| `i64.rem_s` | `(i64, i64) : (i64)`        | [S]      | 0x60   | `%s` (14)
+
+The `rem_s` instruction returns the signed remainder from a division of its
+operands interpreted as signed integers, with the result having the same sign as
+the left operand (the dividend).
+
+**Trap:** Division by zero, when the right operand (the divisor) is zero.
+
+> This instruction does not trap when the [minimum signed integer value] is
+divided by `-1`; it returns `0` which is the correct remainder (even though the
+same operands to `div_s` do cause a trap).
+
+> This instruction differs from what is often called a
+["modulo" operation](https://en.wikipedia.org/wiki/Modulo_operation) in its
+handling of negative numbers.
+
+#### Integer Remainder, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.rem_u` | `(i32, i32) : (i32)`        | [U]      | 0x46   | `%u` (14)
+| `i64.rem_u` | `(i64, i64) : (i64)`        | [U]      | 0x61   | `%u` (14)
+
+The `rem_u` instruction returns the unsigned remainder from a division of its
+operands interpreted as unsigned integers.
+
+**Trap:** Division by zero, when the right operand (the divisor) is zero.
+
+> This instruction corresponds to what is sometimes called "modulo" in other
+languages.
+
+#### Integer Bitwise And
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.and`   | `(i32, i32) : (i32)`        | [G]      | 0x47   | `&` (9)
+| `i64.and`   | `(i64, i64) : (i64)`        | [G]      | 0x62   | `&` (9)
+
+The `and` instruction returns the [bitwise and] of its operands.
+
+#### Integer Bitwise Or
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.or`    | `(i32, i32) : (i32)`        | [G]      | 0x48   | `|` (7)
+| `i64.or`    | `(i64, i64) : (i64)`        | [G]      | 0x63   | `|` (7)
+
+The `or` instruction returns the [bitwise inclusive-or] of its operands.
+
+#### Integer Bitwise Exclusive-Or
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.xor`   | `(i32, i32) : (i32)`        | [G]      | 0x49   | `^` (8)
+| `i64.xor`   | `(i64, i64) : (i64)`        | [G]      | 0x64   | `^` (8)
+
+The `xor` instruction returns the [bitwise exclusive-or] of its operands.
+
+> A [bitwise negate](https://en.wikipedia.org/wiki/Bitwise_operation#NOT)
+operation can be performed by a `xor` instruction with negative one as the first
+operand, an operation sometimes called "one's complement" in other languages.
+
+#### Integer Shift Left
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.shl`   | `(i32, i32) : (i32)`        | [T], [G] | 0x4a   | `<<` (12)
+| `i64.shl`   | `(i64, i64) : (i64)`        | [T], [G] | 0x65   | `<<` (12)
+
+The `shl` instruction returns the value of the first operand [shifted] to the
+left by the [shift count].
+
+#### Integer Shift Right, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.shr_s` | `(i32, i32) : (i32)`        | [T], [S] | 0x4c   | `>>s` (12)
+| `i64.shr_s` | `(i64, i64) : (i64)`        | [T], [S] | 0x67   | `>>s` (12)
+
+The `shr_s` instruction returns the value of the first operand
+[shifted](https://en.wikipedia.org/wiki/Arithmetic_shift) to the right by the
+[shift count].
+
+> This instruction corresponds to what is sometimes called
+"arithmetic right shift" in other languages.
+
+> `shr_s` is similar to `div_s` when the divisor is a power of two, however the
+rounding of negative values is different. `shr_s` effectively rounds down, while
+`div_s` rounds toward zero.
+
+#### Integer Shift Right, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.shr_u` | `(i32, i32) : (i32)`        | [T], [U] | 0x4b   | `>>u` (12)
+| `i64.shr_u` | `(i64, i64) : (i64)`        | [T], [U] | 0x66   | `>>u` (12)
+
+The `shr_u` instruction returns the value of the first operand [shifted] to the
+right by the [shift count].
+
+> This instruction corresponds to what is sometimes called
+"logical right shift" in other languages.
+
+#### Integer Rotate Left
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `i32.rotl`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb7
+| `i64.rotl`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb9
+
+The `rotl` instruction returns the value of the first operand rotated to the
+left by the [shift count].
+
+> Rotating left is similar to shifting left, however vacated bits are set
+to the values of the bits which would otherwise be discarded by the shift,
+so the bits conceptually "rotate back around".
+
+#### Integer Rotate Right
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `i32.rotr`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb6
+| `i64.rotr`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb8
+
+The `rotr` instruction returns the value of the first operand rotated to the
+right by the [shift count].
+
+> Rotating right is similar to shifting right, however vacated bits are set
+to the values of the bits which would otherwise be discarded by the shift,
+so the bits conceptually "rotate back around".
+
+#### Integer Count Leading Zeros
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `i32.clz`   | `(i32) : (i32)`             | [G]      | 0x57
+| `i64.clz`   | `(i64) : (i64)`             | [G]      | 0x72
+
+The `clz` instruction returns the number of "leading zeros" in its operand.
+The "leading zeros" are the longest contiguous sequence of 0-bits starting
+at the most significant bit and extending downward.
+
+> This instruction is fully defined when all bits are zero; it returns the
+number of bits in the operand type.
+
+#### Integer Count Trailing Zeros
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `i32.ctz`   | `(i32) : (i32)`             | [G]      | 0x58
+| `i64.ctz`   | `(i64) : (i64)`             | [G]      | 0x73
+
+The `ctz` instruction returns the number of "trailing zeros" in its operand.
+The "trailing zeros" are the longest contiguous sequence of 0-bits starting
+at the least significant bit and extending upward.
+
+> This instruction is fully defined when all bits are zero; it returns the
+number of bits in the operand type.
+
+#### Integer Population Count
+
+| Name         | Signature                  | Families | Opcode
+| ----         | ---------                  | -------- | ------
+| `i32.popcnt` | `(i32) : (i32)`            | [G]      | 0x59
+| `i64.popcnt` | `(i64) : (i64)`            | [G]      | 0x74
+
+The `popcnt` instruction returns the number of 1-bits in its operand.
+
+> This instruction is fully defined when all bits are zero; it returns 0.
+
+> This instruction corresponds to what is sometimes called a
+["hamming weight"][hamming weight] in other languages.
+
+#### Integer Equal To Zero
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.eqz`   | `(i32) : (i32)`             | [G]      | 0x5a   | `!` (15)
+| `i64.eqz`   | `(i64) : (i32)`             | [G]      | 0xba   | `!` (15)
+
+The `eqz` instruction returns [true] if the operand is equal to zero, or
+[false] otherwise.
+
+> This serves as a form of "logical not" operation which can be used to
+invert boolean conditions.
+
+### Floating-Point Instructions
+
+0. [Floating-Point Add](#floating-point-add)
+0. [Floating-Point Subtract](#floating-point-subtract)
+0. [Floating-Point Multiply](#floating-point-multiply)
+0. [Floating-Point Divide](#floating-point-divide)
+0. [Floating-Point Square Root](#floating-point-square-root)
+0. [Floating-Point Minimum](#floating-point-minimum)
+0. [Floating-Point Maximum](#floating-point-maximum)
+0. [Floating-Point Ceiling](#floating-point-ceiling)
+0. [Floating-Point Floor](#floating-point-floor)
+0. [Floating-Point Truncate](#floating-point-truncate)
+0. [Floating-Point Nearest](#floating-point-nearest)
+0. [Floating-Point Absolute Value](#floating-point-absolute-value)
+0. [Floating-Point Negate](#floating-point-negate)
+0. [Floating-Point CopySign](#floating-point-copysign)
+
+#### Floating-Point Add
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.add`   | `(f32, f32) : (f32)`        | [F]      | 0x75   | `+` (13)
+| `f64.add`   | `(f64, f64) : (f64)`        | [F]      | 0x89   | `+` (13)
+
+The `add` instruction returns the sum of its operands.
+
+This performs the IEEE 754-2008 `addition` operation.
+
+#### Floating-Point Subtract
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.sub`   | `(f32, f32) : (f32)`        | [F]      | 0x76   | `-` (13)
+| `f64.sub`   | `(f64, f64) : (f64)`        | [F]      | 0x8a   | `-` (13)
+
+The `sub` instruction returns the difference of its operands.
+
+This performs the IEEE 754-2008 `subtraction` operation.
+
+#### Floating-Point Multiply
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.mul`   | `(f32, f32) : (f32)`        | [F]      | 0x77   | `*` (14)
+| `f64.mul`   | `(f64, f64) : (f64)`        | [F]      | 0x8b   | `*` (14)
+
+The `mul` instruction returns the product of its operands.
+
+This performs the IEEE 754-2008 `multiplication` operation.
+
+#### Floating-Point Divide
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.div`   | `(f32, f32) : (f32)`        | [F]      | 0x78   | `/` (14)
+| `f64.div`   | `(f64, f64) : (f64)`        | [F]      | 0x8c   | `/` (14)
+
+The `div` instruction returns the quotient of its operands.
+
+This performs the IEEE 754-2008 `division` operation.
+
+#### Floating-Point Square Root
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.sqrt`  | `(f32) : (f32)`             | [F]      | 0x82
+| `f64.sqrt`  | `(f64) : (f64)`             | [F]      | 0x96
+
+The `sqrt` instruction returns the square root of its operand.
+
+This performs the IEEE 754-2008 `squareRoot` operation.
+
+#### Floating-Point Minimum
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.min`   | `(f32, f32) : (f32)`        | [F]      | 0x79
+| `f64.min`   | `(f64, f64) : (f64)`        | [F]      | 0x8d
+
+The `min` instruction returns the minimum value among its operands. For
+this instruction, negative zero is considered less than zero, and NaN values are
+considered less than any other value.
+
+> This differs from the IEEE 754-2008 `minNum` operation in that it returns a
+NaN if either operand is a NaN, and in that the behavior on negative zero is
+fully specified.
+
+> This differs from the common `x<y?x:y` expansion in its handling of
+negative zero and NaN values.
+
+#### Floating-Point Maximum
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.max`   | `(f32, f32) : (f32)`        | [F]      | 0x7a
+| `f64.max`   | `(f64, f64) : (f64)`        | [F]      | 0x8e
+
+The `max` instruction returns the maximum value among its operands. For the this
+instruction, negative zero is considered less than zero, and NaN values are
+considered greater than any other value.
+
+> This differs from the IEEE 754-2008 `maxNum` operation in that it returns a
+NaN if either operand is a NaN, and in that the behavior on negative zero is
+fully specified.
+
+> This differs from the common `x>y?x:y` expansion in its handling of negative
+zero and NaN values.
+
+#### Floating-Point Ceiling
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.ceil`  | `(f32) : (f32)`             | [F]      | 0x7e
+| `f64.ceil`  | `(f64) : (f64)`             | [F]      | 0x92
+
+The `ceil` instruction returns the value of the operand rounded up to the
+nearest integer value.
+
+This performs the IEEE 754-2008 `roundToIntegralTowardPositive` operation.
+
+> See also [Floor and Ceiling Functions].
+
+#### Floating-Point Floor
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.floor` | `(f32) : (f32)`             | [F]      | 0x7f
+| `f64.floor` | `(f64) : (f64)`             | [F]      | 0x93
+
+The `floor` instruction returns the value of the operand rounded down to the
+nearest integer value.
+
+This performs the IEEE 754-2008 `roundToIntegralTowardNegative` operation.
+
+> See also [Floor and Ceiling Functions].
+
+#### Floating-Point Truncate
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.trunc` | `(f32) : (f32)`             | [F]      | 0x80
+| `f64.trunc` | `(f64) : (f64)`             | [F]      | 0x94
+
+The `trunc` instruction returns the value of the operand rounded towards
+zero to the nearest integer value.
+
+This performs the IEEE 754-2008 `roundToIntegralTowardZero` operation.
+
+#### Floating-Point Nearest
+
+| Name          | Signature                 | Families | Opcode
+| ----          | ---------                 | -------- | ------
+| `f32.nearest` | `(f32) : (f32)`           | [F]      | 0x81
+| `f64.nearest` | `(f64) : (f64)`           | [F]      | 0x95
+
+The `nearest` instruction returns the value of the operand
+[rounded to the nearest integer value](https://en.wikipedia.org/wiki/Nearest_integer_function).
+
+This performs the IEEE 754-2008 `roundToIntegralTiesToEven` operation.
+
+> This instruction differs from
+[`Math.round` in ECMAScript](https://tc39.github.io/ecma262/#sec-math.round)
+which rounds ties up.
+
+> This instruction differs from
+[`round` in C](http://en.cppreference.com/w/c/numeric/math/round) which rounds
+ties away from zero.
+
+#### Floating-Point Absolute Value
+
+| Name        | Signature                   | Families | Opcode
+| ----        | ---------                   | -------- | ------
+| `f32.abs`   | `(f32) : (f32)`             | [Z]      | 0x7b
+| `f64.abs`   | `(f64) : (f64)`             | [Z]      | 0x8f
+
+The `abs` instruction returns the absolute value of the operand.
+
+This is a bitwise instruction, so it just sets the sign bit to zero and
+preserves all other bits, even when the operand is a NaN.
+
+This performs the IEEE 754-2008 `abs` operation.
+
+> This differs from comparing whether the operand value is negative and negating
+it, in that it always inverts the sign bit, even for a negative zero or a NaN.
+
+#### Floating-Point Negate
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.neg`   | `(f32) : (f32)`             | [Z]      | 0x7c   | `-` (15)
+| `f64.neg`   | `(f64) : (f64)`             | [Z]      | 0x90   | `-` (15)
+
+The `neg` instruction returns the value of the operand with the sign bit
+reversed.
+
+This is a bitwise instruction, so it just inverts the sign bit and preserves all
+other bits, even when the operand is a NaN.
+
+This performs the IEEE 754-2008 `negate` operation.
+
+> This differs from subtracting the operand value from (negative) zero or
+multiplying by negative one, in that it's guaranteed to preserve the bits of a
+NaN.
+
+#### Floating-Point CopySign
+
+| Name           | Signature                | Families | Opcode
+| ----           | ---------                | -------- | ------
+| `f32.copysign` | `(f32, f32) : (f32)`     | [Z]      | 0x7d
+| `f64.copysign` | `(f64, f64) : (f64)`     | [Z]      | 0x91
+
+The `copysign` instruction returns the value of the left operand with the
+sign bit of the right operand.
+
+This is a bitwise instruction, so it just transfers the sign bit and preserves
+all other bits of the left operand, even when the left operand is a NaN.
+
+This performs the IEEE 754-2008 `copySign` operation.
+
+### Integer Comparison Instructions
+
+0. [Integer Equality](#integer-equality)
+0. [Integer Inequality](#integer-inequality)
+0. [Integer Less Than, Signed](#integer-less-than-signed)
+0. [Integer Less Than, Unsigned](#integer-less-than-unsigned)
+0. [Integer Less Than Or Equal To, Signed](#integer-less-than-or-equal-to-signed)
+0. [Integer Less Than Or Equal To, Unsigned](#integer-less-than-or-equal-to-unsigned)
+0. [Integer Greater Than, Signed](#integer-greater-than-signed)
+0. [Integer Greater Than, Unsigned](#integer-greater-than-unsigned)
+0. [Integer Greater Than Or Equal To, Signed](#integer-greater-than-or-equal-to-signed)
+0. [Integer Greater Than Or Equal To, Unsigned](#integer-greater-than-or-equal-to-unsigned)
+
+#### Integer Equality
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.eq`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4d   | `==` (10)
+| `i64.eq`    | `(i64, i64) : (i32)`        | [C], [G] | 0x68   | `==` (10)
+
+The `eq` instruction tests whether the operands are equal.
+
+#### Integer Inequality
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.ne`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4e   | `!=` (10)
+| `i64.ne`    | `(i64, i64) : (i32)`        | [C], [G] | 0x69   | `!=` (10)
+
+The `ne` instruction tests whether the operands are not equal.
+
+#### Integer Less Than, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.lt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x4f   | `<s` (11)
+| `i64.lt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6a   | `<s` (11)
+
+The `lt_s` instruction tests whether the left operand is less than the right
+operand, interpreting the operands as signed values.
+
+#### Integer Less Than, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.lt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x51   | `<u` (11)
+| `i64.lt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6c   | `<u` (11)
+
+The `lt_u` instruction tests whether the left operand is less than the right
+operand, interpreting the operands as unsigned values.
+
+#### Integer Less Than Or Equal To, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.le_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x50   | `<=s` (11)
+| `i64.le_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6b   | `<=s` (11)
+
+The `le_s` instruction tests whether the left operand is less than or equal
+to the right operand, interpreting the operands as signed values.
+
+> This instruction corresponds to what is sometimes called "at most" in other
+languages.
+
+#### Integer Less Than Or Equal To, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.le_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x52   | `<=u` (11)
+| `i64.le_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6d   | `<=u` (11)
+
+The `le_u` instruction tests whether the left operand is less than or equal
+to the right operand, interpreting the operands as unsigned values.
+
+> This instruction corresponds to what is sometimes called "at most" in other
+languages.
+
+#### Integer Greater Than, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.gt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x53   | `>s` (11)
+| `i64.gt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6e   | `>s` (11)
+
+The `gt_s` instruction tests whether the left operand is greater than the right
+operand, interpreting the operands as signed values.
+
+#### Integer Greater Than, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.gt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x55   | `>u` (11)
+| `i64.gt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x70   | `>u` (11)
+
+The `gt_u` instruction tests whether the left operand is greater than the right
+operand, interpreting the operands as unsigned values.
+
+#### Integer Greater Than Or Equal To, Signed
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.ge_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x54   | `>=s` (11)
+| `i64.ge_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6f   | `>=s` (11)
+
+The `ge_s` instruction tests whether the left operand is greater than or equal
+to the right operand, interpreting the operands as signed values.
+
+> This instruction corresponds to what is sometimes called "at least" in other
+languages.
+
+#### Integer Greater Than Or Equal To, Unsigned
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `i32.ge_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x56   | `>=u` (11)
+| `i64.ge_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x71   | `>=u` (11)
+
+The `ge_u` instruction tests whether the left operand is greater than or equal
+to the right operand, interpreting the operands as unsigned values.
+
+> This instruction corresponds to what is sometimes called "at least" in other
+languages.
+
+### Floating-Point Comparison Instructions
+
+0. [Floating-Point Equality](#floating-point-equality)
+0. [Floating-Point Inequality](#floating-point-inequality)
+0. [Floating-Point Less Than](#floating-point-less-than)
+0. [Floating-Point Less Than Or Equal To](#floating-point-less-than-or-equal-to)
+0. [Floating-Point Greater Than](#floating-point-greater-than)
+0. [Floating-Point Greater Than Or Equal To](#floating-point-greater-than-or-equal-to)
+
+#### Floating-Point Equality
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.eq`    | `(f32, f32) : (i32)`        | [C], [F] | 0x83   | `==` (10)
+| `f64.eq`    | `(f64, f64) : (i32)`        | [C], [F] | 0x97   | `==` (10)
+
+The `eq` instruction tests whether the operands are equal. It returns false if
+either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietEqual` operation.
+
+#### Floating-Point Inequality
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.ne`    | `(f32, f32) : (i32)`        | [C], [F] | 0x84   | `!=` (10)
+| `f64.ne`    | `(f64, f64) : (i32)`        | [C], [F] | 0x98   | `!=` (10)
+
+The `ne` instruction tests whether the operands are not equal. Unlike the other
+comparison operators, it returns [true] if either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietNotEqual` operation.
+
+#### Floating-Point Less Than
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.lt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x85   | `<` (11)
+| `f64.lt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x99   | `<` (11)
+
+The `lt` instruction tests whether the left operand is less than the right
+operand. It returns false if either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietLess` operation.
+
+#### Floating-Point Less Than Or Equal To
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.le`    | `(f32, f32) : (i32)`        | [C], [F] | 0x86   | `<=` (11)
+| `f64.le`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9a   | `<=` (11)
+
+The `le` instruction tests whether the left operand is less than or equal
+to the right operand. It returns false if either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietLessEqual` operation.
+
+#### Floating-Point Greater Than
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.gt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x87   | `>` (11)
+| `f64.gt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9b   | `>` (11)
+
+The `gt` instruction tests whether the left operand is greater than the right
+operand. It returns false if either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietGreater` operation.
+
+#### Floating-Point Greater Than Or Equal To
+
+| Name        | Signature                   | Families | Opcode | Syntax
+| ----        | ---------                   | -------- | ------ | ------
+| `f32.ge`    | `(f32, f32) : (i32)`        | [C], [F] | 0x88   | `>=` (11)
+| `f64.ge`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9c   | `>=` (11)
+
+The `gt` instruction tests whether the left operand is greater than or equal
+to the right operand. It returns false if either operand is a NaN.
+
+This performs the IEEE 754-2008 `compareQuietGreaterEqual` operation.
+
+### Conversion Instructions
+
+0. [Integer Wrap](#integer-wrap)
+0. [Integer Extend, Signed](#integer-extend-signed)
+0. [Integer Extend, Unsigned](#integer-extend-unsigned)
+0. [Floating-Point Truncate to Integer, Signed](#floating-point-truncate-to-integer-signed)
+0. [Floating-Point Truncate to Integer, Unsigned](#floating-point-truncate-to-integer-unsigned)
+0. [Floating-Point Demote](#floating-point demote)
+0. [Floating-Point Promote](#floating-point promote)
+0. [Integer Convert To Floating-Point, Signed](#integer-convert-to-floating-point-signed)
+0. [Integer Convert To Floating-Point, Unsigned](#integer-convert-to-floating-point-unsigned)
+0. [Reinterpret](#reinterpret)
+
+#### Integer Wrap
+
+| Name           | Signature                | Families | Opcode
+| ----           | ---------                | -------- | ------
+| `i32.wrap/i64` | `(i64) : (i32)`          | [G]      | 0xa1
+
+The `wrap` instruction returns the value of its operand silently wrapped to its
+result type. Wrapping means reducing the value modulo the number of unique
+values in the result type.
+
+> This instruction corresponds to what is sometimes called an integer "truncate"
+in other languages, however WebAssembly uses "truncate" to mean discarding the
+least significant bits, while "wrap" means discarding the most significant bits.
+
+#### Integer Extend, Signed
+
+| Name               | Signature            | Families | Opcode
+| ----               | ---------            | -------- | ------
+| `i64.extend_s/i32` | `(i32) : (i64)`      | [S]      | 0xa6
+
+The `extend_s` instruction returns the value of its operand [sign-extended] to its
+result type.
+
+#### Integer Extend, Unsigned
+
+| Name               | Signature            | Families | Opcode
+| ----               | ---------            | -------- | ------
+| `i64.extend_u/i32` | `(i32) : (i64)`      | [U]      | 0xa7
+
+The `extend_u` instruction returns the value of its operand zero-extended to its
+result type.
+
+#### Floating-Point Truncate to Integer, Signed
+
+| Name              | Signature             | Families | Opcode
+| ----              | ---------             | -------- | ------
+| `i32.trunc_s/f32` | `(f32) : (i32)`       | [F], [S] | 0x9d
+| `i32.trunc_s/f64` | `(f64) : (i32)`       | [F], [S] | 0x9e
+| `i64.trunc_s/f32` | `(f32) : (i64)`       | [F], [S] | 0xa2
+| `i64.trunc_s/f64` | `(f64) : (i64)`       | [F], [S] | 0xa3
+
+The `trunc_u` instruction returns the value of its operand, interpreted as a
+signed value, rounded toward zero to the nearest integer.
+
+**Trap:** Invalid Conversion, when a floating-point Invalid condition occurs,
+due to the operand being outside the range that can be converted (including NaN
+values and infinities).
+
+This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
+
+#### Floating-Point Truncate to Integer, Unsigned
+
+| Name              | Signature             | Families | Opcode
+| ----              | ---------             | -------- | ------
+| `i32.trunc_u/f32` | `(f32) : (i32)`       | [F], [U] | 0x9f
+| `i32.trunc_u/f64` | `(f64) : (i32)`       | [F], [U] | 0xa0
+| `i64.trunc_u/f32` | `(f32) : (i64)`       | [F], [U] | 0xa4
+| `i64.trunc_u/f64` | `(f64) : (i64)`       | [F], [U] | 0xa5
+
+The `trunc_u` instruction returns the value of its operand, interpreted as an
+unsigned value, rounded toward zero to the nearest integer.
+
+**Trap:** Invalid Conversion, when an Invalid condition occurs, due to the
+operand being outside the range that can be converted (including NaN values and
+infinities).
+
+This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
+
+#### Floating-Point Demote
+
+| Name             | Signature              | Families | Opcode
+| ----             | ---------              | -------- | ------
+| `f32.demote/f64` | `(f64) : (f32)`        | [F]      | 0xac
+
+The `demote` instruction returns the value of its operand rounded to the nearest
+value in the result type, with ties rounded to the nearest even value.
+
+This performs the IEEE 754-2008 `convertFormat` operation.
+
+#### Floating-Point Promote
+
+| Name              | Signature             | Families | Opcode
+| ----              | ---------             | -------- | ------
+| `f64.promote/f32` | `(f32) : (f64)`       | [F]      | 0xb2
+
+The `promote` instruction returns the value of its operand converted to the
+result type.
+
+This performs the IEEE 754-2008 `convertFormat` operation.
+
+> This instruction never needs to perform rounding.
+
+#### Integer Convert To Floating-Point, Signed
+
+| Name                | Signature           | Families | Opcode
+| ----                | ---------           | -------- | ------
+| `f32.convert_s/i32` | (i32) : (f32)       | [F], [S] | 0xa8
+| `f32.convert_s/i64` | (i64) : (f32)       | [F], [S] | 0xaa
+| `f64.convert_s/i32` | (i32) : (f64)       | [F], [S] | 0xae
+| `f64.convert_s/i64` | (i64) : (f64)       | [F], [S] | 0xb0
+
+The `convert_s` instruction returns the value of its operand, interpreted as a
+signed integer, converted to the result type, rounded to the nearest
+representable value.
+
+This performs the IEEE 754-2008 `convertFromInt` operation.
+
+#### Integer Convert To Floating-Point, Unsigned
+
+| Name                | Signature           | Families | Opcode
+| ----                | ---------           | -------- | ------
+| `f32.convert_u/i32` | (i32) : (f32)       | [F], [U] | 0xa9
+| `f32.convert_u/i64` | (i64) : (f32)       | [F], [U] | 0xab
+| `f64.convert_u/i32` | (i32) : (f64)       | [F], [U] | 0xaf
+| `f64.convert_u/i64` | (i64) : (f64)       | [F], [U] | 0xb1
+
+The `convert_u` instruction returns the value of its operand, interpreted as an
+unsigned integer, converted to the result type, rounded to the nearest
+representable value.
+
+This performs the IEEE 754-2008 `convertFromInt` operation.
+
+#### Reinterpret
+
+| Name                  | Signature         | Families | Opcode
+| ----                  | ---------         | -------- | ------
+| `i32.reinterpret/f32` | (f32) : (i32)     |          | 0xb4
+| `i64.reinterpret/f64` | (f64) : (i64)     |          | 0xb5
+| `f32.reinterpret/i32` | (i32) : (f32)     |          | 0xad
+| `f64.reinterpret/i64` | (i64) : (f64)     |          | 0xb3
+
+The `reinterpret` instruction returns a value which has the same bit-pattern as
+its operand value, in its result type.
+
+> The operand type is always the same width as the result type, so this
+instruction is always exact.
+
+### Load and Store Instructions
+
+0. [Load](#load)
+0. [Store](#store)
+0. [Extending Load, Signed](#extending-load-signed)
+0. [Extending Load, Unsigned](#extending-load-unsigned)
+0. [Wrapping Store](#wrapping-store)
+
+#### Load
+
+| Name        | Signature                                           | Families | Opcode
+| ----        | ---------                                           | -------- | ------
+| `i32.load`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [G] | 0x2a
+| `i64.load`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [G] | 0x2b
+| `f32.load`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [Z] | 0x2c
+| `f64.load`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [Z] | 0x2d
+
+The `load` instruction performs a [load](#loading) of the same size as its type.
+
+Floating-point loads preserve all the bits of the value, performing an
+IEEE 754-2008 `copy` operation.
+
+#### Store
+
+| Name        | Signature                                                     | Families | Opcode
+| ----        | ---------                                                     | -------- | ------
+| `i32.store` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : () | [M], [G] | 0x33
+| `i64.store` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : () | [M], [G] | 0x34
+| `f32.store` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f32) : () | [M], [F] | 0x35
+| `f64.store` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f64) : () | [M], [F] | 0x36
+
+The `store` instruction performs a [store](#storing) of `$value` of the same
+size as its type.
+
+Floating-point stores preserve all the bits of the value, performing an
+IEEE 754-2008 `copy` operation.
+
+#### Extending Load, Signed
+
+| Name           | Signature                                           | Families | Opcode
+| ----           | ---------                                           | -------- | ------
+| `i32.load8_s`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [S] | 0x20
+| `i32.load16_s` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [S] | 0x22
+|                |                                                     |          |
+| `i64.load8_s`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [S] | 0x24
+| `i64.load16_s` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [S] | 0x26
+| `i64.load32_s` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [S] | 0x28
+
+The signed extending load instructions perform a [load](#loading) of narrower
+width than their type, and return the value [sign-extended] to their type.
+ - `load8_s` loads an 8-bit value.
+ - `load16_s` loads a 16-bit value.
+ - `load32_s` loads a 32-bit value.
+
+#### Extending Load, Unsigned
+
+| Name           | Signature                                           | Families | Opcode
+| ----           | ---------                                           | -------- | ------
+| `i32.load8_u`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [U] | 0x21
+| `i32.load16_u` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32) | [M], [U] | 0x23
+|                |                                                     |          |
+| `i64.load8_u`  | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [U] | 0x25
+| `i64.load16_u` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [U] | 0x27
+| `i64.load32_u` | <$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64) | [M], [U] | 0x29
+
+The unsigned extending load instructions perform a [load](#loading) of narrower
+width than their type, and return the value [zero-extended] to their type.
+ - `load8_u` loads an 8-bit value.
+ - `load16_u` loads a 16-bit value.
+ - `load32_u` loads a 32-bit value.
+
+#### Wrapping Store
+
+| Name          | Signature                                                     | Families | Opcode
+| ----          | ---------                                                     | -------- | ------
+| `i32.store8`  | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : () | [M], [G] | 0x2e
+| `i32.store16` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : () | [M], [G] | 0x2f
+|               |                                                               |          |
+| `i64.store8`  | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : () | [M], [G] | 0x30
+| `i64.store16` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : () | [M], [G] | 0x31
+| `i64.store32` | <$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : () | [M], [G] | 0x32
+
+The wrapping store instructions performs a [store](#storing) of `$value`
+silently wrapped to a narrower type.
+ - `store8` stores an 8-bit value.
+ - `store16` stores a 16-bit value.
+ - `store32` stores a 32-bit value.
+
+> See the note in the [wrap instruction](#integer-wrap) about the meaning of the
+name "wrap".
+
+### Additional Memory-Related Instructions
+
+0. [Grow Memory](#grow-memory)
+0. [Current Memory](#current-memory)
+
+#### Grow Memory
+
+| Name          | Signature                 | Families | Opcode
+| ----          | ---------                 | -------- | ------
+| `grow_memory` | (iPTR) : (iPTR)           | [R]      | 0x39
+
+The `grow_memory` instruction increases the size of the referenced linear memory
+space by a given unsigned delta, in units of [pages]. It returns the previous
+linear memory size, also as an unsigned value in units of pages, or `-1` on
+failure.
+
+When a maximum memory size is declared in the referenced linear memory space,
+`grow_memory` fails if it would grow past the maximum. However, `grow_memory`
+may still fail before the maximum if it was not possible to reserve the space up
+front or if enabling the reserved memory fails.
+
+> Since the return value is in units of pages, `-1` is not otherwise a valid
+memory size.
+
+#### Current Memory
+
+| Name             | Signature              | Families | Opcode
+| ----             | ---------              | -------- | ------
+| `current_memory` | () : (iPTR)            | [R]      | 0x3b
+
+The `current_memory` instruction returns the size of the referenced linear
+memory space, as an unsigned value in units of [pages].
+
+[M]: #m-memory-access-instruction-family
+[R]: #r-memory-resize-instruction-family
+[B]: #b-branch-instruction-family
+[L]: #l-call-instruction-family
+[C]: #c-comparison-instruction-family
+[T]: #t-shift-instruction-family
+[G]: #g-generic-integer-instruction-family
+[S]: #s-signed-integer-instruction-family
+[U]: #u-unsigned-integer-instruction-family
+[F]: #f-floating-point-instruction-family
+[Z]: #z-floating-point-bitwise-instruction-family
+[hamming weight]: https://en.wikipedia.org/wiki/Hamming_weight
+[shifted]: https://en.wikipedia.org/wiki/Logical_shift
+[shift count]: #shift-count
+[two's complement sum]: https://en.wikipedia.org/wiki/Two%27s_complement#Addition
+[two's complement difference]: https://en.wikipedia.org/wiki/Two%27s_complement#Subtraction
+[two's complement product]: https://en.wikipedia.org/wiki/Two%27s_complement#Multiplication
+[bitwise and]: https://en.wikipedia.org/wiki/Bitwise_operation#AND
+[bitwise inclusive-or]: https://en.wikipedia.org/wiki/Bitwise_operation#OR
+[bitwise exclusive-or]: https://en.wikipedia.org/wiki/Bitwise_operation#XOR
+[Floor and Ceiling Functions]: https://en.wikipedia.org/wiki/Floor_and_ceiling_functions
+[IEEE 754-2008]: https://en.wikipedia.org/wiki/IEEE_floating_point
+[two's complement]: https://en.wikipedia.org/wiki/Two%27s_complement
+[minimum signed integer value]: https://en.wikipedia.org/wiki/Two%27s_complement#Most_negative_number
+[KiB]: https://en.wikipedia.org/wiki/Kibibyte
+[bit]: https://en.wikipedia.org/wiki/Bit
+[true]: #booleans
+[false]: #booleans
+[sign-extend]: https://en.wikipedia.org/wiki/Sign_extension
+[sign-extended]: https://en.wikipedia.org/wiki/Sign_extension
+[bytes]: #bytes
+[pages]: #pages
+[effective address]: #effective-address
+[little-endian byte order]: https://en.wikipedia.org/wiki/Endianness#Little.
+[accessed bytes]: #accessed-bytes
+[pop]: #type-stack-pop
+[merge]: #control-flow-stack-type-merge

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -44,7 +44,7 @@ execution. Instances can include [linear memory](#linear-memory-section), which
 can serve the purpose of an address space for program data. For security and
 determinism, linear memory is *sandboxed*, and the other data structures in an
 instance, including the call stack, are allocated outside of linear memory so
-that they cannot be corrupted by errant linear memory accesses. An instance can
+that they cannot be corrupted by errant linear-memory accesses. An instance can
 then be executed, either by execution of its [start function](#start-section) or
 by calls to its exported functions.
 
@@ -88,14 +88,14 @@ Basics
 
 ### Bytes
 
-[*Bytes*] in WebAssembly are 8-[bit], and are the addressing unit of linear
-memory accesses.
+[*Bytes*] in WebAssembly are 8-[bit], and are the addressing unit of
+linear-memory accesses.
 
 [*Bytes*]: https://en.wikipedia.org/wiki/Byte
 
 ### Pages
 
-[*Pages*] in WebAssembly are 64 [KiB], and are the units used in linear memory
+[*Pages*] in WebAssembly are 64 [KiB], and are the units used in linear-memory
 size declarations and size operations.
 
 [*Pages*]: https://en.wikipedia.org/wiki/Page_(computer_memory)
@@ -107,10 +107,10 @@ size declarations and size operations.
 
 #### Integer Types
 
-| Name  | Bits
-| ----  | ----
-| `i32` | 32
-| `i64` | 64
+| Name  | Bits |
+| ----- | ---- |
+| `i32` | 32   |
+| `i64` | 64   |
 
 Integer types in WebAssembly aren't inherently signed or unsigned. They may be
 interpreted as signed or unsigned by individual operations. When interpreted as
@@ -138,16 +138,16 @@ values, rather than using the literal encodings described here.
 
 #### Floating-Point Types
 
-| Name  | Bits
-| ----  | ----
-| `f32` | 32
-| `f64` | 64
+| Name  | Bits |
+| ----- | ---- |
+| `f32` | 32   |
+| `f64` | 64   |
 
 `f32` in WebAssembly uses the IEEE 754-2008 [binary32] format, commonly known as
-"Single Precision".
+"single precision".
 
 `f64` in WebAssembly uses the IEEE 754-2008 [binary64] format, commonly known as
-"Double Precision".
+"double precision".
 
 > Unlike with [Numbers in ECMAScript], [NaN] values in WebAssembly have sign
 bits and significand fields which may be observed and manipulated (though they
@@ -170,7 +170,8 @@ such with a link to this section.
 completely unspecified.
 
 > There is no requirement that a given implementation make the same choice every
-time, even within the same instance of a module.
+time, even for successive executions of the same instruction within the same
+instance of a module.
 
 
 Module
@@ -224,8 +225,11 @@ would produce if it were executed within a function body.
 
 **Validation:**
  - If the instruction is a `get_global`, the global index is required to be
-   within the bounds of the [Global Index Space], and the indexed global
+   within the bounds of the [global index space], and the indexed global
    declaration is required to have the immutable flag set.
+
+> In the future, more instructions may be permitted as instantiation-time
+initializers.
 
 ### Module Contents
 
@@ -297,22 +301,22 @@ The Import Section consists of an [array] of imports.
 
 An *import* is one of the following:
  - a function import.
- - a global import.
  - a linear-memory import.
+ - a global import.
  - a table import.
 
 All imports contain:
  - a *module [string]*, identifying a module to import from.
- - a *name [string]*, identifying an entity in that module to import.
+ - a *name [string]*, identifying an export in that module to import.
 
 A *function import* additionally contains:
  - a function declaration, as described in the [Function Section].
 
-A *global import* additionally contains:
- - a global declaration, as described in the [Global Section].
-
 A *linear-memory import* additionally contains:
  - a linear-memory declaration, as described in the [Linear-Memory Section].
+
+A *global import* additionally contains:
+ - a global declaration, as described in the [Global Section].
 
 A *table import* additionally contains:
  - a table declaration, as described in the [Table Section].
@@ -320,10 +324,10 @@ A *table import* additionally contains:
 The meaning of the module string and name string are determined by the embedding
 environment.
 
-Imports provide access to entities, defined and allocated outside the scope of
-this specification (though they may be defined by other WebAssembly modules),
-but which have behavior compatible with their corresponding concepts defined in
-this spec.
+Imports provide access to constructs, defined and allocated by external entities
+outside the scope of this specification (though they may be other WebAssembly
+modules), but which have behavior consistent with their corresponding concepts
+defined in this spec.
 
 **Validation:**
  - All global imports must be immutable.
@@ -354,9 +358,11 @@ The Table Section consists of an [array] of table declarations.
 
 A *table declaration* consists of:
  - A *default* flag.
- - An *element type*, for which the only valid value is `"function"`.
+ - An *element type*, for which the only valid value is `"anyfunc"`.
  - An *initial length*.
  - A *maximum length*.
+
+Tables with an element type of "anyfunc" hold function references of any type.
 
 > Additional elements types may be added in the future.
 
@@ -373,8 +379,8 @@ A *linear-memory declaration* contains:
  - An optional *maximum size*, which if present is an unsigned `iPTR` value, in
    units of [pages]. See the [`grow_memory`](#grow-memory) instruction for
    further information on this field.
- - A *default* flag, which is a boolean value indicating whether the linear
-   memory space is to be the default linear memory space for the module.
+ - A *default* flag, which is a boolean value indicating whether the
+   linear-memory space is to be the default linear-memory space for the module.
 
 TODO: The index bitwidth field anticipates a proposal to add this flag.
 
@@ -389,14 +395,11 @@ the initial size up front.
 
 **Name:** `export`
 
-The Export Section consists of an [array] of exports from the module. Exports
-make functions available to be called from outside the module, either by other
-WebAssembly modules or through other mechanism specific to the embedding
-environment.
+The Export Section consists of an [array] of exports.
 
 An *export* is one of the following:
  - a function export.
- - a memory export.
+ - a linear-memory export.
  - a global export.
  - a table export.
 
@@ -404,24 +407,24 @@ All exports contain:
  - a *name [string]*.
 
 An *function export* additionally contains:
- - an [index] of a function in the [Function Index Space] to export.
+ - an [index] of a function in the [function index space] to export.
 
-A *memory export* consists of:
- - an [index] of a linear-memory space in the [Linear-Memory Index Space] to
+A *linear-memory export* consists of:
+ - an [index] of a linear-memory space in the [linear-memory index space] to
    export.
 
 A *global export* consists of:
- - an [index] of a global in the [Global Index Space] to export.
+ - an [index] of a global in the [global index space] to export.
 
 A *table export* consists of:
- - an [index] of a table in the [Table Index Space] to export.
+ - an [index] of a table in the [table index space] to export.
 
 The meaning of the module string and name string are determined by the embedding
 environment.
 
 Exports provide access to an instance's constructs to external entities outside
 the scope of this specification (though they may be other WebAssembly modules),
-but which have behavior compatible with their corresponding concepts defined in
+but which have behavior consistent with their corresponding concepts defined in
 this spec.
 
 **Validation:**
@@ -476,8 +479,8 @@ A *data initializer* consists of:
    [instantiation-time initializer](#instantiation-time-initializers).
  - a [string] of data.
 
-It describes data to be loaded into linear memory identified by the index in the
-[linear-memory index space] during
+It describes data to be loaded into the linear memory identified by the index in
+the [linear-memory index space] during
 [linear-memory instantiation](#linear-memory-instantiation).
 
 **Validation:**
@@ -485,7 +488,7 @@ It describes data to be loaded into linear memory identified by the index in the
     - The linear-memory index is required to be within the bounds of the
       linear-memory index space.
     - A linear-memory space is identified by the linear-memory index in the
-      linear-memory space and:
+      linear-memory index space and:
        - The sum of the start offset and the length of the string is required to
          be less than the initial size declared for the linear-memory space.
        - The start offset is required to be greater than the index of any byte
@@ -500,7 +503,7 @@ The Global Section consists of an [array] of global declarations.
 
 A *global declaration* consists of:
  - A [type].
- - An *immutable flag*.
+ - An *immutable* flag.
  - An optional *initializer*, which is an
    [instantiation-time initializer](#instantiation-time-initializers).
 
@@ -518,7 +521,7 @@ A *table initializer* consists of:
 
 A *table element initializer* consists of:
  - an index-space selector, which conceptually identifies an index space and for
-   which the only valid value is "the Function Index Space".
+   which the only valid value is "the function index Space".
  - an index into the selected space.
 
 **Validation:**
@@ -541,6 +544,8 @@ A *table element initializer* consists of:
 [Linear-Memory Section].
 
 > Initializers may be able to reference other index spaces in the future.
+
+TODO: Rename this to the Table Initializer Section?
 
 #### Name Section
 
@@ -588,7 +593,7 @@ index for each imported function, in the order the imports appear in the
  - For each element in the index space, the type index is required to be within
    the bounds of the [Type Section] array.
 
-> The function index space is used by [`call` instructions](#call) to identify
+> The function index space is used by [`call`](#call) instructions to identify
 the callee of a direct call.
 
 #### Global Index Space
@@ -605,7 +610,7 @@ for each imported global, in the order the imports appear in the
 
 #### Linear-Memory Index Space
 
-The *linear-memory index space* begins with an index for each linear memory
+The *linear-memory index space* begins with an index for each linear-memory
 space defined in the [Linear-Memory Section], if present, in the order of that
 section, followed by an index for each imported linear memory, in the order the
 imports appear in the [Import Section].
@@ -625,13 +630,13 @@ imports appear in the [Import Section].
 
 > The validation rules here specifically avoid requiring the size in bytes of
 linear memory to be representable as an unsigned `iPTR`. For example a 32-bit
-linear address space could theoretically be resized to 4 GiB if the
+linear-memory address space could theoretically be resized to 4 GiB if the
 implementation has sufficient resources; the index of every byte would be
 addressable, even though the total number of bytes would not be.
 
-> Multiple linear memory spaces may be permitted in the future.
+> Multiple linear-memory spaces may be permitted in the future.
 
-> 64-bit linear memory spaces may be permitted in the future.
+> 64-bit linear-memory spaces may be permitted in the future.
 
 #### Table Index Space
 
@@ -652,7 +657,7 @@ Binary Format
 --------------------------------------------------------------------------------
 
 TODO: Describe the binary format. The high-level ideas are:
- - A module starts with a *magic cookie*, consisting of the 4-byte-sequence
+ - A module starts with a *magic cookie*, consisting of the 4-byte sequence
    0x00, 0x61, 0x73, 0x6d, followed by the [version](#module-contents) [index],
    followed by the encodings of the sections.
  - Most module [indices] values are typically encoded with [LEB128].
@@ -662,6 +667,7 @@ TODO: Describe the binary format. The high-level ideas are:
    by its immediate operand values.
  - Most immediate operand values are encoded with [LEB128], though there are
    several special cases.
+ - Function bodies end with an implicit [`end`](#end) instruction.
 
 [LEB128]: https://en.wikipedia.org/wiki/LEB128
 
@@ -670,6 +676,9 @@ contents are not generally "text", followed by the UTF-8 encoding of the string
 "asm".
 
 TODO: Renumber the opcodes strategically?
+
+TODO: Will the `end` be made explicit? Monitor
+https://github.com/WebAssembly/design/pull/666
 
 
 Text Format
@@ -704,10 +713,11 @@ The requirements for function body validation are:
  - The instruction sequence is required to be non-empty, and the last
    instruction in the sequence is required to be an [`end`](#end).
  - Control-flow constructs are required to form properly nested *regions*. Each
-   `loop`, `block`, and the function entry begin a region required to be
-   terminated with an `end`. Each `if` begins a region terminated with either an
-   `end` or an `else`. Each `else` begins a region terminated with an `end`.
-   Each `end` and each `else` terminates exactly one region.
+   [`loop`](#loop), [`block`](#block), and the function entry begin a region
+   required to be terminated with an [`end`](#end). Each [`if`](#if) begins a
+   region terminated with either an [`end`](#end) or an [`else`](#else). Each
+   [`else`](#else) begins a region terminated with an [`end`](#end). Each `end`
+   and each `else` terminates exactly one region.
  - Branches to labels must be from within the region bounded by the instruction
    that binds the label.
  - The sequence of values that would be on the value stack at execution of each
@@ -728,9 +738,6 @@ The requirements for function body validation are:
 one entry point.
 
 > There are no implicit type conversions in WebAssembly.
-
-TODO: Will the `end` be made explicit? Monitor
-https://github.com/WebAssembly/design/pull/666
 
 #### Function Body Validation Algorithm
 
@@ -795,8 +802,8 @@ that the [requirements](#function-body-validation-requirements) are met.
 
 > The control-flow stack's limit values effectively mark region boundaries in
 the type stack. Regions are required to be nested, and each region's limit value
-is greater than those of the regions that enclose it. Things pushed onto the
-type stack outside a region cannot be popped from within the region.
+is greater than those of the regions that enclose it. Types pushed onto the type
+stack outside a region cannot be popped from within the region.
 
 ##### Type-Sequence Merge
 
@@ -821,14 +828,14 @@ which consists of the following steps:
    [instantiated](#linear-memory-instantiation).
  - If a [Table Section] is present, each table is
    [instantiated](#table-instantiation).
- - A finite quantity of [call-stack resources] are allocated.
+ - A finite quantity of [call-stack resources] is allocated.
  - A *globals array* is allocated, which is a heterogeneous array of globals
    corresponding to the entries in the module's [Global Section]. The initial
    value of each global is the value of its
    [instantiation-time initializer](#instantiation-time-initializers), if it has
    one, or an all-zeros bit-pattern otherwise.
 
-> The contents of the Module, including functions and their bodies, are outside
+> The contents of an instance, including functions and their bodies, are outside
 any linear address space and not any accessible to applications. WebAssembly is
 therefore conceptually a [Harvard Architecture].
 
@@ -842,7 +849,7 @@ https://github.com/WebAssembly/design/pull/719
 A linear-memory declaration in the [Linear-Memory Section] may be instantiated
 as follows:
 
-An array of bytes with the length being the value of the linear-memory space's
+An array of [bytes] with the length being the value of the linear-memory space's
 initial size field is created and added to the instance. Any byte not
 initialized by any data initializer is initialized to zero.
 
@@ -859,7 +866,7 @@ For each table in the [Table Section]:
    elements of the table's element type.
 
 For each table initializer in the [Element Section], for the table identified by
-the table index in the table index space:
+the table index in the [table index space]:
  - A contiguous of elements in the table starting at the table initializer's
    start offset is initialized according to the elements of the table element
    initializers array, which specify an indexed element in their selected index
@@ -910,7 +917,7 @@ are created:
 > Implementations needn't create a literal array to store the locals, or literal
 stacks to manage values at runtime.
 
-> These data structures are all allocated outside any linear address space and
+> These data structures are all allocated outside any linear-address space and
 are not any accessible to applications.
 
 #### Function Execution Initialization
@@ -984,10 +991,18 @@ additional content.
 
 ### Instruction Mnemonic Field
 
-Instruction [mnemonics] are short names identifying specific instructions. Many
-instructions have type-specific behavior, in which case there is a unique
+Instruction [mnemonics] are short names identifying specific instructions.
+
+Many instructions have type-specific behavior, in which case there is a unique
 mnemonic for each type, formed by prepending a *type prefix*, such as `i32.` or
 `f64.`, to the base instruction mnemonic.
+
+Conversion instructions have additional type-specific behavior; their mnemonic
+additionally has a *type suffix* appended, such as `/i32` or `/f64`, indicating
+the input type.
+
+The base menomics for [Signed][S] and [unsigned][U] instructions have the
+convention of ending in "_s" and "_u" respectively.
 
 [mnemonics]: https://en.wikipedia.org/wiki/Assembly_language#Opcode_mnemonics_and_extended_mnemonics
 
@@ -1017,7 +1032,7 @@ The following named values are defined:
    value.
 
 A few special constructs are used for special purposes:
- - `iPTR` is for use with a linear memory access, and signifies the integer type
+ - `iPTR` is for use with a linear-memory access, and signifies the integer type
    associated with addresses within the accessed linear-memory space.
  - `TABLE` indicates a branch table, which is a sequence of immediate integer
    values for use in the [table branch](#table-branch) instruction.
@@ -1056,17 +1071,19 @@ These instructions load from and store to a linear-memory space.
 
 ##### Effective Address
 
-The *effective address* of a linear memory access is computed by adding `$base`
-and `$offset`, both interpreted as unsigned, at infinite precision, so that
-there is no overflow.
+The *effective address* of a linear-memory access is computed by adding `$base`
+and `$offset`, both interpreted as unsigned, at infinite range and precision, so
+that there is no overflow.
 
 ##### Alignment
 
 **Slow:** If the effective address isn't a multiple of `$align`, the access is
 *misaligned*, and the instruction may execute very slowly.
 
-> When `$align` is greater than or equal to the size of the access, the access
-is *naturally aligned*. When it's less, the access is *unaligned*.
+> When `$align` is at least the size of the access, the access is
+*naturally aligned*. When it's less, the access is *unaligned*. Naturally
+aligned accesses may be faster than unaligned accesses, though both may be much
+faster than misaligned accesses.
 
 > There is no other semantic effect associated with `$align`; misaligned and
 unaligned loads and stores still behave normally.
@@ -1089,6 +1106,9 @@ For a load access, a value is read from the [accessed bytes], in
 For a store access, the value to store is written to the [accessed bytes], in
 [little-endian byte order].
 
+> If any of the bytes are out of bounds, the Out Of Bounds trap is triggered
+before any of the bytes are written to.
+
 ##### Linear-Memory Access Validation
 
  - `$align` is required to be a [power of 2].
@@ -1098,7 +1118,7 @@ For a store access, the value to store is written to the [accessed bytes], in
 TODO: Will offsets be encoded as signed? Monitor
 https://github.com/WebAssembly/design/issues/584
 
-TODO: Should memory accesses have a linear-memory-space immediate?
+TODO: Should linear-memory accesses have a linear-memory-space immediate?
 
 [power of 2]: https://en.wikipedia.org/wiki/Power_of_two
 
@@ -1108,7 +1128,8 @@ TODO: Should memory accesses have a linear-memory-space immediate?
 
  - The module is required to contain a default linear-memory space.
 
-TODO: Should memory size instructions have a linear-memory-space immediate?
+TODO: Should linear-memory size instructions have a linear-memory-space
+immediate?
 
 #### B: Branch Instruction Family
 
@@ -1128,6 +1149,8 @@ entry is popped.
 
 > In practice, implementations may precompute the destinations of branches so
 that they don't literally need to scan in this manner.
+
+> Branching is sometimes called "jumping" in other languages.
 
 #### L: Call Instruction Family
 
@@ -1332,9 +1355,9 @@ Instructions
 
 #### Block
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `block`     | `() : ()`                   |          | 0x01
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `block`     | `() : ()`                   |          | 0x01   |
 
 The `block` instruction pushes an unbound [label] onto the control-flow stack.
 
@@ -1347,9 +1370,9 @@ stack.
 
 #### Loop
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `loop`      | `() : ()`                   |          | 0x02
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `loop`      | `() : ()`                   |          | 0x02   |
 
 The `loop` instruction binds a [label] to the current position and pushes it
 onto the control-flow stack.
@@ -1375,9 +1398,9 @@ https://github.com/WebAssembly/design/pull/710
 
 #### Unconditional Branch
 
-| Mnemonic    | Signature                                              | Families | Opcode
-| --------    | ---------                                              | -------- | ------
-| `br`        | `<$arity: i32, $depth: i32> (T[$arity]) : (T[$arity])` | [B] [Q]  | 0x06
+| Mnemonic    | Signature                                              | Families | Opcode |
+| ----------- | ------------------------------------------------------ | -------- | ------ |
+| `br`        | `<$arity: i32, $depth: i32> (T[$arity]) : (T[$arity])` | [B] [Q]  | 0x06   |
 
 The `br` instruction [branches](#branching) according to the control flow stack
 entry `$depth` from the top. It returns the values of its operands.
@@ -1394,9 +1417,9 @@ TODO: This anticipates a proposal to make `br`, `br_table`, `return`, and
 
 #### Conditional Branch
 
-| Mnemonic    | Signature                                                               | Families | Opcode
-| --------    | ---------                                                               | -------- | ------
-| `br_if`     | `<$arity: i32, $depth: i32> (T[$arity], $condition: i32) : (T[$arity])` | [B]      | 0x07
+| Mnemonic    | Signature                                                               | Families | Opcode |
+| ----------- | ----------------------------------------------------------------------- | -------- | ------ |
+| `br_if`     | `<$arity: i32, $depth: i32> (T[$arity], $condition: i32) : (T[$arity])` | [B]      | 0x07   |
 
 If `$condition` is [true], the `br_if` instruction [branches](#branching)
 according to the control flow stack entry `$depth` from the top. Otherwise, it
@@ -1417,9 +1440,9 @@ https://github.com/WebAssembly/design/pull/709
 
 #### Table Branch
 
-| Mnemonic    | Signature                                                                    | Families | Opcode
-| --------    | ---------                                                                    | -------- | ------
-| `br_table`  | `<$arity: i32, TABLE, $default: i32> (T[$arity], $index: i32) : (T[$arity])` | [B] [Q]  | 0x08
+| Mnemonic    | Signature                                                                    | Families | Opcode |
+| ----------- | ---------------------------------------------------------------------------- | -------- | ------ |
+| `br_table`  | `<$arity: i32, TABLE, $default: i32> (T[$arity], $index: i32) : (T[$arity])` | [B] [Q]  | 0x08   |
 
 First, the `br_table` instruction selects a depth to use. If `$index` is within
 the bounds of the table, the depth is the value of the indexed table element.
@@ -1444,9 +1467,9 @@ with the other branch instructions.
 
 #### If
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `if`        | `($condition: i32) : ()`    | [B]      | 0x03
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `if`        | `($condition: i32) : ()`    | [B]      | 0x03   |
 
 The `if` instruction pushes an unbound [label] onto the control-flow stack. If
 `$condition` is [false], it then [branches](#branching) to this label.
@@ -1455,16 +1478,16 @@ The `if` instruction pushes an unbound [label] onto the control-flow stack. If
  - An entry is pushed onto the control-flow stack containing no type sequence,
    and a limit value of the current length of the type stack.
 
-TODO: Do `if`/`else` have labels? Monitor at least
+TODO: Do `if` and `else` have labels? Monitor at least
 https://github.com/WebAssembly/design/pull/710
 
 > Each `if` needs either a corresponding [`else`](#else) or [`end`](#end).
 
 #### Else
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `else`      | `(T[$any]) : (T[$any])`     | [B]      | 0x04
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `else`      | `(T[$any]) : (T[$any])`     | [B]      | 0x04   |
 
 The `else` instruction binds the control-flow stack top's [label] to the current
 position, pops an entry from the control-flow stack, pushes a new unbound
@@ -1483,9 +1506,9 @@ label. It returns the values of its operands.
 
 #### End
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `end`       | `(T[$any]) : (T[$any])`     |          | 0x0f
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `end`       | `(T[$any]) : (T[$any])`     |          | 0x0f   |
 
 The `end` instruction pops an entry from the control-flow stack. If the entry's
 [label] is unbound, the label is bound to the current position. It returns the
@@ -1503,9 +1526,9 @@ values of its operands.
 
 #### Return
 
-| Mnemonic    | Signature                                 | Families | Opcode
-| --------    | ---------                                 | -------- | ------
-| `return`    | `<$arity: i32> (T[$arity]) : (T[$arity])` | [B] [Q]  | 0x09
+| Mnemonic    | Signature                                 | Families | Opcode |
+| ----------- | ----------------------------------------- | -------- | ------ |
+| `return`    | `<$arity: i32> (T[$arity]) : (T[$arity])` | [B] [Q]  | 0x09   |
 
 The `return` instruction [branches](#branching) according to the control-flow
 stack bottom. It returns the values of its operands.
@@ -1523,11 +1546,11 @@ actual function return.
 
 #### Unreachable
 
-| Mnemonic      | Signature                 | Families | Opcode
-| --------      | ---------                 | -------- | ------
-| `unreachable` | `() : ()`                 | [Q]      | 0x0a
+| Mnemonic      | Signature                 | Families | Opcode |
+| ------------- | ------------------------- | -------- | ------ |
+| `unreachable` | `() : ()`                 | [Q]      | 0x0a   |
 
-**Trap:** Unreachable, always.
+**Trap:** Unreachable reached, always.
 
 > The `unreachable` instruction is meant to represent code that isn't meant to
 be executed except in the case of a bug in the application.
@@ -1548,17 +1571,17 @@ be executed except in the case of a bug in the application.
 
 #### Nop
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `nop`       | `() : ()`                   |          | 0x00
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `nop`       | `() : ()`                   |          | 0x00   |
 
 The `nop` instruction does nothing.
 
 #### Drop
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `drop`      | `(T[1]) : ()`               |          | 0x0b
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `drop`      | `(T[1]) : ()`               |          | 0x0b   |
 
 The `drop` instruction does nothing.
 
@@ -1567,12 +1590,12 @@ discard unneeded values from the value stack.
 
 #### Constant
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `i32.const` | `<i32> () : (i32)`          |          | 0x10
-| `i64.const` | `<i64> () : (i64)`          |          | 0x11
-| `f32.const` | `<f32> () : (f32)`          |          | 0x12
-| `f64.const` | `<f64> () : (f64)`          |          | 0x13
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `i32.const` | `<i32> () : (i32)`          |          | 0x10   |
+| `i64.const` | `<i64> () : (i64)`          |          | 0x11   |
+| `f32.const` | `<f32> () : (f32)`          |          | 0x12   |
+| `f64.const` | `<f64> () : (f64)`          |          | 0x13   |
 
 The `const` instruction returns the value of its immediate.
 
@@ -1583,9 +1606,9 @@ https://github.com/WebAssembly/design/pull/696
 
 #### Get Local
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `get_local` | `<$id: i32> () : (T[1])`    |          | 0x14
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `get_local` | `<$id: i32> () : (T[1])`    |          | 0x14   |
 
 The `get_local` instruction returns the value of the local at index `$id` in the
 locals array. The type parameter is bound to the type of the local.
@@ -1595,9 +1618,9 @@ locals array. The type parameter is bound to the type of the local.
 
 #### Set Local
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `set_local` | `<$id: i32> (T[1]) : ()`    |          | 0x15
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `set_local` | `<$id: i32> (T[1]) : ()`    |          | 0x15   |
 
 The `set_local` instruction sets the value of the local at index `$id` in the
 locals array to the value given in the operand. The type parameter is bound to
@@ -1611,9 +1634,9 @@ the type of the local.
 
 #### Tee Local
 
-| Mnemonic    | Signature                    | Families | Opcode
-| --------    | ---------                    | -------- | ------
-| `tee_local` | `<$id: i32> (T[1]) : (T[1])` |          | 0x19
+| Mnemonic    | Signature                    | Families | Opcode |
+| ----------- | ---------------------------- | -------- | ------ |
+| `tee_local` | `<$id: i32> (T[1]) : (T[1])` |          | 0x19   |
 
 The `tee_local` instruction sets the value of the locals at index `$id` in the
 locals array to the value given in the operand. Its return value is the value of
@@ -1630,36 +1653,36 @@ return value.
 
 #### Get Global
 
-| Mnemonic     | Signature                  | Families | Opcode
-| --------     | ---------                  | -------- | ------
-| `get_global` | `<$id: i32> () : (T[1])`   |          | TODO
+| Mnemonic     | Signature                  | Families | Opcode |
+| ------------ | -------------------------- | -------- | ------ |
+| `get_global` | `<$id: i32> () : (T[1])`   |          | TODO   |
 
 The `get_global` instruction returns the value of the global identified by index
-`$id` in the [Global Index Space]. The type parameter is bound to the type of
+`$id` in the [global index space]. The type parameter is bound to the type of
 the global.
 
 **Validation:**
- - `$id` is required to be within the bounds of the Global Index Space.
+ - `$id` is required to be within the bounds of the global index space.
 
 #### Set Global
 
-| Mnemonic     | Signature                  | Families | Opcode
-| --------     | ---------                  | -------- | ------
-| `set_global` | `<$id: i32> (T[1]) : ()`   |          | TODO
+| Mnemonic     | Signature                  | Families | Opcode |
+| ------------ | -------------------------- | -------- | ------ |
+| `set_global` | `<$id: i32> (T[1]) : ()`   |          | TODO   |
 
 The `set_global` instruction sets the value of the global identified by index
-`$id` in the [Global Index Space] to the value given in the operand. The type
+`$id` in the [global index space] to the value given in the operand. The type
 parameter is bound to the type of the global.
 
 **Validation:**
- - `$id` is required to be within the bounds of the Global Index Space.
+ - `$id` is required to be within the bounds of the global index space.
  - The indexed global is required to be declared not immutable.
 
 #### Select
 
-| Mnemonic    | Signature                                | Families | Opcode
-| --------    | ---------                                | -------- | ------
-| `select`    | `(T[1], T[1], $condition: i32) : (T[1])` |          | 0x16
+| Mnemonic    | Signature                                | Families | Opcode |
+| ----------- | ---------------------------------------- | -------- | ------ |
+| `select`    | `(T[1], T[1], $condition: i32) : (T[1])` |          | 0x16   |
 
 The `select` instruction returns its first operand if `$condition` is [true], or
 its second operand otherwise.
@@ -1672,15 +1695,15 @@ https://github.com/WebAssembly/design/pull/695
 
 #### Call
 
-| Mnemonic    | Signature                                                | Families | Opcode
-| --------    | ---------                                                | -------- | ------
-| `call`      | `<$arity: i32, $callee: i32> (T[$args]) : (T[$returns])` | [L]      | 0x17
+| Mnemonic    | Signature                                                | Families | Opcode |
+| ----------- | -------------------------------------------------------- | -------- | ------ |
+| `call`      | `<$arity: i32, $callee: i32> (T[$args]) : (T[$returns])` | [L]      | 0x17   |
 
 The `call` instruction performs a [call](#calling) to the function with index
-`$callee` in the [Function Index Space].
+`$callee` in the [function index space].
 
 **Validation:**
- - `$callee` is required to be within the bounds of the Function Index Space.
+ - `$callee` is required to be within the bounds of the function index space.
  - [Call validation](#call-validation) is required; the callee signature is the
    signature of the indexed function.
 
@@ -1689,9 +1712,9 @@ https://github.com/WebAssembly/design/pull/695
 
 #### Indirect Call
 
-| Mnemonic        | Signature                                                                 | Families | Opcode
-| --------        | ---------                                                                 | -------- | ------
-| `call_indirect` | `<$arity: i32, $signature: i32> ($callee: i32, T[$args]) : (T[$returns])` | [L]      | 0x18
+| Mnemonic        | Signature                                                                 | Families | Opcode |
+| --------------- | ------------------------------------------------------------------------- | -------- | ------ |
+| `call_indirect` | `<$arity: i32, $signature: i32> ($callee: i32, T[$args]) : (T[$returns])` | [L]      | 0x18   |
 
 The `call_indirect` instruction performs a [call](#calling) to the function in
 the default table with index `$callee`.
@@ -1739,10 +1762,10 @@ https://github.com/WebAssembly/design/pull/695
 
 #### Integer Add
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.add`   | `(i32, i32) : (i32)`        | [G]      | 0x40   | `+` (13)
-| `i64.add`   | `(i64, i64) : (i64)`        | [G]      | 0x5b   | `+` (13)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.add`   | `(i32, i32) : (i32)`        | [G]      | 0x40   | `+` (13)    |
+| `i64.add`   | `(i64, i64) : (i64)`        | [G]      | 0x5b   | `+` (13)    |
 
 The integer `add` instruction returns the [two's complement sum] of its
 operands. The carry bit is silently discarded.
@@ -1752,10 +1775,10 @@ this instruction can be used to add either signed or unsigned values.
 
 #### Integer Subtract
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.sub`   | `(i32, i32) : (i32)`        | [G]      | 0x41   | `-` (13)
-| `i64.sub`   | `(i64, i64) : (i64)`        | [G]      | 0x5c   | `-` (13)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.sub`   | `(i32, i32) : (i32)`        | [G]      | 0x41   | `-` (13)    |
+| `i64.sub`   | `(i64, i64) : (i64)`        | [G]      | 0x5c   | `-` (13)    |
 
 The integer `sub` instruction returns the [two's complement difference] of its
 operands. The borrow bit is silently discarded.
@@ -1768,10 +1791,10 @@ as the first operand.
 
 #### Integer Multiply
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.mul`   | `(i32, i32) : (i32)`        | [G]      | 0x42   | `*` (14)
-| `i64.mul`   | `(i64, i64) : (i64)`        | [G]      | 0x5d   | `*` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.mul`   | `(i32, i32) : (i32)`        | [G]      | 0x42   | `*` (14)    |
+| `i64.mul`   | `(i64, i64) : (i64)`        | [G]      | 0x5d   | `*` (14)    |
 
 The integer `mul` instruction returns the low half of the
 [two's complement product] its operands.
@@ -1781,10 +1804,10 @@ this instruction can be used to multiply either signed or unsigned values.
 
 #### Integer Divide, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.div_s` | `(i32, i32) : (i32)`        | [S]      | 0x43   | `/s` (14)
-| `i64.div_s` | `(i64, i64) : (i64)`        | [S]      | 0x5e   | `/s` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.div_s` | `(i32, i32) : (i32)`        | [S]      | 0x43   | `/s` (14)   |
+| `i64.div_s` | `(i64, i64) : (i64)`        | [S]      | 0x5e   | `/s` (14)   |
 
 The `div_s` instruction returns the signed quotient of its operands, interpreted
 as signed. The quotient is silently rounded to the nearest integer toward zero.
@@ -1797,10 +1820,10 @@ zero.
 
 #### Integer Divide, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.div_u` | `(i32, i32) : (i32)`        | [U]      | 0x44   | `/u` (14)
-| `i64.div_u` | `(i64, i64) : (i64)`        | [U]      | 0x5f   | `/u` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.div_u` | `(i32, i32) : (i32)`        | [U]      | 0x44   | `/u` (14)   |
+| `i64.div_u` | `(i64, i64) : (i64)`        | [U]      | 0x5f   | `/u` (14)   |
 
 The `div_u` instruction returns the unsigned quotient of its operands,
 interpreted as unsigned. The quotient is silently rounded to the nearest integer
@@ -1811,10 +1834,10 @@ zero.
 
 #### Integer Remainder, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.rem_s` | `(i32, i32) : (i32)`        | [S]      | 0x45   | `%s` (14)
-| `i64.rem_s` | `(i64, i64) : (i64)`        | [S]      | 0x60   | `%s` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.rem_s` | `(i32, i32) : (i32)`        | [S]      | 0x45   | `%s` (14)   |
+| `i64.rem_s` | `(i64, i64) : (i64)`        | [S]      | 0x60   | `%s` (14)   |
 
 The `rem_s` instruction returns the signed remainder from a division of its
 operand values interpreted as signed, with the result having the same sign as
@@ -1830,17 +1853,17 @@ same operands to `div_s` do cause a trap).
 > This instruction differs from what is often called a ["modulo" operation] in
 its handling of negative numbers.
 
-> This instruction has some [common pitfalls].
+> This instruction has some [common pitfalls] to avoid.
 
 ["modulo" operation]: https://en.wikipedia.org/wiki/Modulo_operation
 [common pitfalls]: https://en.wikipedia.org/wiki/Modulo_operation#Common_pitfalls
 
 #### Integer Remainder, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.rem_u` | `(i32, i32) : (i32)`        | [U]      | 0x46   | `%u` (14)
-| `i64.rem_u` | `(i64, i64) : (i64)`        | [U]      | 0x61   | `%u` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.rem_u` | `(i32, i32) : (i32)`        | [U]      | 0x46   | `%u` (14)   |
+| `i64.rem_u` | `(i64, i64) : (i64)`        | [U]      | 0x61   | `%u` (14)   |
 
 The `rem_u` instruction returns the unsigned remainder from a division of its
 operand values interpreted as unsigned.
@@ -1853,10 +1876,10 @@ languages.
 
 #### Integer Bitwise And
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.and`   | `(i32, i32) : (i32)`        | [G]      | 0x47   | `&` (9)
-| `i64.and`   | `(i64, i64) : (i64)`        | [G]      | 0x62   | `&` (9)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.and`   | `(i32, i32) : (i32)`        | [G]      | 0x47   | `&` (9)     |
+| `i64.and`   | `(i64, i64) : (i64)`        | [G]      | 0x62   | `&` (9)     |
 
 The `and` instruction returns the [bitwise and] of its operands.
 
@@ -1864,10 +1887,10 @@ The `and` instruction returns the [bitwise and] of its operands.
 
 #### Integer Bitwise Or
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.or`    | `(i32, i32) : (i32)`        | [G]      | 0x48   | `|` (7)
-| `i64.or`    | `(i64, i64) : (i64)`        | [G]      | 0x63   | `|` (7)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.or`    | `(i32, i32) : (i32)`        | [G]      | 0x48   | `|` (7)     |
+| `i64.or`    | `(i64, i64) : (i64)`        | [G]      | 0x63   | `|` (7)     |
 
 The `or` instruction returns the [bitwise inclusive-or] of its operands.
 
@@ -1875,10 +1898,10 @@ The `or` instruction returns the [bitwise inclusive-or] of its operands.
 
 #### Integer Bitwise Exclusive-Or
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.xor`   | `(i32, i32) : (i32)`        | [G]      | 0x49   | `^` (8)
-| `i64.xor`   | `(i64, i64) : (i64)`        | [G]      | 0x64   | `^` (8)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.xor`   | `(i32, i32) : (i32)`        | [G]      | 0x49   | `^` (8)     |
+| `i64.xor`   | `(i64, i64) : (i64)`        | [G]      | 0x64   | `^` (8)     |
 
 The `xor` instruction returns the [bitwise exclusive-or] of its operands.
 
@@ -1891,10 +1914,10 @@ negative one as the first operand, an operation sometimes called
 
 #### Integer Shift Left
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.shl`   | `(i32, i32) : (i32)`        | [T], [G] | 0x4a   | `<<` (12)
-| `i64.shl`   | `(i64, i64) : (i64)`        | [T], [G] | 0x65   | `<<` (12)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.shl`   | `(i32, i32) : (i32)`        | [T], [G] | 0x4a   | `<<` (12)   |
+| `i64.shl`   | `(i64, i64) : (i64)`        | [T], [G] | 0x65   | `<<` (12)   |
 
 The `shl` instruction returns the value of the first operand [shifted] to the
 left by the [shift count].
@@ -1904,10 +1927,10 @@ the shift count.
 
 #### Integer Shift Right, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.shr_s` | `(i32, i32) : (i32)`        | [T], [S] | 0x4c   | `>>s` (12)
-| `i64.shr_s` | `(i64, i64) : (i64)`        | [T], [S] | 0x67   | `>>s` (12)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.shr_s` | `(i32, i32) : (i32)`        | [T], [S] | 0x4c   | `>>s` (12)  |
+| `i64.shr_s` | `(i64, i64) : (i64)`        | [T], [S] | 0x67   | `>>s` (12)  |
 
 The `shr_s` instruction returns the value of the first operand
 [shifted](https://en.wikipedia.org/wiki/Arithmetic_shift) to the right by the
@@ -1922,10 +1945,10 @@ rounding of negative values is different. `shr_s` effectively rounds down, while
 
 #### Integer Shift Right, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.shr_u` | `(i32, i32) : (i32)`        | [T], [U] | 0x4b   | `>>u` (12)
-| `i64.shr_u` | `(i64, i64) : (i64)`        | [T], [U] | 0x66   | `>>u` (12)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.shr_u` | `(i32, i32) : (i32)`        | [T], [U] | 0x4b   | `>>u` (12)  |
+| `i64.shr_u` | `(i64, i64) : (i64)`        | [T], [U] | 0x66   | `>>u` (12)  |
 
 The `shr_u` instruction returns the value of the first operand [shifted] to the
 right by the [shift count].
@@ -1938,10 +1961,10 @@ of the shift count.
 
 #### Integer Rotate Left
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `i32.rotl`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb7
-| `i64.rotl`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb9
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `i32.rotl`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb7   |
+| `i64.rotl`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb9   |
 
 The `rotl` instruction returns the value of the first operand [rotated] to the
 left by the [shift count].
@@ -1952,10 +1975,10 @@ conceptually "rotate back around".
 
 #### Integer Rotate Right
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `i32.rotr`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb6
-| `i64.rotr`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb8
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `i32.rotr`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb6   |
+| `i64.rotr`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb8   |
 
 The `rotr` instruction returns the value of the first operand [rotated] to the
 right by the [shift count].
@@ -1966,10 +1989,10 @@ bits conceptually "rotate back around".
 
 #### Integer Count Leading Zeros
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `i32.clz`   | `(i32) : (i32)`             | [G]      | 0x57
-| `i64.clz`   | `(i64) : (i64)`             | [G]      | 0x72
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `i32.clz`   | `(i32) : (i32)`             | [G]      | 0x57   |
+| `i64.clz`   | `(i64) : (i64)`             | [G]      | 0x72   |
 
 The `clz` instruction returns the number of leading zeros in its operand. The
 *leading zeros* are the longest contiguous sequence of zero-bits starting at the
@@ -1980,10 +2003,10 @@ number of bits in the operand type.
 
 #### Integer Count Trailing Zeros
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `i32.ctz`   | `(i32) : (i32)`             | [G]      | 0x58
-| `i64.ctz`   | `(i64) : (i64)`             | [G]      | 0x73
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `i32.ctz`   | `(i32) : (i32)`             | [G]      | 0x58   |
+| `i64.ctz`   | `(i64) : (i64)`             | [G]      | 0x73   |
 
 The `ctz` instruction returns the number of trailing zeros in its operand. The
 *trailing zeros* are the longest contiguous sequence of zero-bits starting at
@@ -1994,10 +2017,10 @@ number of bits in the operand type.
 
 #### Integer Population Count
 
-| Mnemonic     | Signature                  | Families | Opcode
-| --------     | ---------                  | -------- | ------
-| `i32.popcnt` | `(i32) : (i32)`            | [G]      | 0x59
-| `i64.popcnt` | `(i64) : (i64)`            | [G]      | 0x74
+| Mnemonic     | Signature                  | Families | Opcode |
+| ------------ | -------------------------- | -------- | ------ |
+| `i32.popcnt` | `(i32) : (i32)`            | [G]      | 0x59   |
+| `i64.popcnt` | `(i64) : (i64)`            | [G]      | 0x74   |
 
 The `popcnt` instruction returns the number of 1-bits in its operand.
 
@@ -2010,10 +2033,10 @@ in other languages.
 
 #### Integer Equal To Zero
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.eqz`   | `(i32) : (i32)`             | [G]      | 0x5a   | `!` (15)
-| `i64.eqz`   | `(i64) : (i32)`             | [G]      | 0xba   | `!` (15)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.eqz`   | `(i32) : (i32)`             | [G]      | 0x5a   | `!` (15)    |
+| `i64.eqz`   | `(i64) : (i32)`             | [G]      | 0xba   | `!` (15)    |
 
 The `eqz` instruction returns [true] if the operand is equal to zero, or [false]
 otherwise.
@@ -2040,60 +2063,60 @@ otherwise.
 
 #### Floating-Point Add
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.add`   | `(f32, f32) : (f32)`        | [F]      | 0x75   | `+` (13)
-| `f64.add`   | `(f64, f64) : (f64)`        | [F]      | 0x89   | `+` (13)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.add`   | `(f32, f32) : (f32)`        | [F]      | 0x75   | `+` (13)    |
+| `f64.add`   | `(f64, f64) : (f64)`        | [F]      | 0x89   | `+` (13)    |
 
 The floating-point `add` instruction performs the IEEE 754-2008 `addition`
 operation according to the [general floating-point rules][F].
 
 #### Floating-Point Subtract
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.sub`   | `(f32, f32) : (f32)`        | [F]      | 0x76   | `-` (13)
-| `f64.sub`   | `(f64, f64) : (f64)`        | [F]      | 0x8a   | `-` (13)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.sub`   | `(f32, f32) : (f32)`        | [F]      | 0x76   | `-` (13)    |
+| `f64.sub`   | `(f64, f64) : (f64)`        | [F]      | 0x8a   | `-` (13)    |
 
 The floating-point `sub` instruction performs the IEEE 754-2008 `subtraction`
 operation according to the [general floating-point rules][F].
 
 #### Floating-Point Multiply
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.mul`   | `(f32, f32) : (f32)`        | [F]      | 0x77   | `*` (14)
-| `f64.mul`   | `(f64, f64) : (f64)`        | [F]      | 0x8b   | `*` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.mul`   | `(f32, f32) : (f32)`        | [F]      | 0x77   | `*` (14)    |
+| `f64.mul`   | `(f64, f64) : (f64)`        | [F]      | 0x8b   | `*` (14)    |
 
 The floating-point `mul` instruction performs the IEEE 754-2008 `multiplication`
 operation according to the [general floating-point rules][F].
 
 #### Floating-Point Divide
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.div`   | `(f32, f32) : (f32)`        | [F]      | 0x78   | `/` (14)
-| `f64.div`   | `(f64, f64) : (f64)`        | [F]      | 0x8c   | `/` (14)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.div`   | `(f32, f32) : (f32)`        | [F]      | 0x78   | `/` (14)    |
+| `f64.div`   | `(f64, f64) : (f64)`        | [F]      | 0x8c   | `/` (14)    |
 
 The `div` instruction performs the IEEE 754-2008 `division` operation according
 to the [general floating-point rules][F].
 
 #### Floating-Point Square Root
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.sqrt`  | `(f32) : (f32)`             | [F]      | 0x82
-| `f64.sqrt`  | `(f64) : (f64)`             | [F]      | 0x96
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.sqrt`  | `(f32) : (f32)`             | [F]      | 0x82   |
+| `f64.sqrt`  | `(f64) : (f64)`             | [F]      | 0x96   |
 
 The `sqrt` instruction performs the IEEE 754-2008 `squareRoot` operation
 according to the [general floating-point rules][F].
 
 #### Floating-Point Minimum
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.min`   | `(f32, f32) : (f32)`        | [F]      | 0x79
-| `f64.min`   | `(f64, f64) : (f64)`        | [F]      | 0x8d
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.min`   | `(f32, f32) : (f32)`        | [F]      | 0x79   |
+| `f64.min`   | `(f64, f64) : (f64)`        | [F]      | 0x8d   |
 
 The `min` instruction returns the minimum value among its operands. For this
 instruction, negative zero is considered less than zero. If either operand is a
@@ -2108,10 +2131,10 @@ negative zero and NaN values.
 
 #### Floating-Point Maximum
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.max`   | `(f32, f32) : (f32)`        | [F]      | 0x7a
-| `f64.max`   | `(f64, f64) : (f64)`        | [F]      | 0x8e
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.max`   | `(f32, f32) : (f32)`        | [F]      | 0x7a   |
+| `f64.max`   | `(f64, f64) : (f64)`        | [F]      | 0x8e   |
 
 The `max` instruction returns the maximum value among its operands. For this
 instruction, negative zero is considered less than zero. If either operand is a
@@ -2126,10 +2149,10 @@ zero and NaN values.
 
 #### Floating-Point Ceiling
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.ceil`  | `(f32) : (f32)`             | [F]      | 0x7e
-| `f64.ceil`  | `(f64) : (f64)`             | [F]      | 0x92
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.ceil`  | `(f32) : (f32)`             | [F]      | 0x7e   |
+| `f64.ceil`  | `(f64) : (f64)`             | [F]      | 0x92   |
 
 The `ceil` instruction performs the IEEE 754-2008
 `roundToIntegralTowardPositive` operation according to the
@@ -2140,10 +2163,10 @@ here; the value is rounded up to the nearest integer.
 
 #### Floating-Point Floor
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.floor` | `(f32) : (f32)`             | [F]      | 0x7f
-| `f64.floor` | `(f64) : (f64)`             | [F]      | 0x93
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.floor` | `(f32) : (f32)`             | [F]      | 0x7f   |
+| `f64.floor` | `(f64) : (f64)`             | [F]      | 0x93   |
 
 The `floor` instruction performs the IEEE 754-2008
 `roundToIntegralTowardNegative` operation according to the
@@ -2154,10 +2177,10 @@ here; the value is rounded down to the nearest integer.
 
 #### Floating-Point Truncate
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.trunc` | `(f32) : (f32)`             | [F]      | 0x80
-| `f64.trunc` | `(f64) : (f64)`             | [F]      | 0x94
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.trunc` | `(f32) : (f32)`             | [F]      | 0x80   |
+| `f64.trunc` | `(f64) : (f64)`             | [F]      | 0x94   |
 
 The `trunc` instruction performs the IEEE 754-2008
 `roundToIntegralTowardZero` operation according to the
@@ -2170,10 +2193,10 @@ the value is discarded, effectively rounding to the nearest integer toward zero.
 
 #### Floating-Point Nearest Integer
 
-| Mnemonic      | Signature                 | Families | Opcode
-| --------      | ---------                 | -------- | ------
-| `f32.nearest` | `(f32) : (f32)`           | [F]      | 0x81
-| `f64.nearest` | `(f64) : (f64)`           | [F]      | 0x95
+| Mnemonic      | Signature                 | Families | Opcode |
+| ------------- | ------------------------- | -------- | ------ |
+| `f32.nearest` | `(f32) : (f32)`           | [F]      | 0x81   |
+| `f64.nearest` | `(f64) : (f64)`           | [F]      | 0x95   |
 
 The `nearest` instruction performs the IEEE 754-2008
 `roundToIntegralTiesToEven` operation according to the
@@ -2193,10 +2216,10 @@ up, and it differs from [`round` in C] which rounds ties away from zero.
 
 #### Floating-Point Absolute Value
 
-| Mnemonic    | Signature                   | Families | Opcode
-| --------    | ---------                   | -------- | ------
-| `f32.abs`   | `(f32) : (f32)`             | [Z]      | 0x7b
-| `f64.abs`   | `(f64) : (f64)`             | [Z]      | 0x8f
+| Mnemonic    | Signature                   | Families | Opcode |
+| ----------- | --------------------------- | -------- | ------ |
+| `f32.abs`   | `(f32) : (f32)`             | [Z]      | 0x7b   |
+| `f64.abs`   | `(f64) : (f64)`             | [Z]      | 0x8f   |
 
 The `abs` instruction performs the IEEE 754-2008 `abs` operation.
 
@@ -2209,10 +2232,10 @@ values as not less than zero.
 
 #### Floating-Point Negate
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.neg`   | `(f32) : (f32)`             | [Z]      | 0x7c   | `-` (15)
-| `f64.neg`   | `(f64) : (f64)`             | [Z]      | 0x90   | `-` (15)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.neg`   | `(f32) : (f32)`             | [Z]      | 0x7c   | `-` (15)    |
+| `f64.neg`   | `(f64) : (f64)`             | [Z]      | 0x90   | `-` (15)    |
 
 The `neg` instruction performs the IEEE 754-2008 `negate` operation.
 
@@ -2226,10 +2249,10 @@ values.
 
 #### Floating-Point CopySign
 
-| Mnemonic       | Signature                | Families | Opcode
-| --------       | ---------                | -------- | ------
-| `f32.copysign` | `(f32, f32) : (f32)`     | [Z]      | 0x7d
-| `f64.copysign` | `(f64, f64) : (f64)`     | [Z]      | 0x91
+| Mnemonic       | Signature                | Families | Opcode |
+| -------------- | ------------------------ | -------- | ------ |
+| `f32.copysign` | `(f32, f32) : (f32)`     | [Z]      | 0x7d   |
+| `f64.copysign` | `(f64, f64) : (f64)`     | [Z]      | 0x91   |
 
 The `copysign` instruction performs the IEEE 754-2008 `copySign` operation.
 
@@ -2252,19 +2275,19 @@ either operand is a NaN or a zero.
 
 #### Integer Equality
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.eq`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4d   | `==` (10)
-| `i64.eq`    | `(i64, i64) : (i32)`        | [C], [G] | 0x68   | `==` (10)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.eq`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4d   | `==` (10)   |
+| `i64.eq`    | `(i64, i64) : (i32)`        | [C], [G] | 0x68   | `==` (10)   |
 
 The integer `eq` instruction tests whether the operands are equal.
 
 #### Integer Inequality
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.ne`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4e   | `!=` (10)
-| `i64.ne`    | `(i64, i64) : (i32)`        | [C], [G] | 0x69   | `!=` (10)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.ne`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4e   | `!=` (10)   |
+| `i64.ne`    | `(i64, i64) : (i32)`        | [C], [G] | 0x69   | `!=` (10)   |
 
 The integer `ne` instruction tests whether the operands are not equal.
 
@@ -2273,30 +2296,30 @@ languages.
 
 #### Integer Less Than, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.lt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x4f   | `<s` (11)
-| `i64.lt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6a   | `<s` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.lt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x4f   | `<s` (11)   |
+| `i64.lt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6a   | `<s` (11)   |
 
 The `lt_s` instruction tests whether the first operand is less than the second
 operand, interpreting the operands as signed.
 
 #### Integer Less Than, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.lt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x51   | `<u` (11)
-| `i64.lt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6c   | `<u` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.lt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x51   | `<u` (11)   |
+| `i64.lt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6c   | `<u` (11)   |
 
 The `lt_u` instruction tests whether the first operand is less than the second
 operand, interpreting the operands as unsigned.
 
 #### Integer Less Than Or Equal To, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.le_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x50   | `<=s` (11)
-| `i64.le_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6b   | `<=s` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.le_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x50   | `<=s` (11)  |
+| `i64.le_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6b   | `<=s` (11)  |
 
 The `le_s` instruction tests whether the first operand is less than or equal to
 the second operand, interpreting the operands as signed.
@@ -2306,10 +2329,10 @@ languages.
 
 #### Integer Less Than Or Equal To, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.le_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x52   | `<=u` (11)
-| `i64.le_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6d   | `<=u` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.le_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x52   | `<=u` (11)  |
+| `i64.le_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6d   | `<=u` (11)  |
 
 The `le_u` instruction tests whether the first operand is less than or equal to
 the second operand, interpreting the operands as unsigned.
@@ -2319,30 +2342,30 @@ languages.
 
 #### Integer Greater Than, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.gt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x53   | `>s` (11)
-| `i64.gt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6e   | `>s` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.gt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x53   | `>s` (11)   |
+| `i64.gt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6e   | `>s` (11)   |
 
 The `gt_s` instruction tests whether the first operand is greater than the
 second operand, interpreting the operands as signed.
 
 #### Integer Greater Than, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.gt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x55   | `>u` (11)
-| `i64.gt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x70   | `>u` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.gt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x55   | `>u` (11)   |
+| `i64.gt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x70   | `>u` (11)   |
 
 The `gt_u` instruction tests whether the first operand is greater than the
 second operand, interpreting the operands as unsigned.
 
 #### Integer Greater Than Or Equal To, Signed
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.ge_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x54   | `>=s` (11)
-| `i64.ge_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6f   | `>=s` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.ge_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x54   | `>=s` (11)  |
+| `i64.ge_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6f   | `>=s` (11)  |
 
 The `ge_s` instruction tests whether the first operand is greater than or equal
 to the second operand, interpreting the operands as signed.
@@ -2352,10 +2375,10 @@ languages.
 
 #### Integer Greater Than Or Equal To, Unsigned
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `i32.ge_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x56   | `>=u` (11)
-| `i64.ge_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x71   | `>=u` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `i32.ge_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x56   | `>=u` (11)  |
+| `i64.ge_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x71   | `>=u` (11)  |
 
 The `ge_u` instruction tests whether the first operand is greater than or equal
 to the second operand, interpreting the operands as unsigned.
@@ -2374,10 +2397,10 @@ languages.
 
 #### Floating-Point Equality
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.eq`    | `(f32, f32) : (i32)`        | [C], [F] | 0x83   | `==` (10)
-| `f64.eq`    | `(f64, f64) : (i32)`        | [C], [F] | 0x97   | `==` (10)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.eq`    | `(f32, f32) : (i32)`        | [C], [F] | 0x83   | `==` (10)   |
+| `f64.eq`    | `(f64, f64) : (i32)`        | [C], [F] | 0x97   | `==` (10)   |
 
 The floating-point `eq` instruction performs the IEEE 754-2008
 `compareQuietEqual` operation according to the
@@ -2385,10 +2408,10 @@ The floating-point `eq` instruction performs the IEEE 754-2008
 
 #### Floating-Point Inequality
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.ne`    | `(f32, f32) : (i32)`        | [C], [F] | 0x84   | `!=` (10)
-| `f64.ne`    | `(f64, f64) : (i32)`        | [C], [F] | 0x98   | `!=` (10)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.ne`    | `(f32, f32) : (i32)`        | [C], [F] | 0x84   | `!=` (10)   |
+| `f64.ne`    | `(f64, f64) : (i32)`        | [C], [F] | 0x98   | `!=` (10)   |
 
 The floating-point `ne` instruction performs the IEEE 754-2008
 `compareQuietNotEqual` operation according to the
@@ -2400,40 +2423,40 @@ instruction.
 
 #### Floating-Point Less Than
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.lt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x85   | `<` (11)
-| `f64.lt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x99   | `<` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.lt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x85   | `<` (11)    |
+| `f64.lt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x99   | `<` (11)    |
 
 The `lt` instruction performs the IEEE 754-2008 `compareQuietLess` operation
 according to the [general floating-point rules][F].
 
 #### Floating-Point Less Than Or Equal To
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.le`    | `(f32, f32) : (i32)`        | [C], [F] | 0x86   | `<=` (11)
-| `f64.le`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9a   | `<=` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.le`    | `(f32, f32) : (i32)`        | [C], [F] | 0x86   | `<=` (11)   |
+| `f64.le`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9a   | `<=` (11)   |
 
 The `le` instruction performs the IEEE 754-2008 `compareQuietLessEqual`
 operation according to the [general floating-point rules][F].
 
 #### Floating-Point Greater Than
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.gt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x87   | `>` (11)
-| `f64.gt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9b   | `>` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.gt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x87   | `>` (11)    |
+| `f64.gt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9b   | `>` (11)    |
 
 The `gt` instruction performs the IEEE 754-2008 `compareQuietGreater` operation
 according to the [general floating-point rules][F].
 
 #### Floating-Point Greater Than Or Equal To
 
-| Mnemonic    | Signature                   | Families | Opcode | Syntax
-| --------    | ---------                   | -------- | ------ | ------
-| `f32.ge`    | `(f32, f32) : (i32)`        | [C], [F] | 0x88   | `>=` (11)
-| `f64.ge`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9c   | `>=` (11)
+| Mnemonic    | Signature                   | Families | Opcode | Syntax      |
+| ----------- | --------------------------- | -------- | ------ | ----------- |
+| `f32.ge`    | `(f32, f32) : (i32)`        | [C], [F] | 0x88   | `>=` (11)   |
+| `f64.ge`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9c   | `>=` (11)   |
 
 The `ge` instruction performs the IEEE 754-2008 `compareQuietGreaterEqual`
 operation according to the [general floating-point rules][F].
@@ -2453,9 +2476,9 @@ operation according to the [general floating-point rules][F].
 
 #### Integer Wrap
 
-| Mnemonic       | Signature                | Families | Opcode
-| --------       | ---------                | -------- | ------
-| `i32.wrap/i64` | `(i64) : (i32)`          | [G]      | 0xa1
+| Mnemonic       | Signature                | Families | Opcode |
+| -------------- | ------------------------ | -------- | ------ |
+| `i32.wrap/i64` | `(i64) : (i32)`          | [G]      | 0xa1   |
 
 The `wrap` instruction returns the value of its operand silently wrapped to its
 result type. Wrapping means reducing the value modulo the number of unique
@@ -2468,30 +2491,30 @@ effectively discarding the most significant digits.
 
 #### Integer Extend, Signed
 
-| Mnemonic           | Signature            | Families | Opcode
-| --------           | ---------            | -------- | ------
-| `i64.extend_s/i32` | `(i32) : (i64)`      | [S]      | 0xa6
+| Mnemonic           | Signature            | Families | Opcode |
+| ------------------ | -------------------- | -------- | ------ |
+| `i64.extend_s/i32` | `(i32) : (i64)`      | [S]      | 0xa6   |
 
 The `extend_s` instruction returns the value of its operand [sign-extended] to
 its result type.
 
 #### Integer Extend, Unsigned
 
-| Mnemonic           | Signature            | Families | Opcode
-| --------           | ---------            | -------- | ------
-| `i64.extend_u/i32` | `(i32) : (i64)`      | [U]      | 0xa7
+| Mnemonic           | Signature            | Families | Opcode |
+| ------------------ | -------------------- | -------- | ------ |
+| `i64.extend_u/i32` | `(i32) : (i64)`      | [U]      | 0xa7   |
 
 The `extend_u` instruction returns the value of its operand zero-extended to its
 result type.
 
 #### Truncate Floating-Point to Integer, Signed
 
-| Mnemonic          | Signature             | Families | Opcode
-| --------          | ---------             | -------- | ------
-| `i32.trunc_s/f32` | `(f32) : (i32)`       | [F], [S] | 0x9d
-| `i32.trunc_s/f64` | `(f64) : (i32)`       | [F], [S] | 0x9e
-| `i64.trunc_s/f32` | `(f32) : (i64)`       | [F], [S] | 0xa2
-| `i64.trunc_s/f64` | `(f64) : (i64)`       | [F], [S] | 0xa3
+| Mnemonic          | Signature             | Families | Opcode |
+| ----------------- | --------------------- | -------- | ------ |
+| `i32.trunc_s/f32` | `(f32) : (i32)`       | [F], [S] | 0x9d   |
+| `i32.trunc_s/f64` | `(f64) : (i32)`       | [F], [S] | 0x9e   |
+| `i64.trunc_s/f32` | `(f32) : (i64)`       | [F], [S] | 0xa2   |
+| `i64.trunc_s/f64` | `(f64) : (i64)`       | [F], [S] | 0xa3   |
 
 The `trunc_s` instruction performs the IEEE 754-2008
 `convertToIntegerTowardZero` operation, with the result value interpreted as
@@ -2503,12 +2526,12 @@ occurs, due to the operand being outside the range that can be converted
 
 #### Truncate Floating-Point to Integer, Unsigned
 
-| Mnemonic          | Signature             | Families | Opcode
-| --------          | ---------             | -------- | ------
-| `i32.trunc_u/f32` | `(f32) : (i32)`       | [F], [U] | 0x9f
-| `i32.trunc_u/f64` | `(f64) : (i32)`       | [F], [U] | 0xa0
-| `i64.trunc_u/f32` | `(f32) : (i64)`       | [F], [U] | 0xa4
-| `i64.trunc_u/f64` | `(f64) : (i64)`       | [F], [U] | 0xa5
+| Mnemonic          | Signature             | Families | Opcode |
+| ----------------- | --------------------- | -------- | ------ |
+| `i32.trunc_u/f32` | `(f32) : (i32)`       | [F], [U] | 0x9f   |
+| `i32.trunc_u/f64` | `(f64) : (i32)`       | [F], [U] | 0xa0   |
+| `i64.trunc_u/f32` | `(f32) : (i64)`       | [F], [U] | 0xa4   |
+| `i64.trunc_u/f64` | `(f64) : (i64)`       | [F], [U] | 0xa5   |
 
 The `trunc_u` instruction performs the IEEE 754-2008
 `convertToIntegerTowardZero` operation, with the result value interpreted as
@@ -2524,9 +2547,9 @@ truncate up to zero.
 
 #### Floating-Point Demote
 
-| Mnemonic         | Signature              | Families | Opcode
-| --------         | ---------              | -------- | ------
-| `f32.demote/f64` | `(f64) : (f32)`        | [F]      | 0xac
+| Mnemonic         | Signature              | Families | Opcode |
+| ---------------- | ---------------------- | -------- | ------ |
+| `f32.demote/f64` | `(f64) : (f32)`        | [F]      | 0xac   |
 
 The `demote` instruction performs the IEEE 754-2008 `convertFormat` operation,
 converting from its operand type to its result type, according to the
@@ -2536,9 +2559,9 @@ converting from its operand type to its result type, according to the
 
 #### Floating-Point Promote
 
-| Mnemonic          | Signature             | Families | Opcode
-| --------          | ---------             | -------- | ------
-| `f64.promote/f32` | `(f32) : (f64)`       | [F]      | 0xb2
+| Mnemonic          | Signature             | Families | Opcode |
+| ----------------- | --------------------- | -------- | ------ |
+| `f64.promote/f32` | `(f32) : (f64)`       | [F]      | 0xb2   |
 
 The `promote` instruction performs the IEEE 754-2008 `convertFormat` operation,
 converting from its operand type to its result type, according to the
@@ -2548,38 +2571,42 @@ converting from its operand type to its result type, according to the
 
 #### Convert Integer To Floating-Point, Signed
 
-| Mnemonic            | Signature           | Families | Opcode
-| --------            | ---------           | -------- | ------
-| `f32.convert_s/i32` | `(i32) : (f32)`     | [F], [S] | 0xa8
-| `f32.convert_s/i64` | `(i64) : (f32)`     | [F], [S] | 0xaa
-| `f64.convert_s/i32` | `(i32) : (f64)`     | [F], [S] | 0xae
-| `f64.convert_s/i64` | `(i64) : (f64)`     | [F], [S] | 0xb0
+| Mnemonic            | Signature           | Families | Opcode |
+| ------------------- | ------------------- | -------- | ------ |
+| `f32.convert_s/i32` | `(i32) : (f32)`     | [F], [S] | 0xa8   |
+| `f32.convert_s/i64` | `(i64) : (f32)`     | [F], [S] | 0xaa   |
+| `f64.convert_s/i32` | `(i32) : (f64)`     | [F], [S] | 0xae   |
+| `f64.convert_s/i64` | `(i64) : (f64)`     | [F], [S] | 0xb0   |
 
 The `convert_s` instruction performs the IEEE 754-2008 `convertFromInt`
 operation, with its operand value interpreted as signed, according to the
 [general floating-point rules][F].
 
+> `f64.convert_s/i32` is always exact; the other instructions here may round.
+
 #### Convert Integer To Floating-Point, Unsigned
 
-| Mnemonic            | Signature           | Families | Opcode
-| --------            | ---------           | -------- | ------
-| `f32.convert_u/i32` | `(i32) : (f32)`     | [F], [U] | 0xa9
-| `f32.convert_u/i64` | `(i64) : (f32)`     | [F], [U] | 0xab
-| `f64.convert_u/i32` | `(i32) : (f64)`     | [F], [U] | 0xaf
-| `f64.convert_u/i64` | `(i64) : (f64)`     | [F], [U] | 0xb1
+| Mnemonic            | Signature           | Families | Opcode |
+| ------------------- | ------------------- | -------- | ------ |
+| `f32.convert_u/i32` | `(i32) : (f32)`     | [F], [U] | 0xa9   |
+| `f32.convert_u/i64` | `(i64) : (f32)`     | [F], [U] | 0xab   |
+| `f64.convert_u/i32` | `(i32) : (f64)`     | [F], [U] | 0xaf   |
+| `f64.convert_u/i64` | `(i64) : (f64)`     | [F], [U] | 0xb1   |
 
 The `convert_u` instruction performs the IEEE 754-2008 `convertFromInt`
 operation, with its operand value interpreted as unsigned, according to the
 [general floating-point rules][F].
 
+> `f64.convert_u/i32` is always exact; the other instructions here may round.
+
 #### Reinterpret
 
-| Mnemonic              | Signature         | Families | Opcode
-| --------              | ---------         | -------- | ------
-| `i32.reinterpret/f32` | `(f32) : (i32)`   |          | 0xb4
-| `i64.reinterpret/f64` | `(f64) : (i64)`   |          | 0xb5
-| `f32.reinterpret/i32` | `(i32) : (f32)`   |          | 0xad
-| `f64.reinterpret/i64` | `(i64) : (f64)`   |          | 0xb3
+| Mnemonic              | Signature         | Families | Opcode |
+| --------------------- | ----------------- | -------- | ------ |
+| `i32.reinterpret/f32` | `(f32) : (i32)`   |          | 0xb4   |
+| `i64.reinterpret/f64` | `(f64) : (i64)`   |          | 0xb5   |
+| `f32.reinterpret/i32` | `(i32) : (f32)`   |          | 0xad   |
+| `f64.reinterpret/i64` | `(i64) : (f64)`   |          | 0xb3   |
 
 The `reinterpret` instruction returns a value which has the same bit-pattern as
 its operand value, in its result type.
@@ -2597,12 +2624,12 @@ instruction is always exact.
 
 #### Load
 
-| Mnemonic    | Signature                                             | Families | Opcode
-| --------    | ---------                                             | -------- | ------
-| `i32.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [G] | 0x2a
-| `i64.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [G] | 0x2b
-| `f32.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (f32)` | [M], [Z] | 0x2c
-| `f64.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (f64)` | [M], [Z] | 0x2d
+| Mnemonic    | Signature                                             | Families | Opcode |
+| ----------- | ----------------------------------------------------- | -------- | ------ |
+| `i32.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [G] | 0x2a   |
+| `i64.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [G] | 0x2b   |
+| `f32.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (f32)` | [M], [Z] | 0x2c   |
+| `f64.load`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (f64)` | [M], [Z] | 0x2d   |
 
 The `load` instruction performs a [load](#loading) of the same size as its type.
 
@@ -2614,12 +2641,12 @@ IEEE 754-2008 `copy` operation.
 
 #### Store
 
-| Mnemonic    | Signature                                                       | Families | Opcode
-| --------    | ---------                                                       | -------- | ------
-| `i32.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x33
-| `i64.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x34
-| `f32.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f32) : ()` | [M], [F] | 0x35
-| `f64.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f64) : ()` | [M], [F] | 0x36
+| Mnemonic    | Signature                                                       | Families | Opcode |
+| ----------- | --------------------------------------------------------------- | -------- | ------ |
+| `i32.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x33   |
+| `i64.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x34   |
+| `f32.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f32) : ()` | [M], [F] | 0x35   |
+| `f64.store` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: f64) : ()` | [M], [F] | 0x36   |
 
 The `store` instruction performs a [store](#storing) of `$value` of the same
 size as its type.
@@ -2632,14 +2659,14 @@ IEEE 754-2008 `copy` operation.
 
 #### Extending Load, Signed
 
-| Mnemonic       | Signature                                             | Families | Opcode
-| --------       | ---------                                             | -------- | ------
-| `i32.load8_s`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [S] | 0x20
-| `i32.load16_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [S] | 0x22
+| Mnemonic       | Signature                                             | Families | Opcode |
+| -------------- | ----------------------------------------------------- | -------- | ------ |
+| `i32.load8_s`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [S] | 0x20   |
+| `i32.load16_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [S] | 0x22   |
 |                |                                                       |          |
-| `i64.load8_s`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x24
-| `i64.load16_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x26
-| `i64.load32_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x28
+| `i64.load8_s`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x24   |
+| `i64.load16_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x26   |
+| `i64.load32_s` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [S] | 0x28   |
 
 The signed extending load instructions perform a [load](#loading) of narrower
 width than their type, and return the value [sign-extended] to their type.
@@ -2652,14 +2679,14 @@ width than their type, and return the value [sign-extended] to their type.
 
 #### Extending Load, Unsigned
 
-| Mnemonic       | Signature                                             | Families | Opcode
-| --------       | ---------                                             | -------- | ------
-| `i32.load8_u`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [U] | 0x21
-| `i32.load16_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [U] | 0x23
-|                |                                                       |          |
-| `i64.load8_u`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x25
-| `i64.load16_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x27
-| `i64.load32_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x29
+| Mnemonic       | Signature                                             | Families | Opcode |
+| -------------- | ----------------------------------------------------- | -------- | ------ |
+| `i32.load8_u`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [U] | 0x21   |
+| `i32.load16_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i32)` | [M], [U] | 0x23   |
+|                |                                                       |          |        |
+| `i64.load8_u`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x25   |
+| `i64.load16_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x27   |
+| `i64.load32_u` | `<$offset: iPTR, $align: iPTR> ($base: iPTR) : (i64)` | [M], [U] | 0x29   |
 
 The unsigned extending load instructions perform a [load](#loading) of narrower
 width than their type, and return the value zero-extended to their type.
@@ -2672,14 +2699,14 @@ width than their type, and return the value zero-extended to their type.
 
 #### Wrapping Store
 
-| Mnemonic      | Signature                                                       | Families | Opcode
-| --------      | ---------                                                       | -------- | ------
-| `i32.store8`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x2e
-| `i32.store16` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x2f
-|               |                                                                 |          |
-| `i64.store8`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x30
-| `i64.store16` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x31
-| `i64.store32` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x32
+| Mnemonic      | Signature                                                       | Families | Opcode |
+| ------------- | --------------------------------------------------------------- | -------- | ------ |
+| `i32.store8`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x2e   |
+| `i32.store16` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i32) : ()` | [M], [G] | 0x2f   |
+|               |                                                                 |          |        |
+| `i64.store8`  | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x30   |
+| `i64.store16` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x31   |
+| `i64.store32` | `<$offset: iPTR, $align: iPTR> ($base: iPTR, $value: i64) : ()` | [M], [G] | 0x32   |
 
 The wrapping store instructions performs a [store](#storing) of `$value`
 silently wrapped to a narrower width.
@@ -2695,44 +2722,45 @@ the name "wrap".
 
 ### Additional Memory-Related Instructions
 
-0. [Grow Memory](#grow-memory)
-0. [Current Memory](#current-memory)
+0. [Grow Linear-Memory Size](#grow-linear-memory-size)
+0. [Current Linear-Memory Size](#current-linear-memory-size)
 
-#### Grow Memory
+#### Grow Linear-Memory Size
 
-| Mnemonic      | Signature                 | Families | Opcode
-| --------      | ---------                 | -------- | ------
-| `grow_memory` | `(iPTR) : (iPTR)`         | [R]      | 0x39
+| Mnemonic      | Signature                 | Families | Opcode |
+| ------------- | ------------------------- | -------- | ------ |
+| `grow_memory` | `(iPTR) : (iPTR)`         | [R]      | 0x39   |
 
-The `grow_memory` instruction increases the size of the referenced linear memory
+The `grow_memory` instruction increases the size of the referenced linear-memory
 space by a given unsigned amount, in units of [pages]. If the index of any byte
 of the referenced linear-memory space would be unrepresentable in an unsigned
-`iPTR`, or if allocation fails due to insufficient dynamic resources, it returns
-`-1`; otherwise it returns the previous linear memory size, also as an unsigned
-value in units of [pages].
-
-When a maximum size is present in the referenced linear-memory space,
-`grow_memory` fails if it would grow past the maximum. However, `grow_memory`
-may still fail before the maximum if it wasn't possible to reserve the space up
-front or if enabling the reserved memory fails.
+`iPTR`, or if allocation fails due to insufficient dynamic resources, or if the
+referenced linear-memory space has a maximum size that the linear-memory size
+would exceed, it returns `-1`; otherwise it returns the previous linear-memory
+size, also as an unsigned value in units of [pages].
 
 **Validation**:
- - [Linear memory size validation](#linear-memory-size-validation) is required.
+ - [Linear-memory size validation](#linear-memory-size-validation) is required.
+
+> This instruction can fail even when a maximum size is present and not yet
+reached.
 
 > Since the return value is in units of pages, `-1` isn't otherwise a valid
-linear memory size.
+linear-memory size.
 
-#### Current Memory
+TODO: Rename this and `current_memory` to have "linear" in the mnemonic?
 
-| Mnemonic         | Signature              | Families | Opcode
-| --------         | ---------              | -------- | ------
-| `current_memory` | `() : (iPTR)`          | [R]      | 0x3b
+#### Current Linear-Memory Size
 
-The `current_memory` instruction returns the size of the referenced linear
-memory space, as an unsigned value in units of [pages].
+| Mnemonic         | Signature              | Families | Opcode |
+| ---------------- | ---------------------- | -------- | ------ |
+| `current_memory` | `() : (iPTR)`          | [R]      | 0x3b   |
+
+The `current_memory` instruction returns the size of the referenced
+linear-memory space, as an unsigned value in units of [pages].
 
 **Validation**:
- - [Linear memory size validation](#linear-memory-size-validation) is required.
+ - [Linear-memory size validation](#linear-memory-size-validation) is required.
 
 [M]: #m-linear-memory-access-instruction-family
 [R]: #r-linear-memory-size-instruction-family
@@ -2758,10 +2786,10 @@ memory space, as an unsigned value in units of [pages].
 [Global Section]: #global-section
 [Element Section]: #element-section
 [Name Section]: #name-section
-[Function Index Space]: #function-index-space
-[Global Index Space]: #global-index-space
-[Linear-Memory Index Space]: #linear-memory-index-space
-[Table Index Space]: #table-index-space
+[function Index space]: #function-index-space
+[global index space]: #global-index-space
+[linear-memory index space]: #linear-memory-index-space
+[table index space]: #table-index-space
 [accessed bytes]: #accessed-bytes
 [array]: #array
 [arrays]: #array

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -308,8 +308,8 @@ data to be loaded into linear memory as part of
  - For each element of the array, the sum of the start offset and the length of
    the string is required to be less than the initial size declared in the
    [Memory Section](#memory-section).
- - The start offset of each element of the array is required to be greater
-   than the index of any byte initialized by elements that precede it.
+ - The start offset of each element of the array is required to be greater than
+   the index of any byte initialized by elements that precede it.
 
 #### Global Section
 
@@ -408,9 +408,9 @@ instruction in the sequence is required to be an [`end`](#end).
 For each instruction in the body, in sequence order:
  - For each construct in the instruction's signature's operands in reverse
    order:
-    - If the element is a [type], a type is popped from the type stack and
+    - If the construct is a [type], a type is popped from the type stack and
       required to be the same.
-    - If the element is a list of type parameters, and the parameters are not
+    - If the construct is a list of type parameters, and the parameters are not
       yet bound, a type for each type parameter in the list in reverse order is
       popped from the type stack and bound to it.
     - Otherwise, a type for each type in the list in reverse order is popped
@@ -418,8 +418,8 @@ For each instruction in the body, in sequence order:
    The popped types in reverse (again) order form the *operand sequence*.
  - Unless the instruction is a [control-flow barrier][Q], then for each
    construct in the instruction's signature's returns:
-    - If the element is a [type], a type is pushed onto the type stack.
-    - If the element is a list of type parameters, they are required to be
+    - If the construct is a [type], a type is pushed onto the type stack.
+    - If the construct is a list of type parameters, they are required to be
       bound, and the type bound to each type parameter is pushed onto the type
       stack.
  - If the instruction has a **Validation** clause, its requirements are
@@ -443,7 +443,7 @@ type stack outside a region cannot be popped from within the region.
 > There are no implicit type conversions in WebAssembly.
 
 TODO: Will the `end` be made explicit? Monitor
-https://github.com/WebAssembly/design/pull/666.
+https://github.com/WebAssembly/design/pull/666
 
 #### Type-Sequence Merge
 
@@ -494,8 +494,8 @@ support creation of the array.
 #### Call Stack Resources
 
 Call stack resources are an abstract quantity, with discrete units, of which a
-[nondeterministic] amount is allocated during instantiation, belonging to
-an instance.
+[nondeterministic] amount is allocated during instantiation, belonging to an
+instance.
 
 > This is used by [call instructions][L].
 
@@ -546,7 +546,7 @@ bit-pattern values.
 
 The instruction at the current position is remembered, and the current position
 is incremented to point to the position following it. Then the remembered
-instruction is executed as follows.
+instruction is executed as follows:
 
 For each operand [type] in the instruction's signature in reverse order, a value
 is popped from the value stack and provided as the corresponding operand value.
@@ -761,7 +761,7 @@ For a store access, the value to store is written to the [accessed bytes], in
  - The module is required to contain a [Memory Section](#memory-section).
 
 TODO: Will offsets be encoded as signed? Monitor
-https://github.com/WebAssembly/design/issues/584.
+https://github.com/WebAssembly/design/issues/584
 
 [power of 2]: https://en.wikipedia.org/wiki/Power_of_two
 
@@ -785,7 +785,7 @@ is resized down to the entry's limit value.
 
 Then, if the entry's [label] is bound, the current position is set to the bound
 position. Otherwise, the position to bind the label to is found by scanning
-forward through the instructions, executing just [`block`](#block),
+forward through the instructions, as if executing just [`block`](#block),
 [`loop`](#loop), and [`end`](#end) instructions, until the label is bound. Then
 the current position is set to that position.
 
@@ -901,7 +901,7 @@ by one of the following rules, selected [nondeterministically]:
    remaining bits.
 
 TODO: How does NaN propagation work? Monitor
-https://github.com/WebAssembly/design/pull/713.
+https://github.com/WebAssembly/design/pull/713
 
 Implementations are permitted to further implement the IEEE 754-2008 section
 "Operations with NaNs" recommendation that operations propagate NaN bits from
@@ -988,11 +988,14 @@ The `loop` instruction binds a [label] to the current position and pushes it
 onto the control-flow stack.
 
 **Validation:**
- - An entry is pushed onto the control-flow stack containing no type sequence,
-   and a limit value of the current length of the type stack.
+ - An entry is pushed onto the control-flow stack containing an empty type
+   sequence, and a limit value of the current length of the type stack.
 
 > The `loop` instruction does not perform a loop by itself. It merely introduces
-label that may be used by a branch to form an actual loop.
+a label that may be used by a branch to form an actual loop.
+
+> Since `loop`'s control-flow stack entry starts with an empty type sequence,
+branches to the top of the loop must not have any result values.
 
 > Each `loop` needs a corresponding [`end`](#end) to pop its label from the
 stack.
@@ -1017,9 +1020,6 @@ entry `$depth` from the top. It returns the values of its operands.
  - The operand sequence is [merged] into the control-flow stack entry `$depth`
    from the top.
 
-TODO: If the control-flow stack entry `$depth` from the top is for a `loop` we
-can't forward a value to it. Same for `br_if` and `br_table`.
-
 TODO: This is currently anticipating a proposal to make `br`, `br_table`,
 `return`, and `unreachable` return "void" rather than "any".
 
@@ -1041,7 +1041,8 @@ does nothing. It returns the values of its operands, except `$condition`.
 > This instruction's `$arity` has a different constraint than others; this is
 intentional and possibly temporary.
 
-TODO: Monitor https://github.com/WebAssembly/design/pull/709.
+TODO: Will `br_if`'s `$arity` be changed? Monitor
+https://github.com/WebAssembly/design/pull/709
 
 #### Table Branch
 
@@ -1082,7 +1083,7 @@ The `if` instruction pushes an unbound [label] onto the control-flow stack. If
    and a limit value of the current length of the type stack.
 
 TODO: Do `if`/`else` have labels? Monitor
-https://github.com/WebAssembly/design/pull/710.
+https://github.com/WebAssembly/design/pull/710
 
 > Each `if` needs either a corresponding [`else`](#else) or [`end`](#end).
 
@@ -1102,8 +1103,8 @@ label. It returns the values of its operands.
    from the top.
  - An entry is popped off the control-flow stack.
  - A new entry is pushed onto the control-flow stack containing the operand
-   sequence as its type sequence, and a limit value of the current length of
-   the type stack.
+   sequence as its type sequence, and a limit value of the current length of the
+   type stack.
 
 > Each `else` needs a corresponding [`end`](#end).
 
@@ -1165,7 +1166,6 @@ be executed except in the case of a bug in the application.
 0. [Call](#call)
 0. [Indirect Call](#indirect-call)
 
-
 #### Nop
 
 | Name        | Signature                   | Families | Opcode
@@ -1197,6 +1197,9 @@ discard unneeded values from the value stack.
 The `const` instruction returns the value of its immediate.
 
 > Floating-point constants can be created with arbitrary bit-patterns.
+
+TODO: This anticipates sanitizing `f32.const`'s opcode. Monitor
+https://github.com/WebAssembly/design/pull/696
 
 #### Get Local
 
@@ -1257,7 +1260,7 @@ to the value given in the operand.
 
 | Name        | Signature                                | Families | Opcode
 | ----        | ---------                                | -------- | ------
-| `select`    | `(T[1], T[1], $condition: i32) : (T[1])` |          | 0x05
+| `select`    | `(T[1], T[1], $condition: i32) : (T[1])` |          | 0x16
 
 The `select` instruction returns its first operand if `$condition` is [true], or
 its second operand otherwise.
@@ -1265,11 +1268,14 @@ its second operand otherwise.
 > This instruction differs from the conditional or ternary operator, eg.
 `x?y:z`, in some languages, in that it's not short-circuiting.
 
+TODO: This anticipates sanitizing `select`'s opcode. Monitor
+https://github.com/WebAssembly/design/pull/695
+
 #### Call
 
 | Name        | Signature                                                | Families | Opcode
 | ----        | ---------                                                | -------- | ------
-| `call`      | `<$arity: i32, $callee: i32> (T[$args]) : (T[$returns])` | [L]      | 0x16
+| `call`      | `<$arity: i32, $callee: i32> (T[$args]) : (T[$returns])` | [L]      | 0x17
 
 The `call` instruction performs a [call](#calling) to the function with index
 `$callee`.
@@ -1281,11 +1287,14 @@ Validation:
 TODO: Update index space, per
 https://github.com/WebAssembly/design/pull/682
 
+TODO: This anticipates sanitizing `select`'s opcode. Monitor
+https://github.com/WebAssembly/design/pull/695
+
 #### Indirect Call
 
 | Name            | Signature                                                                 | Families | Opcode
 | ----            | ---------                                                                 | -------- | ------
-| `call_indirect` | `<$arity: i32, $signature: i32> ($callee: i32, T[$args]) : (T[$returns])` | [L]      | 0x17
+| `call_indirect` | `<$arity: i32, $signature: i32> ($callee: i32, T[$args]) : (T[$returns])` | [L]      | 0x18
 
 The `call_indirect` instruction performs a [call](#calling) to the function with
 index `$callee`.
@@ -1299,10 +1308,12 @@ Validation:
 
 > The dynamic caller/callee signature match is nominal rather than structural.
 
-TODO: Update signature matching and index space, per
-https://github.com/WebAssembly/design/pull/682
+TODO: Update signature matching and index space, comment that indices can
+effectively be used as function pointers, and change signature matching to
+structural, per https://github.com/WebAssembly/design/pull/682
 
-TODO: Comment that indices can effectively be used as function pointers.
+TODO: This anticipates sanitizing `select`'s opcode. Monitor
+https://github.com/WebAssembly/design/pull/695
 
 ### Integer Arithmetic Instructions
 
@@ -1789,8 +1800,8 @@ up, and it differs from [`round` in C] which rounds ties away from zero.
 
 The `abs` instruction performs the IEEE 754-2008 `abs` operation.
 
-> This is a bitwise instruction; it just sets the sign bit to zero and preserves
-all other bits, even when the operand is a NaN or a zero.
+> This is a bitwise instruction; it sets the sign bit to zero and preserves all
+other bits, even when the operand is a NaN or a zero.
 
 > This differs from comparing whether the operand value is less than zero and
 negating it, because comparisons treat negative zero as equal to zero, and NaN
@@ -1805,8 +1816,8 @@ values as not less than zero.
 
 The `neg` instruction performs the IEEE 754-2008 `negate` operation.
 
-> This is a bitwise instruction; it just inverts the sign bit and preserves all
-other bits, even when the operand is a NaN or a zero.
+> This is a bitwise instruction; it inverts the sign bit and preserves all other
+bits, even when the operand is a NaN or a zero.
 
 > This differs from subtracting the operand value from negative zero or
 multiplying it by negative one, because subtraction and multiplication follow
@@ -1822,7 +1833,7 @@ values.
 
 The `copysign` instruction performs the IEEE 754-2008 `copySign` operation.
 
-> This is a bitwise instruction; it just takes the sign bit from the second
+> This is a bitwise instruction; it combines the sign bit from the second
 operand with all bits other than the sign bit from the first operand, even if
 either operand is a NaN or a zero.
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -581,6 +581,9 @@ it might make sense.
 
 ### Module Index Spaces
 
+Module Index Spaces are abstract mappings from indices, starting from zero, to
+various types of elements.
+
 0. [Function Index Space]
 0. [Global Index Space]
 0. [Linear-Memory Index Space]

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -11,13 +11,20 @@ WebAssembly Specification
 0. [Instruction Descriptions](#instruction-descriptions)
 0. [Instructions](#instructions)
 
+![WebAssembly Logo][logo]
+
+[logo]: https://cloud.githubusercontent.com/assets/298127/7970689/95aefe64-09f4-11e5-87c8-b67d25f46901.png "WebAssembly Logo"
+
+TODO: What will the real logo be? Monitor
+https://github.com/WebAssembly/design/issues/112
+
 
 Introduction
 --------------------------------------------------------------------------------
 
-WebAssembly is a general-purpose virtual [ISA] designed to be a compilation
-target for a wide variety of programming languages. Much of its distinct
-personality derives from its security, code compression, and decoding
+WebAssembly, or "wasm" for short, is a general-purpose virtual [ISA] designed to
+be a compilation target for a wide variety of programming languages. Much of its
+distinct personality derives from its security, code compression, and decoding
 optimization features.
 
 The unit of WebAssembly code is the *module*. Modules primarily consist of a
@@ -197,8 +204,8 @@ or [imported](#import-section).
 
 A *table* is similar to a [linear-memory] space whose elements, instead of being
 bytes, are opaque values of a particular *table element type*. Currently the
-only valid element type is "anyfunc", meaning a function with any signature. A
-table of "anyfunc" is used as the index space for
+only valid element type is `"anyfunc"`, meaning a function with any signature. A
+table of `"anyfunc"` is used as the index space for
 [indirect calls](#call-indirect).
 
 Tables can be [defined by a module](#table-section) or
@@ -359,10 +366,10 @@ The meaning of the module string and name string are determined by the embedding
 environment.
 
 Imports provide access to constructs, defined and allocated by external entities
-outside the scope of this specification (though they may be other WebAssembly
-modules), but which have behavior consistent with their corresponding concepts
-defined in this spec. They can be accessed through their respective
-[module index spaces](#module-index-spaces).
+outside the scope of this specification (though they may be exports provided by
+other WebAssembly modules), but which have behavior consistent with their
+corresponding concepts defined in this spec. They can be accessed through their
+respective [module index spaces](#module-index-spaces).
 
 **Validation:**
  - All global imports must be immutable.
@@ -401,7 +408,7 @@ A *table declaration* consists of:
  - An *initial length*.
  - A *maximum length*.
 
-Tables with an element type of "anyfunc" hold function references of any type.
+Tables with an element type of `"anyfunc"` hold function references of any type.
 
 > Additional elements types may be added in the future.
 
@@ -478,7 +485,7 @@ re-export their imports.
 
 **Name:** `start`
 
-The Start Section consists of a function [index]. See
+The Start Section consists of an [index] into the [function index space]. See
 [Instance Execution](#instance-execution) for further information.
 
 **Validation:**
@@ -591,8 +598,8 @@ TODO: Rename this to the Table Initializer Section?
 **Name:** `name`
 
 The Names Section consists of an [array] of function name descriptors, which
-each describe names for the function with the corresponding index in the module,
-and which consist of:
+each describe names for the function with the corresponding index in the
+[function index space] and which consist of:
  - the function name, a [string].
  - the names of the locals in the function, an [array] of [strings].
 
@@ -2736,7 +2743,7 @@ linear-memory space, as an unsigned value in units of [pages].
 [Global Section]: #global-section
 [Element Section]: #element-section
 [Name Section]: #name-section
-[function Index space]: #function-index-space
+[function index space]: #function-index-space
 [global index space]: #global-index-space
 [linear-memory index space]: #linear-memory-index-space
 [table index space]: #table-index-space

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -40,13 +40,15 @@ For more information, see the [Validation section](#validation).
 
 A WebAssembly module can be [*instantiated*] to produce a WebAssembly instance,
 which contains all the data structures required by the module's code for
-execution. Instances can include [linear memory](#linear-memory-section), which
-can serve the purpose of an address space for program data. For security and
+execution. Instances can include [linear memory](#linear-memory), which can
+serve the purpose of an address space for program data. For security and
 determinism, linear memory is *sandboxed*, and the other data structures in an
 instance, including the call stack, are allocated outside of linear memory so
-that they cannot be corrupted by errant linear-memory accesses. An instance can
-then be executed, either by execution of its [start function](#start-section) or
-by calls to its exported functions.
+that they cannot be corrupted by errant linear-memory accesses. Instances can
+also include [tables](#tables), which can serve the purpose of an address space
+for indirect function calls, among other things. An instance can then be
+executed, either by execution of its [start function](#start-section) or by
+calls to its exported functions.
 
 Along with the other contents, each function contains a sequence of
 *instructions*. WebAssembly instructions conceptually communicate with each
@@ -168,36 +170,42 @@ may perform any one of the specified alternatives.
 > All instances of nondeterminism in WebAssembly are explicitly described as
 such with a link to this section.
 
-> There is no "undefined behavior" in WebAssembly where the semantics become
+> There is no ["undefined behavior"] in WebAssembly where the semantics become
 completely unspecified.
 
 > There is no requirement that a given implementation make the same choice every
 time, even for successive executions of the same instruction within the same
 instance of a module.
 
+["undefined behavior"]: https://en.wikipedia.org/wiki/Undefined_behavior
+
 ### Linear Memory
 
 A *linear memory space* is a contiguous, [byte]-addressable, readable and
-writeable range of memory spanning from offset `0` and extending up to a
+writable range of memory spanning from offset `0` and extending up to a
 *linear-memory size*, allocated as part of a WebAssembly instance. The size of a
 linear memory is always a multiple of the [page] size and may be increased
-dynamically (with the [`grow_memory`](#grow-memory) instruction).
+dynamically (with the [`grow_memory`](#grow-memory) instruction). Linear memory
+spaces are sandboxed, so they don't overlap with each other or with other parts
+of a WebAssembly instance, including the call stack, globals, and tables, and
+their bounds are enforced.
 
 Linear-memory spaces can either be [defined by a module](#linear-memory-section)
 or [imported](#import-section).
 
 ### Tables
 
-A *table* is similar to a linear memory whose elements, instead of being bytes,
-are opaque values of a particular *table element type*. Currently the only valid
-element type is "anyfunc", meaning a function with any signature. A table of
-"anyfunc" is used as the index space for [indirect calls](#call-indirect).
+A *table* is similar to a [linear-memory] space whose elements, instead of being
+bytes, are opaque values of a particular *table element type*. Currently the
+only valid element type is "anyfunc", meaning a function with any signature. A
+table of "anyfunc" is used as the index space for
+[indirect calls](#call-indirect).
 
 Tables can be [defined by a module](#table-section) or
 [imported](#import-section).
 
-> In the future, tables are expected to be generalized to hold a wide variety
-of opaque values and serve a wide variety of purposes.
+> In the future, tables are expected to be generalized to hold a wide variety of
+opaque values and serve a wide variety of purposes.
 
 
 Module
@@ -353,7 +361,8 @@ environment.
 Imports provide access to constructs, defined and allocated by external entities
 outside the scope of this specification (though they may be other WebAssembly
 modules), but which have behavior consistent with their corresponding concepts
-defined in this spec.
+defined in this spec. They can be accessed through their respective
+[module index spaces](#module-index-spaces).
 
 **Validation:**
  - All global imports must be immutable.

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -537,16 +537,16 @@ the [linear-memory index space] during
 [linear-memory instantiation](#linear-memory-instantiation).
 
 **Validation:**
- - For each element in the array:
+ - For each data initializer in the array:
     - The linear-memory index is required to be within the bounds of the
       linear-memory index space.
     - A linear-memory space is identified by the linear-memory index in the
       linear-memory index space and:
        - The sum of the start offset and the length of the string is required to
-         be less than the initial size declared for the linear-memory space.
+         be at most the initial size declared for the linear-memory space.
        - The start offset is required to be greater than the index of any byte
-         in the linear-memory space that will be initialized by a prior element
-         in the array.
+         in the linear-memory space that will be initialized by a prior
+         data initializer in the array.
 
 #### Global Section
 
@@ -578,16 +578,16 @@ A *table element initializer* consists of:
  - an index into the selected space.
 
 **Validation:**
- - For each element in the array:
+ - For each table initializer in the array:
     - The table index is required to be within the bounds of the table index
       space.
     - A table is identified by the table index in the table space and:
        - The sum of the start offset and the length of
-         the element initializer array is required to be less than the initial
+         the element initializer array is required to be at most the initial
          size declared for the table.
        - The start offset is required to be greater than the index of any
-         element in the table that will be initialized by a prior element in the
-         array.
+         element in the table that will be initialized by a prior table
+         initializer in the array.
        - For each element of the indexed table element initializer:
           - The type of the elements of the selected index space are required to
             be compatible with the type of the table to be initialized.

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -422,9 +422,6 @@ type stack outside a region cannot be popped from within the region.
 
 > The final [`end`](#end) instruction may be implicit in some representations.
 
-TODO: Permit control-flow merges with conflicting types when the resulting
-value will ultimately be unused?
-
 TODO: Will the `end` be made explicit? Monitor
 https://github.com/WebAssembly/design/pull/666.
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -458,6 +458,9 @@ which consists of the following steps:
  - A finite quantity of [call-stack resources](#call-stack-resources) are
    allocated.
 
+TODO: Will validation of the entire module be required? Monitor
+https://github.com/WebAssembly/design/pull/719
+
 #### Linear Memory Instantiation
 
 An array of bytes with the length being the value of the

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -177,7 +177,7 @@ corresponding to known sections above. They have no semantic effect.
 Function bodies contain an [array] of [types], which are declarations for
 locals, and a sequence of instructions.
 
-##### Positions Within A Function Body
+#### Positions Within A Function Body
 
 A *position* within a function refers to an element of the instruction sequence.
 
@@ -293,12 +293,10 @@ insufficient resources.
 
 ### Recursion Limits
 
-The following two values are chosen before any functions are executed:
+The *recusion limit* is a non-negative integer value selected
+[nondeterministically] before any functions are executed.
 
- - A *recursion increment*.
- - A *recursion limit*.
-
-> These values are used by [call instructions][L].
+> This value is used by [call instructions][L].
 
 ### Module Execution
 
@@ -571,13 +569,15 @@ To obtain the *forwarding control-flow type*:
 #### Calling
 
 The called function &mdash; the *callee* &mdash; is
-[executed](#function-execution), with the `*args*` operands passed to it as its
-incoming arguments, and the current recursion depth value plus the value of the
-[recursion increment](#recursion-limits) as its recursion depth value. The
-return value of the call is defined by the execution.
+[executed](#function-execution), with the `*args*` operands, excluding
+`$callee` when present, passed to it as its incoming arguments, and the current
+recursion depth value plus one as its recursion depth value. The return value of
+the call is defined by the execution.
 
 **Trap:** Call stack overflow, if the recursion depth value is greater than the
 [recursion limit](#recursion-limits).
+
+TODO: Trap on `indirect_call` caller/callee type mismatch.
 
 > This means that implementations are not permitted to perform implicit
 opportunistic tail-call elimination.
@@ -945,6 +945,8 @@ its second operand otherwise.
 The `call` instruction performs a [call](#calling) to the function with index
 `$callee`.
 
+TODO: Validate caller/callee type match.
+
 #### Indirect Call
 
 | Name            | Signature                              | Families | Opcode
@@ -953,6 +955,8 @@ The `call` instruction performs a [call](#calling) to the function with index
 
 The `call_indirect` instruction performs a [call](#calling) to the function with
 index `$callee`.
+
+TODO: Add the function signature immediate and validate it.
 
 ### Integer Instructions
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -49,7 +49,7 @@ contexts, it's common to use these names for exactly opposite purposes.
 To perform a pop from the type stack:
  - If the type stack's size is less than the control flow stack's top's depth
    value, return `void`.
- - Otherwise pop a valid from the type stack and return that.
+ - Otherwise pop a type from the type stack and return that.
 
 #### Control Flow Stack Type Merge
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -682,9 +682,9 @@ A few special constructs are used for special purposes:
    associated with addresses within the accessed linear memory space.
  - `TABLE` indicates a branch table, which is a sequence of immediate integer
    values for use in the [table branch](#table-branch) instruction.
- - `T[x]` is used in type-generic instructions to denote a heterogeneous list
-   of type parameters, where `T` is the name of the list, and `x` is either one
-   of the above named values, an immediate operand, or a literal value, and
+ - `T[x]` is used in type-generic instructions to denote a heterogeneous list of
+   type parameters, where `T` is the name of the list, and `x` is either one of
+   the above named values, an immediate operand, or a literal value, and
    signifies the length.
 
 TODO: Explain the Opcode and Syntax fields of instruction descriptions.
@@ -800,9 +800,9 @@ that they don't literally need to scan in this manner.
 #### Calling
 
 The called function &mdash; the *callee* &mdash; is
-[executed](#function-execution), with the `$args` operands, excluding
-`$callee` when present, passed to it as its incoming arguments. The return value
-of the call is defined by the execution.
+[executed](#function-execution), with the `$args` operands, excluding `$callee`
+when present, passed to it as its incoming arguments. The return value of the
+call is defined by the execution.
 
 At least one unit of [call stack resources](#call-stack-resources) is consumed
 during the execution of the callee, and released when it completes.
@@ -1072,7 +1072,7 @@ with the other branch instructions.
 
 | Name        | Signature                   | Families | Opcode
 | ----        | ---------                   | -------- | ------
-| `if`        | `($condition: i32) : ()`    |          | 0x03
+| `if`        | `($condition: i32) : ()`    | [B]      | 0x03
 
 The `if` instruction pushes an unbound [label] onto the control-flow stack. If
 `$condition` is [false], it then [branches](#branching) to this label.
@@ -1090,7 +1090,7 @@ https://github.com/WebAssembly/design/pull/710.
 
 | Name        | Signature                   | Families | Opcode
 | ----        | ---------                   | -------- | ------
-| `else`      | `(T[$any]) : (T[$any])`     |          | 0x04
+| `else`      | `(T[$any]) : (T[$any])`     | [B]      | 0x04
 
 The `else` instruction binds the control-flow stack top's [label] to the current
 position, pops an entry from the control-flow stack, pushes a new unbound
@@ -2051,9 +2051,9 @@ result type. Wrapping means reducing the value modulo the number of unique
 values in the result type.
 
 > This instruction corresponds to what is sometimes called an integer "truncate"
-in other languages, however WebAssembly uses "truncate" to mean effectively
-discarding the least significant bits, while "wrap" means effectively discarding
-the most significant bits.
+in other languages, however WebAssembly uses the word "truncate" to mean
+effectively discarding the least significant digits, and the word "wrap" to mean
+effectively discarding the most significant digits.
 
 #### Integer Extend, Signed
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -394,9 +394,9 @@ The following invariants are required to be preserved:
    to be non-empty.
  - Whenever an element of either stack is to be accessed by index, the index is
    required to be within the bounds of that stack.
- - When a [type] is to be popped from the type stack, the length of the type
-   stack is required to be greater than the control-flow stack top's limit
-   value.
+ - Whenever the control-flow stack is non-empty, as it is everywhere except
+   after the `end` at the end of the function, the type stack must be longer
+   than the control-flow stack top's limit value.
 
 The type stack begins empty. The control-flow stack begins with one entry, with
 the [type] sequence consisting of the return types of the function, and with the

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -616,16 +616,23 @@ For a store access, the value to store is written to the [accessed bytes], in
 
 #### Linear Memory Access Validation
 
-`$align` is checked to be a power of 2.
+ - `$align` is checked to be a power of 2.
+ - If the module doesn't contain a [Memory Section](#memory-section), validation
+   fails.
+ - [Generic validation](#generic-instruction-validation) is also performed.
 
-[Generic validation](#generic-instruction-validation) is also performed.
-
-### R: Memory-Resize Instruction Family
+### R: Linear Memory-Resize Instruction Family
 
 #### Pages
 
 *Pages* in WebAssembly are 64 [KiB], and are the units used in linear memory
 resizing.
+
+#### Linear Memory-Resize Validation
+
+ - If the module doesn't contain a [Memory Section](#memory-section), validation
+   fails.
+ - [Generic validation](#generic-instruction-validation) is also performed.
 
 ### B: Branch Instruction Family
 
@@ -2081,9 +2088,8 @@ may still fail before the maximum if it wasn't possible to reserve the space up
 front or if enabling the reserved memory fails.
 
 **Validation**:
- - If the module doesn't contain a [Memory Section](#memory-section), validation
-   fails.
- - [Generic validation](#generic-instruction-validation) is also performed.
+ - [Linear memory-resize validation](#linear-memory-resize-validation) is
+   performed.
 
 > Since the return value is in units of pages, `-1` isn't otherwise a valid
 linear memory size.
@@ -2098,9 +2104,8 @@ The `current_memory` instruction returns the size of the referenced linear
 memory space, as an unsigned value in units of [pages].
 
 **Validation**:
- - If the module doesn't contain a [Memory Section](#memory-section), validation
-   fails.
- - [Generic validation](#generic-instruction-validation) is also performed.
+ - [Linear memory-resize validation](#linear-memory-resize-validation) is
+   performed.
 
 [M]: #m-memory-access-instruction-family
 [R]: #r-memory-resize-instruction-family

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -206,7 +206,7 @@ A *table* is similar to a [linear-memory] space whose elements, instead of being
 bytes, are opaque values of a particular *table element type*. Currently the
 only valid element type is `"anyfunc"`, meaning a function with any signature. A
 table of `"anyfunc"` is used as the index space for
-[indirect calls](#call-indirect).
+[indirect calls](#indirect-call).
 
 Tables can be [defined by a module](#table-section) or
 [imported](#import-section).

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -112,8 +112,8 @@ and associated data.
 
 **Validation:**
  - The version index is required to be equal to `0xc`.
- - For each present [known section](#known-sections), the associated
-   **Validation** clause is performed, if one is specified for the section kind.
+ - For each present [known section](#known-sections), the requirements of its
+   **Validation** clause are required, if one is specified for the section kind.
  - Present known sections are required to be ordered in the section sequence as
    they are ordered in the [enumeration of the Known Sections](#known-sections).
 
@@ -356,8 +356,8 @@ Validation
 
 ### Module Validation
 
-Validation of a module entails performing the **Validation** clause of the
-[top-level module description](#module-contents).
+Validation of a module requires the requirements of the **Validation** clause of
+the [top-level module description](#module-contents).
 
 Then, if the module contains a [Code Section](#code-section), each function body
 in the section is [validated](#function-validation).
@@ -1255,7 +1255,7 @@ The `call` instruction performs a [call](#calling) to the function with index
 `$callee`.
 
 Validation:
- - [Call validation](#call-validation) is performed; the callee signature is the
+ - [Call validation](#call-validation) is required; the callee signature is the
    signature of the indexed function.
 
 TODO: Update index space, per
@@ -1274,7 +1274,7 @@ index `$callee`.
 with index `$callee` differs from `$signature`.
 
 Validation:
- - [Call validation](#call-validation) is performed; the callee signature is the
+ - [Call validation](#call-validation) is required; the callee signature is the
    signature with index `$signature` in the [Type Section](#type-section).
 
 > The dynamic caller/callee signature match is nominal rather than structural.
@@ -2180,7 +2180,7 @@ IEEE 754-2008 `copy` operation.
 
 **Validation:**
  - [Linear memory access validation](#linear-memory-access-validation) is
-   performed.
+   required.
 
 #### Store
 
@@ -2199,7 +2199,7 @@ IEEE 754-2008 `copy` operation.
 
 **Validation:**
  - [Linear memory access validation](#linear-memory-access-validation) is
-   performed.
+   required.
 
 #### Extending Load, Signed
 
@@ -2220,7 +2220,7 @@ width than their type, and return the value [sign-extended] to their type.
 
 **Validation:**
  - [Linear memory access validation](#linear-memory-access-validation) is
-   performed.
+   required.
 
 #### Extending Load, Unsigned
 
@@ -2241,7 +2241,7 @@ width than their type, and return the value zero-extended to their type.
 
 **Validation:**
  - [Linear memory access validation](#linear-memory-access-validation) is
-   performed.
+   required.
 
 #### Wrapping Store
 
@@ -2262,7 +2262,7 @@ silently wrapped to a narrower width.
 
 **Validation:**
  - [Linear memory access validation](#linear-memory-access-validation) is
-   performed.
+   required.
 
 > See the comment in the [wrap instruction](#integer-wrap) about the meaning of
 the name "wrap".
@@ -2292,7 +2292,7 @@ front or if enabling the reserved memory fails.
 
 **Validation**:
  - [Linear memory-resize validation](#linear-memory-resize-validation) is
-   performed.
+   required.
 
 > Since the return value is in units of pages, `-1` isn't otherwise a valid
 linear memory size.
@@ -2308,7 +2308,7 @@ memory space, as an unsigned value in units of [pages].
 
 **Validation**:
  - [Linear memory-resize validation](#linear-memory-resize-validation) is
-   performed.
+   required.
 
 [M]: #m-memory-access-instruction-family
 [R]: #r-memory-resize-instruction-family

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -1,15 +1,17 @@
-# WebAssembly Specification
+WebAssembly Specification
+================================================================================
 
 0. [Module](#module)
 0. [Validation](#validation)
 0. [Execution](#execution)
 0. [Types](#types)
-0. [Signatures](#signatures)
+0. [Instruction Signatures](#instruction-signatures)
 0. [Instruction Families](#instruction-families)
 0. [Instructions](#instructions)
 
 
-## Module
+Module
+--------------------------------------------------------------------------------
 
 0. [Module Types](#module-types)
 0. [Module Contents](#module-contents)
@@ -26,12 +28,16 @@ These types describe various data structures present in WebAssembly modules:
 
 #### Index
 
-An *index* is an `i32` value which is interpreted as unsigned.
+An *index* is a 32-bit unsigned integer value.
+
+> Indices may be represented in compressed form in some representations.
 
 #### Array
 
 An *array* is an [index] indicating a number of elements, plus a sequence of
 that many elements.
+
+> Array elements need not all be the same size in some representations.
 
 #### String
 
@@ -53,7 +59,6 @@ There are several *known sections*:
 0. [Type Section](#type-section)
 0. [Import Section](#import-section)
 0. [Function Section](#function-section)
-0. [Table Section](#table-section)
 0. [Memory Section](#memory-section)
 0. [Export Section](#export-section)
 0. [Start Section](#start-section)
@@ -65,8 +70,8 @@ There are several *known sections*:
 
 **Name:** `type`.
 
-The Type Section contains an [array] of all function signatures that will be used
-in the module.
+The Type Section contains an [array] of all function signatures that will be
+used in the module.
 
 Each function signature contains a *parameter list*, an [array] of [types], and
 a *return list*, also an [array] of [types].
@@ -106,7 +111,7 @@ The Memory Section contains:
  - A *maximum size*, which is an unsigned `iPTR` value, in units of [pages]. See
    the [`grow_memory`](#grow-memory) instruction for further information on this
    field.
- - An *exported* flag, which is a boolean indicating whether the memory is
+ - An *exported* flag, which is a boolean value indicating whether the memory is
    visible outside the module.
 
 #### Export Section
@@ -138,8 +143,7 @@ The Code Section contains an [array] of [function bodies](#function-bodies).
 **Name:** `data`
 
 The Data Section contains an [array] of [string] and offset pairs describing
-data to be loaded into linear memory before
-[Execution](#execution).
+data to be loaded into linear memory before [Execution](#execution).
 
 #### Name Section
 
@@ -173,19 +177,16 @@ corresponding to known sections above. They have no semantic effect.
 Function bodies contain an [array] of [types], which are declarations for
 locals, and a sequence of instructions.
 
-##### Positions within a function body
+##### Positions Within A Function Body
 
-A *position* within a function refers to an element of the sequence, or to an
-additional *return position* which is sequenced after the end of the function
-body.
-
-TODO: Add an implicit `end` at the return position.
+A *position* within a function refers to an element of the instruction sequence.
 
 > In the binary encoding, positions are represented as byte offsets; in the text
 format, positions are represented with a special syntax.
 
 
-## Validation
+Validation
+--------------------------------------------------------------------------------
 
 ### Module Validation
 
@@ -195,7 +196,7 @@ TODO: Describe module validation.
 
 For the duration of the validation of a function body, several data structures
 are created:
- - A *control-flow stack*, with entries containing
+ - A *control-flow stack*, with entries each containing
     - A [control-flow type](#control-flow-type).
     - A *limit* value.
  - A *[type] stack*.
@@ -227,51 +228,77 @@ To merge two [control-flow types]:
 
 #### Function Validation Initialization
 
+If the instruction sequence is empty, or if the last instruction in the sequence
+is not an `end`, validation fails.
+
 The current position starts at the first position. The type stack begins empty.
 The control-flow stack starts with one entry. This entry's control-flow type is
 the first return type of the function, if it has any, or `void` otherwise. Its
 limit value is zero.
 
+> The final `end` instruction may be implicit in some representations.
+
 #### Function Body Validation
 
-If the current position is the return position,
-[function return validation](#function-return-validation) is prompted and
-validation of the function is thereafter complete.
-
-Otherwise, the instruction at the current position is remembered, and the
-current position is incremented to point to the position following it. Then the
-remembered instruction is validated as follows.
+The instruction at the current position is remembered, and the current position
+is incremented to point to the position following it. Then the remembered
+instruction is validated as follows.
 
 If the instruction has a **Validation** clause, that clause describes its
-validation. Otherwise, the following generic validation is performed:
+validation. Otherwise, [generic validation](#generic-instruction-validation) is
+performed.
 
-For each operand [type] in the instruction's signature in reverse order, a type
-is popped from the type stack and checked to match it. Each return type of the
-instruction's signature is then pushed onto the type stack.
-
-If the instruction's signature has no return types, and the length of the type
-stack is greater than the control-flow stack top's limit value, validation
-fails.
+If the current position is now past the end of the sequence,
+[function return validation](#function-return-validation) is initiated and
+validation of the function is thereafter complete.
 
 Otherwise, [validation](#function-body-validation) is resumed.
 
+TODO: `unreachable`, `br`, `return`, and `br_table` return type validation.
+
+#### Generic Instruction Validation
+
+For each operand [type] in the instruction's signature in reverse order, a
+type is popped from the type stack and checked to match it. Each return type of
+the instruction's signature is then pushed onto the type stack.
+
+Then, if the instruction's signature has no return types, and the length of the
+type stack is greater than the control-flow stack top's limit value, validation
+fails.
+
 #### Function Return Validation
 
-When a *return* is prompted, if the function signature has any return types, a
-type is popped from the type stack and checked to match the first return type.
-The type stack is then checked to be empty. If no failures were detected,
-function validation is successful.
-
-TODO: Require the control-flow stack to be empty too.
+If the function signature has any return types, a type is popped from the type
+stack and checked to match the first return type. The type stack and the
+control-flow stack are then both checked to be empty. If no failures were
+detected anywhere in the function, function validation is successful.
 
 
-## Execution
+Execution
+--------------------------------------------------------------------------------
 
 Before any code in a module can be executed, the whole module must first be
 [validated](#validation).
 
-The contents of the [Data Section](#data-section) are loaded into linear
-memory. Each [string] is loaded into linear memory at its associated offset.
+The contents of the [Data Section](#data-section) are loaded into linear memory.
+Each [string] is loaded into linear memory at its associated offset.
+
+Then, the [recursion limit](#recursion-limits) values are chosen,
+[nondeterministically].
+
+TODO: Describe module versus instance, and describe instantiation.
+
+TODO: Implementations can, nondeterministically, trap at any time, due to
+insufficient resources.
+
+### Recursion Limits
+
+The following two values are chosen before any functions are executed:
+
+ - A *recursion increment*.
+ - A *recursion limit*.
+
+> These values are used by [call instructions][L].
 
 ### Module Execution
 
@@ -290,15 +317,13 @@ The input to execution of a function consists of:
 
 For the duration of the execution of a function body, several data structures
 are created:
- - A *control-flow stack*, which holds label identifiers for reference from
-   branch instructions.
+ - A *control-flow stack*, which holds [labels] for reference from branch
+   instructions.
  - A *value stack*, which carries values between instructions.
  - A *locals* array, containing an element for each argument of the function in
    the argument's [type], as well as an element for each local declaration in
    the function.
  - A *current position*.
-
-TODO: Define labels and binding.
 
 > Implementations need not create a literal array to store the locals, or
 literal stacks to manage values at runtime.
@@ -307,7 +332,7 @@ literal stacks to manage values at runtime.
 
 The current position starts at the first instruction in the function body. The
 value stack begins empty. The control-flow stack begins with an entry holding a
-label bound to the return position.
+[label] bound to the last instruction in the instruction sequence.
 
 The value of each incoming argument is copied to the local with the
 corresponding index, and the rest of the locals are initialized to all-zeros
@@ -315,40 +340,50 @@ bit-pattern values.
 
 #### Function Body Execution
 
-If the current position is the return position,
-[function return execution](#function-return-execution) is prompted and
-execution of the function is thereafter complete.
-
-Otherwise, the instruction at the current position is remembered, and the
-current position is incremented to point to the position following it. Then the
-remembered instruction is executed as follows.
+The instruction at the current position is remembered, and the current position
+is incremented to point to the position following it. Then the remembered
+instruction is executed as follows.
 
 For each operand [type] in the instruction's signature in reverse order, a value
 is popped from the value stack and provided as the corresponding operand value.
-The instruction is then executed as described in
-the [Instructions Section](#instructions) entry describing it. Instructions may
-inspect and/or modify the current position, the label stack, the locals or other
-state. They may evoke side effects or trigger a [trap].
+The instruction is then executed as described in the
+[Instructions Section](#instructions) entry describing it. Each of the
+instruction's return values are then pushed onto the value stack.
 
-They produce a value for each return [type] in the instruction's signature. Each
-return value is then pushed onto the value stack, and
-[execution](#function-body-execution) is resumed.
+If the current position is now past the end of the sequence,
+[function return execution](#function-return-execution) is initiated and
+execution of the function is thereafter complete.
+
+Otherwise, [execution](#function-body-execution) is resumed.
+
+#### Labels
+
+A label is a value which is either *unbound*, or *bound* to a specific position.
+
+#### Nondeterminism
+
+When semantics are specified as *nondeterministic*, a WebAssembly implementation
+may perform any one of the specified alternatives.
+
+> There is no requirement that a given implementation make the same choice every
+time, even within the same program.
 
 #### Instruction Traps
 
-Instructions may also *trap*, in which case execution of the current module is
+Instructions may *trap*, in which case execution of the current module is
 immediately terminated and abnormal termination is reported to the embedding
 environment.
 
 #### Function Return Execution
 
-When a *return* is prompted, one value for each return [type] in the function
-signature in reverse order is popped from the value stack. If the function
-execution was prompted by a call instruction, these values are provided as the
-call's return value. Otherwise, they are provided to the embedding environment.
+One value for each return [type] in the function signature in reverse order is
+popped from the value stack. If the function execution was prompted by a call
+instruction, these values are provided as the call's return value. Otherwise,
+they are provided to the embedding environment.
 
 
-## Types
+Types
+--------------------------------------------------------------------------------
 
 0. [Integer Types](#integer-types)
 0. [Floating-Point Types](#floating-point-types)
@@ -383,37 +418,52 @@ the values `0` and `1` for false and true.
 | `f32` | 32
 | `f64` | 64
 
-`f32` is the IEEE 754-2008
+`f32` uses the IEEE 754-2008
 [binary32](https://en.wikipedia.org/wiki/Single-precision_floating-point_format)
-type, commonly known as "Single Precision".
+format, commonly known as "Single Precision".
 
-`f64` is the IEEE 754-2008
+`f64` uses the IEEE 754-2008
 [binary64](https://en.wikipedia.org/wiki/Double-precision_floating-point_format)
-type, commonly known as "Double Precision".
+format, commonly known as "Double Precision".
 
 > Unlike with
 [Numbers in ECMAScript](https://tc39.github.io/ecma262/#sec-ecmascript-language-types-number-type),
 [NaN](https://en.wikipedia.org/wiki/NaN) values in WebAssembly have sign bits
-and significant fields which may be observed and manipulated (though they are
+and significand fields which may be observed and manipulated (though they are
 usually unimportant).
 
 
-## Signatures
+Instruction Signatures
+--------------------------------------------------------------------------------
 
-Signatures describe the explicit inputs and outputs to an instruction. In this
-document they are described in the following form:
+Instruction signatures describe the explicit inputs and outputs to an
+instruction. They are described in either of the following forms:
 
-`(` arguments `)` `:` `(` returns `)`
+ - `(` *arguments* `)` `:` `(` *returns* `)`
+ - `<` *immediates* `>` `(` *arguments* `)` `:` `(` *returns* `)`
 
-or
+*Immediates*, if present, is a list of [typed] value names, representing values
+provided by the module itself as input to an instruction. *Arguments* is a list
+of [typed] value names representing values provided by program execution as
+input to an instruction. *Returns* is a list of [types], representing values
+computed by an instruction that are provided back to the program execution.
 
-`<` immediates `>` `(` arguments `)` `:` `(` returns `)`
+A few special constructs are used for special purposes:
+ - `iPTR` is for use with a linear memory access, and signifies the integer type
+   associated with addresses within the accessed linear memory space.
+ - `TABLE` indicates a branch table, which is a sequence of immediate integer
+   values for use in the [table branch](#table-branch) instruction.
+ - `T` is used in type-generic instructions to denote a type parameter.
+ - `T?` is used in type-generic instructions to denote either a type parameter
+   or no type.
+ - `*args*` is used in [call instructions][L] and indicates a sequence of typed
+   value names providing the values for the arguments in the call.
+ - `*returns*` is also used in [call instructions][L] and indicates a sequence
+   of types, describing the function's return types.
 
-TODO: Describe signatures, and shorthand: iPTR, `<immediates>`, TABLE, T, T?,
-`*args*`, and `*returns*`.
 
-
-## Instruction Families
+Instruction Families
+--------------------------------------------------------------------------------
 
 WebAssembly instructions may belong to several families:
 
@@ -441,26 +491,26 @@ are the addressing unit of linear memory spaces.
 #### Effective Address
 
 The *effective address* of a linear memory access is computed by adding `$base`
-with `$offset` at infinite precision, so that there is no overflow.
+and `$offset` at infinite precision, so that there is no overflow.
 
 #### Alignment
 
 **Slow:** If the effective address is not a multiple of `$align`, the access is
 *misaligned*, and the instruction may execute very slowly.
 
-> When `$align` is equal to the size of the access, the access has
-*natural alignment*. When it is less, the access is *unaligned*.
+> When `$align` is greater than or equal to the size of the access, the access
+is *naturally aligned*. When it is less, the access is *unaligned*.
 
 > There is no other semantic effect associated with `$align`; misaligned and
 unaligned loads and stores still function normally.
 
 #### Accessed Bytes
 
-The *accessed bytes* consist of a contiguous sequence of [bytes] starting at
-the [effective address], with a length implied by the accessing instruction.
+The *accessed bytes* consist of a contiguous sequence of [bytes] starting at the
+[effective address], with a length implied by the accessing instruction.
 
-**Trap:** Out Of Bounds, if any of the [bytes] of a linear memory access are
-beyond the end of the accessed linear memory space.
+**Trap:** Out Of Bounds, if any of the accessed bytes are beyond the end of the
+accessed linear memory space.
 
 #### Loading
 
@@ -471,6 +521,12 @@ For a load access, a value is read from the [accessed bytes], in
 
 For a store access, the value to store is written to the [accessed bytes], in
 [little-endian byte order].
+
+#### Linear Memory Access Validation
+
+`$align` is checked to be a power of 2.
+
+[Generic validation](#generic-instruction-validation) is also performed.
 
 ### R: Memory-Resize Instruction Family
 
@@ -486,11 +542,11 @@ resizing.
 In a branch according to a given control-flow stack entry, first the value stack
 is resized to the entry's limit value.
 
-Then, if the entry's label is bound to a position, the current position is set
-to that position. Otherwise, the position to bind the label to is found by
-scanning forward through the instructions, executing just `block`, `loop`, and
-`end` instructions, until the label is bound. Then the current position is set
-to that position.
+Then, if the entry's [label] is bound, the current position is set to the bound
+position. Otherwise, the position to bind the label to is found by scanning
+forward through the instructions, executing just `block`, `loop`, and `end`
+instructions, until the label is bound. Then the current position is set to that
+position.
 
 Then, control-flow stack entries are popped until the given control-flow stack
 entry is popped.
@@ -507,20 +563,21 @@ To obtain the *forwarding control-flow type*:
    value, use `void`.
  - Otherwise, validation fails.
 
+> Validation fails if there are unused entries left on the stack. The
+[`drop` instruction](#drop) can be used to discard unused values.
+
 ### L: Call Instruction Family
 
 #### Calling
 
 The called function &mdash; the *callee* &mdash; is
 [executed](#function-execution), with the `*args*` operands passed to it as its
-incoming arguments, and the current recursion depth value plus some
-implementation-defined positive amount as its recursion depth value. The return
-value of the call is defined by the execution.
+incoming arguments, and the current recursion depth value plus the value of the
+[recursion increment](#recursion-limits) as its recursion depth value. The
+return value of the call is defined by the execution.
 
-TODO: Define implementation-defined.
-
-**Trap:** Call stack overflow, if the recursion depth value is greater than some
-implementation-defined limit.
+**Trap:** Call stack overflow, if the recursion depth value is greater than the
+[recursion limit](#recursion-limits).
 
 > This means that implementations are not permitted to perform implicit
 opportunistic tail-call elimination.
@@ -535,16 +592,17 @@ depth.
 
 ### C: Comparison Instruction Family
 
-WebAssembly comparison instructions compare two values and return a
-[boolean](#booleans) result value.
+WebAssembly comparison instructions compare two values and return a [boolean]
+result value.
 
 > In accordance with IEEE 754-2008, for the comparison instructions, negative
-zero is considered equal to zero.
+zero is considered equal to zero, and NaN values are not less than, greater
+than, or equal to any other values, including themselves.
 
 ### T: Shift Instruction Family
 
-In the shift and rotate instructions, "left" means in the direction of greater
-significance, and "right" means in the direction of lesser significance.
+In the shift and rotate instructions, *left* means in the direction of greater
+significance, and *right* means in the direction of lesser significance.
 
 #### Shift Count
 
@@ -552,30 +610,30 @@ The second operand in shift and rotate instructions specifies a *shift count*,
 which is interpreted as an unsigned quantity modulo the number of bits in the
 first operand.
 
-> As a result of the modulo, in `i32` instructions, only the least-significant
-5 bits of the second operand affect the result, and in `i64` instructions only
-the least-significant 6 bits of the second operand affect the result.
+> As a result of the modulo, in `i32` instructions, only the least-significant 5
+bits of the second operand affect the result, and in `i64` instructions only the
+least-significant 6 bits of the second operand affect the result.
 
 > The shift count is interpreted as unsigned even in otherwise signed
-instructions such as [`shr_s`](#integer-shift-right-signed].
+instructions such as [`shr_s`](#integer-shift-right-signed).
 
 ### G: Generic Integer Instruction Family
 
 Except where otherwise specified, these instructions do not specifically
-interpret their operands as explicitly signed or unsigned, and therefore
-do not have an inherent concept of overflow.
+interpret their operands as explicitly signed or unsigned, and therefore do not
+have an inherent concept of overflow.
 
 ### S: Signed Integer Instruction Family
 
-Except where otherwise specified, these instructions interpret their operands as
-signed, return result values interpreted as signed, and [trap] when the result
-value can not be represented as such.
+Except where otherwise specified, these instructions interpret their operand
+values as signed, return result values interpreted as signed, and [trap] when
+the result value can not be represented as such.
 
 ### U: Unsigned Integer Instruction Family
 
-Except where otherwise specified, these instructions interpret their operands as
-unsigned, return result values interpreted as unsigned, and [trap] when the
-result value can not be represented as such.
+Except where otherwise specified, these instructions interpret their operand
+values as unsigned, return result values interpreted as unsigned, and [trap]
+when the result value can not be represented as such.
 
 ### F: Floating-Point Instruction Family
 
@@ -583,25 +641,25 @@ Instructions in this family follow the [IEEE 754-2008] standard, except that:
 
  - They support only "non-stop" mode, and floating-point exceptions are not
    otherwise observable. In particular, neither alternate floating-point
-   exception handling attributes nor the non-computational operators on status
+   exception handling attributes nor the non-computational operations on status
    flags are supported.
 
- - They use the round-to-nearest ties-to-even rounding attribute, except where
+ - They use the IEEE 754-2008 `roundTiesToEven` rounding attribute, except where
    otherwise specified. Non-default directed rounding attributes are not
    supported.
 
 When the result of any instruction in this family (which excludes `neg`, `abs`,
 and `copysign`) is a NaN, the sign bit and the significand field (which does not
 include the implicit leading digit of the significand) of the NaN are computed
-as follows:
+by one of the following rules, selected [nondeterministically]:
 
  - If the instructions has any NaN non-immediate operand values, implementations
-   may select any of them to be the result value, but with the most significant
-   bit of the significand field overwritten to be 1.
+   may [nondeterministically] select any of them to be the result value, but
+   with the most significant bit of the significand field overwritten to be `1`.
 
  - If the implementation does not choose to use an input NaN as a result value,
-   or if there are no input NaNs, the result value has a nondeterministic sign
-   bit, a significand field with 1 in the most significant bit and 0 in the
+   or if there are no input NaNs, the result value has a [nondeterministic] sign
+   bit, a significand field with `1` in the most significant bit and `0` in the
    remaining bits.
 
 Implementations are permitted to further implement the IEEE 754-2008 section
@@ -625,7 +683,8 @@ ways, including in how they operate on NaN and zero values.
 They correspond to the "Sign bit operations" in IEEE 754-2008.
 
 
-## Instructions
+Instructions
+--------------------------------------------------------------------------------
 
 0. [Control Flow Instructions](#control-flow-instructions)
 0. [Basic Instructions](#basic-instructions)
@@ -656,7 +715,7 @@ They correspond to the "Sign bit operations" in IEEE 754-2008.
 | ----        | ---------                   | -------- | ------
 | `block`     | `() : ()`                   |          | 0x01
 
-The `block` instruction pushes an unbound label onto the control-flow stack.
+The `block` instruction pushes an unbound [label] onto the control-flow stack.
 
 **Validation:**
  - An entry is pushed onto the control-flow stack containing `any` and a limit
@@ -668,8 +727,8 @@ The `block` instruction pushes an unbound label onto the control-flow stack.
 | ----        | ---------                   | -------- | ------
 | `loop`      | `() : ()`                   |          | 0x02
 
-The `loop` instruction binds a label to the current position and pushes
-it onto the control-flow stack.
+The `loop` instruction binds a [label] to the current position and pushes it
+onto the control-flow stack.
 
 **Validation:**
  - An entry is pushed onto the control-flow stack containing `any` and a limit
@@ -747,9 +806,10 @@ has more than one.
    [forwarding control-flow type] control-flow type into the control-flow type
    of the control-flow stack entry that depth from the top.
 
-> This instruction serves the role of what is sometimes called a "jump table" in
-other languages. "Branch" is used here instead to emphasize the commonality with
-the other branch instructions.
+> This instruction serves the role of what is sometimes called a
+["jump table"](https://en.wikipedia.org/w/index.php?title=Jump_table) in other
+languages. "Branch" is used here instead to emphasize the commonality with the
+other branch instructions.
 
 #### Return
 
@@ -775,10 +835,8 @@ actual function return.
 
 **Trap:** Unreachable, always.
 
-> The `unreachable` instruction is meant to represent code that is not meant
-to be executed except in the case of a bug in the application.
-
-TODO: `unreachable`, `br`, `return`, and `br_table` return type validation.
+> The `unreachable` instruction is meant to represent code that is not meant to
+be executed except in the case of a bug in the application.
 
 #### End
 
@@ -787,7 +845,7 @@ TODO: `unreachable`, `br`, `return`, and `br_table` return type validation.
 | `end`       | `(T?) : (T?)`               | [B]      | 0x0f
 
 The `end` instruction pops an entry from the control-flow stack. If the entry's
-label is unbound, the label is bound to the current location. Its return value
+[label] is unbound, the label is bound to the current position. Its return value
 is the value of its operand, if it has one.
 
 **Validation:**
@@ -810,6 +868,8 @@ is the value of its operand, if it has one.
 0. [Call](#call)
 0. [Indirect Call](#indirect-call)
 
+TODO: `call_table`
+
 #### Nop
 
 | Name        | Signature                   | Families | Opcode
@@ -822,7 +882,7 @@ The `nop` instruction does nothing.
 
 | Name        | Signature                   | Families | Opcode
 | ----        | ---------                   | -------- | ------
-| `drop`      | `(T) : ()`                  |          | TODO
+| `drop`      | `(T) : ()`                  |          | 0x0b
 
 The `drop` instruction does nothing.
 
@@ -862,7 +922,7 @@ the value given in the operand.
 
 | Name        | Signature                   | Families | Opcode
 | ----        | ---------                   | -------- | ------
-| `tee_local` | `<$id: i32> (T) : (T)`      |          | TODO
+| `tee_local` | `<$id: i32> (T) : (T)`      |          | 0x19
 
 The `tee_local` instruction sets the value in the locals array at index `$id` to
 to the value given in the operand. Its return value is the value of its operand.
@@ -873,8 +933,8 @@ to the value given in the operand. Its return value is the value of its operand.
 | ----        | ---------                       | -------- | ------
 | `select`    | `(T, T, $condition: i32) : (T)` |          | 0x05
 
-The `select` instruction returns its first operand if `$condition` is
-[true], or its second operand otherwise.
+The `select` instruction returns its first operand if `$condition` is [true], or
+its second operand otherwise.
 
 #### Call
 
@@ -882,8 +942,8 @@ The `select` instruction returns its first operand if `$condition` is
 | ----        | ---------                               | -------- | ------
 | `call`      | `<$callee: i32> (*args*) : (*returns*)` | [L]      | 0x16
 
-The `call` instruction performs a [call](#calling) to the function with
-index `$callee`.
+The `call` instruction performs a [call](#calling) to the function with index
+`$callee`.
 
 #### Indirect Call
 
@@ -891,10 +951,8 @@ index `$callee`.
 | ----            | ---------                              | -------- | ------
 | `call_indirect` | `($callee: i32, *args*) : (*returns*)` | [L]      | 0x17
 
-The `call_indirect` instruction performs a [call](#calling) to the
-function with index `$callee`.
-
-TODO: call_table
+The `call_indirect` instruction performs a [call](#calling) to the function with
+index `$callee`.
 
 ### Integer Instructions
 
@@ -925,8 +983,8 @@ TODO: call_table
 | `i32.add`   | `(i32, i32) : (i32)`        | [G]      | 0x40   | `+` (13)
 | `i64.add`   | `(i64, i64) : (i64)`        | [G]      | 0x5b   | `+` (13)
 
-The `add` instruction returns the [two's complement sum] of its operands. On
-overflow, the result is silently wrapped.
+The integer `add` instruction returns the [two's complement sum] of its
+operands. The carry bit is silently discarded.
 
 > Due to WebAssembly's use of [two's complement] to represent signed values,
 this instruction can be used to add either signed or unsigned values.
@@ -938,8 +996,8 @@ this instruction can be used to add either signed or unsigned values.
 | `i32.sub`   | `(i32, i32) : (i32)`        | [G]      | 0x41   | `-` (13)
 | `i64.sub`   | `(i64, i64) : (i64)`        | [G]      | 0x5c   | `-` (13)
 
-The `sub` instruction returns the [two's complement difference] of its operands.
-On overflow, the result is silently wrapped.
+The integer `sub` instruction returns the [two's complement difference] of its
+operands. The borrow bit is silently discarded.
 
 > Due to WebAssembly's use of [two's complement] to represent signed values,
 this instruction can be used to subtract either signed or unsigned values.
@@ -954,8 +1012,8 @@ as the first operand.
 | `i32.mul`   | `(i32, i32) : (i32)`        | [G]      | 0x42   | `*` (14)
 | `i64.mul`   | `(i64, i64) : (i64)`        | [G]      | 0x5d   | `*` (14)
 
-The `mul` instruction returns the [two's complement product] its operands. On
-overflow, the result is silently wrapped.
+The integer `mul` instruction returns the low half of the
+[two's complement product] its operands.
 
 > Due to WebAssembly's use of [two's complement] to represent signed values,
 this instruction can be used to multiply either signed or unsigned values.
@@ -973,7 +1031,7 @@ as signed. The quotient is silently rounded to the nearest integer toward zero.
 **Trap:** Signed overflow, when the [minimum signed integer value] is divided by
 `-1`.
 
-**Trap:** Division by zero, when the right operand (the divisor) is zero.
+**Trap:** Division by zero, when the second operand (the divisor) is zero.
 
 #### Integer Divide, Unsigned
 
@@ -986,7 +1044,7 @@ The `div_u` instruction returns the unsigned quotient of its operands,
 interpreted as unsigned. The quotient is silently rounded to the nearest integer
 toward zero.
 
-**Trap:** Division by zero, when the right operand (the divisor) is zero.
+**Trap:** Division by zero, when the second operand (the divisor) is zero.
 
 #### Integer Remainder, Signed
 
@@ -996,10 +1054,10 @@ toward zero.
 | `i64.rem_s` | `(i64, i64) : (i64)`        | [S]      | 0x60   | `%s` (14)
 
 The `rem_s` instruction returns the signed remainder from a division of its
-operands interpreted as signed, with the result having the same sign as the left
-operand (the dividend).
+operand values interpreted as signed, with the result having the same sign as
+the first operand (the dividend).
 
-**Trap:** Division by zero, when the right operand (the divisor) is zero.
+**Trap:** Division by zero, when the second operand (the divisor) is zero.
 
 > This instruction does not trap when the [minimum signed integer value] is
 divided by `-1`; it returns `0` which is the correct remainder (even though the
@@ -1017,9 +1075,9 @@ handling of negative numbers.
 | `i64.rem_u` | `(i64, i64) : (i64)`        | [U]      | 0x61   | `%u` (14)
 
 The `rem_u` instruction returns the unsigned remainder from a division of its
-operands interpreted as unsigned.
+operand values interpreted as unsigned.
 
-**Trap:** Division by zero, when the right operand (the divisor) is zero.
+**Trap:** Division by zero, when the second operand (the divisor) is zero.
 
 > This instruction corresponds to what is sometimes called "modulo" in other
 languages.
@@ -1065,8 +1123,8 @@ operand, an operation sometimes called "one's complement" in other languages.
 The `shl` instruction returns the value of the first operand [shifted] to the
 left by the [shift count].
 
-> This instruction effectively performs a multiplication by two to the power
-of the shift count.
+> This instruction effectively performs a multiplication by two to the power of
+the shift count.
 
 #### Integer Shift Right, Signed
 
@@ -1109,12 +1167,12 @@ of the shift count.
 | `i32.rotl`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb7
 | `i64.rotl`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb9
 
-The `rotl` instruction returns the value of the first operand rotated to the
+The `rotl` instruction returns the value of the first operand [rotated] to the
 left by the [shift count].
 
-> Rotating left is similar to shifting left, however vacated bits are set
-to the values of the bits which would otherwise be discarded by the shift,
-so the bits conceptually "rotate back around".
+> Rotating left is similar to shifting left, however vacated bits are set to the
+values of the bits which would otherwise be discarded by the shift, so the bits
+conceptually "rotate back around".
 
 #### Integer Rotate Right
 
@@ -1123,12 +1181,12 @@ so the bits conceptually "rotate back around".
 | `i32.rotr`  | `(i32, i32) : (i32)`        | [T], [G] | 0xb6
 | `i64.rotr`  | `(i64, i64) : (i64)`        | [T], [G] | 0xb8
 
-The `rotr` instruction returns the value of the first operand rotated to the
+The `rotr` instruction returns the value of the first operand [rotated] to the
 right by the [shift count].
 
-> Rotating right is similar to shifting right, however vacated bits are set
-to the values of the bits which would otherwise be discarded by the shift,
-so the bits conceptually "rotate back around".
+> Rotating right is similar to shifting right, however vacated bits are set to
+the values of the bits which would otherwise be discarded by the shift, so the
+bits conceptually "rotate back around".
 
 #### Integer Count Leading Zeros
 
@@ -1137,9 +1195,9 @@ so the bits conceptually "rotate back around".
 | `i32.clz`   | `(i32) : (i32)`             | [G]      | 0x57
 | `i64.clz`   | `(i64) : (i64)`             | [G]      | 0x72
 
-The `clz` instruction returns the number of "leading zeros" in its operand.
-The "leading zeros" are the longest contiguous sequence of 0-bits starting
-at the most significant bit and extending downward.
+The `clz` instruction returns the number of leading zeros in its operand. The
+*leading zeros* are the longest contiguous sequence of zero-bits starting at the
+most significant bit and extending downward.
 
 > This instruction is fully defined when all bits are zero; it returns the
 number of bits in the operand type.
@@ -1151,9 +1209,9 @@ number of bits in the operand type.
 | `i32.ctz`   | `(i32) : (i32)`             | [G]      | 0x58
 | `i64.ctz`   | `(i64) : (i64)`             | [G]      | 0x73
 
-The `ctz` instruction returns the number of "trailing zeros" in its operand.
-The "trailing zeros" are the longest contiguous sequence of 0-bits starting
-at the least significant bit and extending upward.
+The `ctz` instruction returns the number of trailing zeros in its operand. The
+*trailing zeros* are the longest contiguous sequence of zero-bits starting at
+the least significant bit and extending upward.
 
 > This instruction is fully defined when all bits are zero; it returns the
 number of bits in the operand type.
@@ -1179,11 +1237,11 @@ The `popcnt` instruction returns the number of 1-bits in its operand.
 | `i32.eqz`   | `(i32) : (i32)`             | [G]      | 0x5a   | `!` (15)
 | `i64.eqz`   | `(i64) : (i32)`             | [G]      | 0xba   | `!` (15)
 
-The `eqz` instruction returns [true] if the operand is equal to zero, or
-[false] otherwise.
+The `eqz` instruction returns [true] if the operand is equal to zero, or [false]
+otherwise.
 
-> This serves as a form of "logical not" operation which can be used to
-invert boolean conditions.
+> This serves as a form of "logical not" operation which can be used to invert
+[boolean] values.
 
 ### Floating-Point Instructions
 
@@ -1197,7 +1255,7 @@ invert boolean conditions.
 0. [Floating-Point Ceiling](#floating-point-ceiling)
 0. [Floating-Point Floor](#floating-point-floor)
 0. [Floating-Point Truncate](#floating-point-truncate)
-0. [Floating-Point Nearest](#floating-point-nearest)
+0. [Floating-Point Nearest Integer](#floating-point-nearest-integer)
 0. [Floating-Point Absolute Value](#floating-point-absolute-value)
 0. [Floating-Point Negate](#floating-point-negate)
 0. [Floating-Point CopySign](#floating-point-copysign)
@@ -1209,9 +1267,8 @@ invert boolean conditions.
 | `f32.add`   | `(f32, f32) : (f32)`        | [F]      | 0x75   | `+` (13)
 | `f64.add`   | `(f64, f64) : (f64)`        | [F]      | 0x89   | `+` (13)
 
-The `add` instruction returns the sum of its operands.
-
-This performs the IEEE 754-2008 `addition` operation.
+The floating-point `add` instruction performs the IEEE 754-2008 `addition`
+operation according to [the general floating-point rules][F].
 
 #### Floating-Point Subtract
 
@@ -1220,9 +1277,8 @@ This performs the IEEE 754-2008 `addition` operation.
 | `f32.sub`   | `(f32, f32) : (f32)`        | [F]      | 0x76   | `-` (13)
 | `f64.sub`   | `(f64, f64) : (f64)`        | [F]      | 0x8a   | `-` (13)
 
-The `sub` instruction returns the difference of its operands.
-
-This performs the IEEE 754-2008 `subtraction` operation.
+The floating-point `sub` instruction performs the IEEE 754-2008 `subtraction`
+operation according to [the general floating-point rules][F].
 
 #### Floating-Point Multiply
 
@@ -1231,9 +1287,8 @@ This performs the IEEE 754-2008 `subtraction` operation.
 | `f32.mul`   | `(f32, f32) : (f32)`        | [F]      | 0x77   | `*` (14)
 | `f64.mul`   | `(f64, f64) : (f64)`        | [F]      | 0x8b   | `*` (14)
 
-The `mul` instruction returns the product of its operands.
-
-This performs the IEEE 754-2008 `multiplication` operation.
+The floating-point `mul` instruction performs the IEEE 754-2008 `multiplication`
+operation according to [the general floating-point rules][F].
 
 #### Floating-Point Divide
 
@@ -1242,9 +1297,8 @@ This performs the IEEE 754-2008 `multiplication` operation.
 | `f32.div`   | `(f32, f32) : (f32)`        | [F]      | 0x78   | `/` (14)
 | `f64.div`   | `(f64, f64) : (f64)`        | [F]      | 0x8c   | `/` (14)
 
-The `div` instruction returns the quotient of its operands.
-
-This performs the IEEE 754-2008 `division` operation.
+The `div` instruction performs the IEEE 754-2008 `division` operation according
+to [the general floating-point rules][F].
 
 #### Floating-Point Square Root
 
@@ -1253,9 +1307,8 @@ This performs the IEEE 754-2008 `division` operation.
 | `f32.sqrt`  | `(f32) : (f32)`             | [F]      | 0x82
 | `f64.sqrt`  | `(f64) : (f64)`             | [F]      | 0x96
 
-The `sqrt` instruction returns the square root of its operand.
-
-This performs the IEEE 754-2008 `squareRoot` operation.
+The `sqrt` instruction performs the IEEE 754-2008 `squareRoot` operation
+according to [the general floating-point rules][F].
 
 #### Floating-Point Minimum
 
@@ -1264,9 +1317,9 @@ This performs the IEEE 754-2008 `squareRoot` operation.
 | `f32.min`   | `(f32, f32) : (f32)`        | [F]      | 0x79
 | `f64.min`   | `(f64, f64) : (f64)`        | [F]      | 0x8d
 
-The `min` instruction returns the minimum value among its operands. For
-this instruction, negative zero is considered less than zero, and NaN values are
-considered less than any other value.
+The `min` instruction returns the minimum value among its operands. For this
+instruction, negative zero is considered less than zero. If either operand is a
+NaN, the result is a NaN determined by [the general floating-point rules][F].
 
 > This differs from the IEEE 754-2008 `minNum` operation in that it returns a
 NaN if either operand is a NaN, and in that the behavior on negative zero is
@@ -1283,8 +1336,8 @@ negative zero and NaN values.
 | `f64.max`   | `(f64, f64) : (f64)`        | [F]      | 0x8e
 
 The `max` instruction returns the maximum value among its operands. For this
-instruction, negative zero is considered less than zero, and NaN values are
-considered greater than any other value.
+instruction, negative zero is considered less than zero. If either operand is a
+NaN, the result is a NaN determined by [the general floating-point rules][F].
 
 > This differs from the IEEE 754-2008 `maxNum` operation in that it returns a
 NaN if either operand is a NaN, and in that the behavior on negative zero is
@@ -1300,12 +1353,12 @@ zero and NaN values.
 | `f32.ceil`  | `(f32) : (f32)`             | [F]      | 0x7e
 | `f64.ceil`  | `(f64) : (f64)`             | [F]      | 0x92
 
-The `ceil` instruction returns the value of the operand rounded up to the
-nearest integer.
+The `ceil` instruction performs the IEEE 754-2008
+`roundToIntegralTowardPositive` operation according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `roundToIntegralTowardPositive` operation.
-
-> See also [Floor and Ceiling Functions].
+> ["Ceiling"][Floor and Ceiling Functions] describes the rounding method used
+here; the value is rounded up to the nearest integer.
 
 #### Floating-Point Floor
 
@@ -1314,12 +1367,12 @@ This performs the IEEE 754-2008 `roundToIntegralTowardPositive` operation.
 | `f32.floor` | `(f32) : (f32)`             | [F]      | 0x7f
 | `f64.floor` | `(f64) : (f64)`             | [F]      | 0x93
 
-The `floor` instruction returns the value of the operand rounded down to the
-nearest integer.
+The `floor` instruction performs the IEEE 754-2008
+`roundToIntegralTowardNegative` operation according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `roundToIntegralTowardNegative` operation.
-
-> See also [Floor and Ceiling Functions].
+> ["Floor"][Floor and Ceiling Functions] describes the rounding method used
+here; the value is rounded down to the nearest integer.
 
 #### Floating-Point Truncate
 
@@ -1328,22 +1381,27 @@ This performs the IEEE 754-2008 `roundToIntegralTowardNegative` operation.
 | `f32.trunc` | `(f32) : (f32)`             | [F]      | 0x80
 | `f64.trunc` | `(f64) : (f64)`             | [F]      | 0x94
 
-The `trunc` instruction returns the value of the operand rounded towards
-zero to the nearest integer.
+The `trunc` instruction performs the IEEE 754-2008
+`roundToIntegralTowardZero` operation according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `roundToIntegralTowardZero` operation.
+> ["Truncate"](https://en.wikipedia.org/wiki/Truncation) describes the rounding
+method used here; the fractional part of the value is discarded, effectively
+rounding to the nearest integer toward zero.
 
-#### Floating-Point Nearest
+#### Floating-Point Nearest Integer
 
 | Name          | Signature                 | Families | Opcode
 | ----          | ---------                 | -------- | ------
 | `f32.nearest` | `(f32) : (f32)`           | [F]      | 0x81
 | `f64.nearest` | `(f64) : (f64)`           | [F]      | 0x95
 
-The `nearest` instruction returns the value of the operand
-[rounded to the nearest integer](https://en.wikipedia.org/wiki/Nearest_integer_function).
+The `nearest` instruction performs the IEEE 754-2008
+`roundToIntegralTiesToEven` operation according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `roundToIntegralTiesToEven` operation.
+> "Nearest" describes the rounding method used here; the value is
+[rounded to the nearest integer](https://en.wikipedia.org/wiki/Nearest_integer_function).
 
 > This instruction differs from
 [`Math.round` in ECMAScript](https://tc39.github.io/ecma262/#sec-math.round)
@@ -1360,15 +1418,14 @@ ties away from zero.
 | `f32.abs`   | `(f32) : (f32)`             | [Z]      | 0x7b
 | `f64.abs`   | `(f64) : (f64)`             | [Z]      | 0x8f
 
-The `abs` instruction returns the absolute value of the operand.
+The `abs` instruction performs the IEEE 754-2008 `abs` operation.
 
-This is a bitwise instruction, so it just sets the sign bit to zero and
-preserves all other bits, even when the operand is a NaN or a zero.
+> This is a bitwise instruction; it just sets the sign bit to zero and preserves
+all other bits, even when the operand is a NaN or a zero.
 
-This performs the IEEE 754-2008 `abs` operation.
-
-> This differs from comparing whether the operand value is negative and negating
-it, in that it always inverts the sign bit, even for a negative zero or a NaN.
+> This differs from comparing whether the operand value is less than zero and
+negating it, because comparisons treat negative zero as equal to zero, and NaN
+values as not less than zero.
 
 #### Floating-Point Negate
 
@@ -1377,17 +1434,15 @@ it, in that it always inverts the sign bit, even for a negative zero or a NaN.
 | `f32.neg`   | `(f32) : (f32)`             | [Z]      | 0x7c   | `-` (15)
 | `f64.neg`   | `(f64) : (f64)`             | [Z]      | 0x90   | `-` (15)
 
-The `neg` instruction returns the value of the operand with the sign bit
-reversed.
+The `neg` instruction performs the IEEE 754-2008 `negate` operation.
 
-This is a bitwise instruction, so it just inverts the sign bit and preserves all
+> This is a bitwise instruction; it just inverts the sign bit and preserves all
 other bits, even when the operand is a NaN or a zero.
 
-This performs the IEEE 754-2008 `negate` operation.
-
-> This differs from subtracting the operand value from (negative) zero or
-multiplying by negative one, in that it's guaranteed to preserve the bits of a
-NaN.
+> This differs from subtracting the operand value from negative zero or
+multiplying it by negative one, because subtraction and multiplication follow
+the [general floating-point rules][F] and may not preserve the bits of NaN
+values.
 
 #### Floating-Point CopySign
 
@@ -1396,13 +1451,11 @@ NaN.
 | `f32.copysign` | `(f32, f32) : (f32)`     | [Z]      | 0x7d
 | `f64.copysign` | `(f64, f64) : (f64)`     | [Z]      | 0x91
 
-The `copysign` instruction returns the value of the left operand with the
-sign bit of the right operand.
+The `copysign` instruction performs the IEEE 754-2008 `copySign` operation.
 
-This is a bitwise instruction, so it just transfers the sign bit and preserves
-all other bits of the left operand, even when the left operand is a NaN.
-
-This performs the IEEE 754-2008 `copySign` operation.
+> This is a bitwise instruction; it just takes the sign bit from the second
+operand with all bits other than the sign bit from the first operand, even if
+either operand is a NaN or a zero.
 
 ### Integer Comparison Instructions
 
@@ -1424,7 +1477,7 @@ This performs the IEEE 754-2008 `copySign` operation.
 | `i32.eq`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4d   | `==` (10)
 | `i64.eq`    | `(i64, i64) : (i32)`        | [C], [G] | 0x68   | `==` (10)
 
-The `eq` instruction tests whether the operands are equal.
+The integer `eq` instruction tests whether the operands are equal.
 
 #### Integer Inequality
 
@@ -1433,7 +1486,7 @@ The `eq` instruction tests whether the operands are equal.
 | `i32.ne`    | `(i32, i32) : (i32)`        | [C], [G] | 0x4e   | `!=` (10)
 | `i64.ne`    | `(i64, i64) : (i32)`        | [C], [G] | 0x69   | `!=` (10)
 
-The `ne` instruction tests whether the operands are not equal.
+The integer `ne` instruction tests whether the operands are not equal.
 
 > This instruction corresponds to what is sometimes called "differs" in other
 languages.
@@ -1445,7 +1498,7 @@ languages.
 | `i32.lt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x4f   | `<s` (11)
 | `i64.lt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6a   | `<s` (11)
 
-The `lt_s` instruction tests whether the left operand is less than the right
+The `lt_s` instruction tests whether the first operand is less than the second
 operand, interpreting the operands as signed.
 
 #### Integer Less Than, Unsigned
@@ -1455,7 +1508,7 @@ operand, interpreting the operands as signed.
 | `i32.lt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x51   | `<u` (11)
 | `i64.lt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6c   | `<u` (11)
 
-The `lt_u` instruction tests whether the left operand is less than the right
+The `lt_u` instruction tests whether the first operand is less than the second
 operand, interpreting the operands as unsigned.
 
 #### Integer Less Than Or Equal To, Signed
@@ -1465,8 +1518,8 @@ operand, interpreting the operands as unsigned.
 | `i32.le_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x50   | `<=s` (11)
 | `i64.le_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6b   | `<=s` (11)
 
-The `le_s` instruction tests whether the left operand is less than or equal
-to the right operand, interpreting the operands as signed.
+The `le_s` instruction tests whether the first operand is less than or equal to
+the second operand, interpreting the operands as signed.
 
 > This instruction corresponds to what is sometimes called "at most" in other
 languages.
@@ -1478,8 +1531,8 @@ languages.
 | `i32.le_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x52   | `<=u` (11)
 | `i64.le_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x6d   | `<=u` (11)
 
-The `le_u` instruction tests whether the left operand is less than or equal
-to the right operand, interpreting the operands as unsigned.
+The `le_u` instruction tests whether the first operand is less than or equal to
+the second operand, interpreting the operands as unsigned.
 
 > This instruction corresponds to what is sometimes called "at most" in other
 languages.
@@ -1491,8 +1544,8 @@ languages.
 | `i32.gt_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x53   | `>s` (11)
 | `i64.gt_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6e   | `>s` (11)
 
-The `gt_s` instruction tests whether the left operand is greater than the right
-operand, interpreting the operands as signed.
+The `gt_s` instruction tests whether the first operand is greater than the
+second operand, interpreting the operands as signed.
 
 #### Integer Greater Than, Unsigned
 
@@ -1501,8 +1554,8 @@ operand, interpreting the operands as signed.
 | `i32.gt_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x55   | `>u` (11)
 | `i64.gt_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x70   | `>u` (11)
 
-The `gt_u` instruction tests whether the left operand is greater than the right
-operand, interpreting the operands as unsigned.
+The `gt_u` instruction tests whether the first operand is greater than the
+second operand, interpreting the operands as unsigned.
 
 #### Integer Greater Than Or Equal To, Signed
 
@@ -1511,8 +1564,8 @@ operand, interpreting the operands as unsigned.
 | `i32.ge_s`  | `(i32, i32) : (i32)`        | [C], [S] | 0x54   | `>=s` (11)
 | `i64.ge_s`  | `(i64, i64) : (i32)`        | [C], [S] | 0x6f   | `>=s` (11)
 
-The `ge_s` instruction tests whether the left operand is greater than or equal
-to the right operand, interpreting the operands as signed.
+The `ge_s` instruction tests whether the first operand is greater than or equal
+to the second operand, interpreting the operands as signed.
 
 > This instruction corresponds to what is sometimes called "at least" in other
 languages.
@@ -1524,8 +1577,8 @@ languages.
 | `i32.ge_u`  | `(i32, i32) : (i32)`        | [C], [U] | 0x56   | `>=u` (11)
 | `i64.ge_u`  | `(i64, i64) : (i32)`        | [C], [U] | 0x71   | `>=u` (11)
 
-The `ge_u` instruction tests whether the left operand is greater than or equal
-to the right operand, interpreting the operands as unsigned.
+The `ge_u` instruction tests whether the first operand is greater than or equal
+to the second operand, interpreting the operands as unsigned.
 
 > This instruction corresponds to what is sometimes called "at least" in other
 languages.
@@ -1546,10 +1599,9 @@ languages.
 | `f32.eq`    | `(f32, f32) : (i32)`        | [C], [F] | 0x83   | `==` (10)
 | `f64.eq`    | `(f64, f64) : (i32)`        | [C], [F] | 0x97   | `==` (10)
 
-The `eq` instruction tests whether the operands are equal. It returns false if
-either operand is a NaN.
-
-This performs the IEEE 754-2008 `compareQuietEqual` operation.
+The floating-point `eq` instruction performs the IEEE 754-2008
+`compareQuietEqual` operation according to
+[the general floating-point rules][F].
 
 #### Floating-Point Inequality
 
@@ -1558,10 +1610,13 @@ This performs the IEEE 754-2008 `compareQuietEqual` operation.
 | `f32.ne`    | `(f32, f32) : (i32)`        | [C], [F] | 0x84   | `!=` (10)
 | `f64.ne`    | `(f64, f64) : (i32)`        | [C], [F] | 0x98   | `!=` (10)
 
-The `ne` instruction tests whether the operands are not equal. Unlike the other
-comparison operators, it returns [true] if either operand is a NaN.
+The floating-point `ne` instruction performs the IEEE 754-2008
+`compareQuietNotEqual` operation according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `compareQuietNotEqual` operation.
+> Unlike the other floating-point comparison instructions, this instruction
+returns [true] if either operand is a NaN. It is the logical inverse of the `eq`
+instruction.
 
 #### Floating-Point Less Than
 
@@ -1570,10 +1625,8 @@ This performs the IEEE 754-2008 `compareQuietNotEqual` operation.
 | `f32.lt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x85   | `<` (11)
 | `f64.lt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x99   | `<` (11)
 
-The `lt` instruction tests whether the left operand is less than the right
-operand. It returns false if either operand is a NaN.
-
-This performs the IEEE 754-2008 `compareQuietLess` operation.
+The `lt` instruction performs the IEEE 754-2008 `compareQuietLess` operation
+according to [the general floating-point rules][F].
 
 #### Floating-Point Less Than Or Equal To
 
@@ -1582,10 +1635,8 @@ This performs the IEEE 754-2008 `compareQuietLess` operation.
 | `f32.le`    | `(f32, f32) : (i32)`        | [C], [F] | 0x86   | `<=` (11)
 | `f64.le`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9a   | `<=` (11)
 
-The `le` instruction tests whether the left operand is less than or equal
-to the right operand. It returns false if either operand is a NaN.
-
-This performs the IEEE 754-2008 `compareQuietLessEqual` operation.
+The `le` instruction performs the IEEE 754-2008 `compareQuietLessEqual`
+operation according to [the general floating-point rules][F].
 
 #### Floating-Point Greater Than
 
@@ -1594,10 +1645,8 @@ This performs the IEEE 754-2008 `compareQuietLessEqual` operation.
 | `f32.gt`    | `(f32, f32) : (i32)`        | [C], [F] | 0x87   | `>` (11)
 | `f64.gt`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9b   | `>` (11)
 
-The `gt` instruction tests whether the left operand is greater than the right
-operand. It returns false if either operand is a NaN.
-
-This performs the IEEE 754-2008 `compareQuietGreater` operation.
+The `gt` instruction performs the IEEE 754-2008 `compareQuietGreater` operation
+according to [the general floating-point rules][F].
 
 #### Floating-Point Greater Than Or Equal To
 
@@ -1606,10 +1655,8 @@ This performs the IEEE 754-2008 `compareQuietGreater` operation.
 | `f32.ge`    | `(f32, f32) : (i32)`        | [C], [F] | 0x88   | `>=` (11)
 | `f64.ge`    | `(f64, f64) : (i32)`        | [C], [F] | 0x9c   | `>=` (11)
 
-The `gt` instruction tests whether the left operand is greater than or equal
-to the right operand. It returns false if either operand is a NaN.
-
-This performs the IEEE 754-2008 `compareQuietGreaterEqual` operation.
+The `ge` instruction performs the IEEE 754-2008 `compareQuietGreaterEqual`
+operation according to [the general floating-point rules][F].
 
 ### Conversion Instructions
 
@@ -1645,8 +1692,8 @@ the most significant bits.
 | ----               | ---------            | -------- | ------
 | `i64.extend_s/i32` | `(i32) : (i64)`      | [S]      | 0xa6
 
-The `extend_s` instruction returns the value of its operand [sign-extended] to its
-result type.
+The `extend_s` instruction returns the value of its operand [sign-extended] to
+its result type.
 
 #### Integer Extend, Unsigned
 
@@ -1666,14 +1713,13 @@ result type.
 | `i64.trunc_s/f32` | `(f32) : (i64)`       | [F], [S] | 0xa2
 | `i64.trunc_s/f64` | `(f64) : (i64)`       | [F], [S] | 0xa3
 
-The `trunc_s` instruction returns the value of its operand rounded toward zero
-to the nearest integer that can be represented as signed in the result type.
+The `trunc_s` instruction performs the IEEE 754-2008
+`convertToIntegerTowardZero` operation, with the result value interpreted as
+signed, according to [the general floating-point rules][F].
 
 **Trap:** Invalid Conversion, when a floating-point Invalid condition occurs,
 due to the operand being outside the range that can be converted (including NaN
 values and infinities).
-
-This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
 
 #### Truncate Floating-Point to Integer, Unsigned
 
@@ -1684,14 +1730,17 @@ This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
 | `i64.trunc_u/f32` | `(f32) : (i64)`       | [F], [U] | 0xa4
 | `i64.trunc_u/f64` | `(f64) : (i64)`       | [F], [U] | 0xa5
 
-The `trunc_u` instruction returns the value of its operand rounded toward zero
-to the nearest integer that can be represented as unsigned in the result type.
+The `trunc_u` instruction performs the IEEE 754-2008
+`convertToIntegerTowardZero` operation, with the result value interpreted as
+unsigned, according to [the general floating-point rules][F].
 
 **Trap:** Invalid Conversion, when an Invalid condition occurs, due to the
 operand being outside the range that can be converted (including NaN values and
 infinities).
 
-This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
+> This instruction's result is unsigned, so it almost always rounds down,
+however it does round up in one place: negative values greater than negative one
+truncate up to zero.
 
 #### Floating-Point Demote
 
@@ -1699,10 +1748,11 @@ This performs the IEEE 754-2008 `convertToIntegerTowardZero` operation.
 | ----             | ---------              | -------- | ------
 | `f32.demote/f64` | `(f64) : (f32)`        | [F]      | 0xac
 
-The `demote` instruction returns the value of its operand rounded to the nearest
-value in the result type, with ties rounded to the nearest even value.
+The `demote` instruction performs the IEEE 754-2008 `convertFormat` operation,
+converting from its operand type to its result type, according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `convertFormat` operation.
+> This is a narrowing conversion which may round or overflow to infinity.
 
 #### Floating-Point Promote
 
@@ -1710,12 +1760,11 @@ This performs the IEEE 754-2008 `convertFormat` operation.
 | ----              | ---------             | -------- | ------
 | `f64.promote/f32` | `(f32) : (f64)`       | [F]      | 0xb2
 
-The `promote` instruction returns the value of its operand converted to the
-result type.
+The `promote` instruction performs the IEEE 754-2008 `convertFormat` operation,
+converting from its operand type to its result type, according to
+[the general floating-point rules][F].
 
-This performs the IEEE 754-2008 `convertFormat` operation.
-
-> This instruction never needs to perform rounding.
+> This is a widening conversion and is always exact.
 
 #### Convert Integer To Floating-Point, Signed
 
@@ -1726,11 +1775,9 @@ This performs the IEEE 754-2008 `convertFormat` operation.
 | `f64.convert_s/i32` | `(i32) : (f64)`     | [F], [S] | 0xae
 | `f64.convert_s/i64` | `(i64) : (f64)`     | [F], [S] | 0xb0
 
-The `convert_s` instruction returns the value of its operand, interpreted as
-signed, converted to the result type, rounded to the nearest representable
-value.
-
-This performs the IEEE 754-2008 `convertFromInt` operation.
+The `convert_s` instruction performs the IEEE 754-2008 `convertFromInt`
+operation, with its operand value interpreted as signed, according to
+[the general floating-point rules][F].
 
 #### Convert Integer To Floating-Point, Unsigned
 
@@ -1741,11 +1788,9 @@ This performs the IEEE 754-2008 `convertFromInt` operation.
 | `f64.convert_u/i32` | `(i32) : (f64)`     | [F], [U] | 0xaf
 | `f64.convert_u/i64` | `(i64) : (f64)`     | [F], [U] | 0xb1
 
-The `convert_u` instruction returns the value of its operand, interpreted as
-unsigned, converted to the result type, rounded to the nearest representable
-value.
-
-This performs the IEEE 754-2008 `convertFromInt` operation.
+The `convert_u` instruction performs the IEEE 754-2008 `convertFromInt`
+operation, with its operand value interpreted as unsigned, according to
+[the general floating-point rules][F].
 
 #### Reinterpret
 
@@ -1762,7 +1807,7 @@ its operand value, in its result type.
 > The operand type is always the same width as the result type, so this
 instruction is always exact.
 
-### Load and Store Instructions
+### Load And Store Instructions
 
 0. [Load](#load)
 0. [Store](#store)
@@ -1784,6 +1829,10 @@ The `load` instruction performs a [load](#loading) of the same size as its type.
 Floating-point loads preserve all the bits of the value, performing an
 IEEE 754-2008 `copy` operation.
 
+**Validation:**
+ - [Linear memory access validation](#linear-memory-access-validation)
+   is performed.
+
 #### Store
 
 | Name        | Signature                                                       | Families | Opcode
@@ -1798,6 +1847,10 @@ size as its type.
 
 Floating-point stores preserve all the bits of the value, performing an
 IEEE 754-2008 `copy` operation.
+
+**Validation:**
+ - [Linear memory access validation](#linear-memory-access-validation)
+   is performed.
 
 #### Extending Load, Signed
 
@@ -1816,6 +1869,10 @@ width than their type, and return the value [sign-extended] to their type.
  - `load16_s` loads a 16-bit value.
  - `load32_s` loads a 32-bit value.
 
+**Validation:**
+ - [Linear memory access validation](#linear-memory-access-validation)
+   is performed.
+
 #### Extending Load, Unsigned
 
 | Name           | Signature                                             | Families | Opcode
@@ -1833,6 +1890,10 @@ width than their type, and return the value zero-extended to their type.
  - `load16_u` loads a 16-bit value.
  - `load32_u` loads a 32-bit value.
 
+**Validation:**
+ - [Linear memory access validation](#linear-memory-access-validation)
+   is performed.
+
 #### Wrapping Store
 
 | Name          | Signature                                                       | Families | Opcode
@@ -1849,6 +1910,10 @@ silently wrapped to a narrower width.
  - `store8` stores an 8-bit value.
  - `store16` stores a 16-bit value.
  - `store32` stores a 32-bit value.
+
+**Validation:**
+ - [Linear memory access validation](#linear-memory-access-validation)
+   is performed.
 
 > See the note in the [wrap instruction](#integer-wrap) about the meaning of the
 name "wrap".
@@ -1912,6 +1977,7 @@ memory space, as an unsigned value in units of [pages].
 [minimum signed integer value]: https://en.wikipedia.org/wiki/Two%27s_complement#Most_negative_number
 [KiB]: https://en.wikipedia.org/wiki/Kibibyte
 [bit]: https://en.wikipedia.org/wiki/Bit
+[boolean]: #booleans
 [true]: #booleans
 [false]: #booleans
 [sign-extend]: https://en.wikipedia.org/wiki/Sign_extension
@@ -1923,13 +1989,19 @@ memory space, as an unsigned value in units of [pages].
 [accessed bytes]: #accessed-bytes
 [pop]: #type-stack-pop
 [merge]: #control-flow-type-merge
-[index]: Index
-[array]: Array
-[string]: String
-[strings]: String
+[index]: #index
+[array]: #array
+[string]: #string
+[strings]: #string
 [type]: #types
 [types]: #types
+[typed]: #types
 [control-flow type]: #control-flow-types
 [control-flow types]: #control-flow-types
 [forwarding control-flow type]: #forwarding-control-flow-type
 [trap]: #instruction-traps
+[rotated]: https://en.wikipedia.org/wiki/Bitwise_operation#Rotate_no_carry
+[nondeterministic]: #nondeterminism
+[nondeterministically]: #nondeterminism
+[label]: #labels
+[labels]: #labels

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -306,8 +306,8 @@ An *import* is one of the following:
  - a table import.
 
 All imports contain:
- - a *module [string]*, identifying a module to import from.
- - a *name [string]*, identifying an export in that module to import.
+ - a *module [string]*.
+ - a *name [string]*.
 
 A *function import* additionally contains:
  - a function declaration, as described in the [Function Section].
@@ -336,6 +336,10 @@ defined in this spec.
  - Embedding-specific validation may be performed on each import.
 
 > Global imports may be permitted to be mutable in the future.
+
+> The module string will often identify a module to import from, and the name
+string an export in that module to import, but embedding environments may
+provide other mechanisms for resolving imports as well.
 
 #### Function Section
 
@@ -584,10 +588,10 @@ it might make sense.
 
 #### Function Index Space
 
-The *function index space* begins with an index for each function in the
-[Function Section], if present, in the order of that section, followed by an
-index for each imported function, in the order the imports appear in the
-[Import Section].
+The *function index space* begins with an index for each imported function, in
+the order the imports appear in the [Import Section], if present, followed by an
+index for each function in the [Function Section], if present, in the order of
+that section.
 
 **Validation:**
  - For each element in the index space, the type index is required to be within
@@ -598,10 +602,10 @@ the callee of a direct call.
 
 #### Global Index Space
 
-The *global index space* begins with an index for each global in the
-[Global Section], if present, in the order of that section, followed by an index
-for each imported global, in the order the imports appear in the
-[Import Section].
+The *global index space* begins with an index for each imported global, in the
+order the imports appear in the [Import Section], if present, followed by an
+index for each global in the [Global Section], if present, in the order of that
+section.
 
 > The global index space is used by:
  - the [`get_global`](#get-global) and [`set_global`](#set-global) instructions.
@@ -610,10 +614,10 @@ for each imported global, in the order the imports appear in the
 
 #### Linear-Memory Index Space
 
-The *linear-memory index space* begins with an index for each linear-memory
-space defined in the [Linear-Memory Section], if present, in the order of that
-section, followed by an index for each imported linear memory, in the order the
-imports appear in the [Import Section].
+The *linear-memory index space* begins with an index for each imported linear
+memory, in the order the imports appear in the [Import Section], if present,
+followed by an index for each linear-memory space in the
+[Linear-Memory Section], if present, in the order of that section.
 
 **Validation:**
  - The index space is required to have at most one element.
@@ -640,10 +644,10 @@ addressable, even though the total number of bytes would not be.
 
 #### Table Index Space
 
-The *table index space* begins with an index for each table defined in the
-[Table Section], in the order of that section, if present, followed by an index
-for each imported table, in the order the imports appear in the
-[Import Section].
+The *table index space* begins with an index for each imported table, in the
+order the imports appear in the [Import Section], if present, followed by an
+index for each table in the [Table Section], if present, in the order of that
+section.
 
 **Validation:**
  - The index space is required to contain at most one table.

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -752,6 +752,7 @@ The following data structures are created:
       pushed inside the current region.
     - An optional [type] sequence, which is used to check that all exits from
       the current region leave the same sequence of types on the type stack.
+    - An *isThisAnIf* flag, indicating whether the entry was pushed for an `if`.
 
 The following invariants are required to be preserved:
  - Whenever an element of either stack is to be popped, that stack is required
@@ -763,8 +764,8 @@ The following invariants are required to be preserved:
    than the control-flow stack top's limit value.
 
 The type stack begins empty. The control-flow stack begins with one entry, with
-the [type] sequence consisting of the return types of the function, and with the
-limit value being zero.
+the [type] sequence consisting of the return types of the function, with the
+limit value being zero, and the isThisAnIf flag being false.
 
 For each instruction in the body, in sequence order:
  - For each construct in the instruction's signature's operands in reverse
@@ -1379,8 +1380,9 @@ Instructions
 The `block` instruction pushes an unbound [label] onto the control-flow stack.
 
 **Validation Algorithm:**
- - An entry is pushed onto the control-flow stack containing no type sequence,
-   and a limit value of the current length of the type stack.
+ - An entry is pushed onto the control-flow stack containing no type sequence, a
+   limit value of the current length of the type stack, and an isThisAnIf value
+   of false.
 
 > Each `block` needs a corresponding [`end`](#end) to pop its label from the
 stack.
@@ -1396,7 +1398,8 @@ onto the control-flow stack.
 
 **Validation Algorithm:**
  - An entry is pushed onto the control-flow stack containing an empty type
-   sequence, and a limit value of the current length of the type stack.
+   sequence, a limit value of the current length of the type stack, and an
+   isThisAnIf value of false.
 
 > The `loop` instruction does not perform a loop by itself. It merely introduces
 a label that may be used by a branch to form an actual loop.
@@ -1493,7 +1496,8 @@ The `if` instruction pushes an unbound [label] onto the control-flow stack. If
 
 **Validation Algorithm:**
  - An entry is pushed onto the control-flow stack containing no type sequence,
-   and a limit value of the current length of the type stack.
+   a limit value of the current length of the type stack, and an isThisAnIf
+   value of true.
 
 TODO: Do `if` and `else` have labels? Monitor at least
 https://github.com/WebAssembly/design/pull/710
@@ -1512,12 +1516,12 @@ position, pops an entry from the control-flow stack, pushes a new unbound
 label. It returns the values of its operands.
 
 **Validation Algorithm:**
- - The operand sequence is [merged] into the control-flow stack entry `$depth`
-   from the top.
+ - The operand sequence is [merged] into the control-flow stack top.
+ - The control-flow stack top's isThisAnIf value is required to be true.
  - An entry is popped off the control-flow stack.
  - A new entry is pushed onto the control-flow stack containing the operand
-   sequence as its type sequence, and a limit value of the current length of the
-   type stack.
+   sequence as its type sequence, a limit value of the current length of the
+   type stack, and an isThisAnIf value of true.
 
 > Each `else` needs a corresponding [`end`](#end).
 

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -823,8 +823,8 @@ The called function &mdash; the *callee* &mdash; is
 `$callee` when present, passed to it as its incoming arguments. The return value
 of the call is defined by the execution.
 
-A unit of [call stack resources](#call-stack-resources) is consumed the
-execution of the callee, and released when it completes.
+At least one unit of [call stack resources](#call-stack-resources) is consumed
+during the execution of the callee, and released when it completes.
 
 **Trap:** Call Stack Exhausted, if the instance has insufficient
 [call stack resources](#call-stack-resources).

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -48,7 +48,7 @@ valid UTF-8 or any other format.
 
 ### Module Contents
 
-Modules contain a version [index]. Currently this number is `0xb`. The initial
+Modules contain a version [index]. Currently this number is `0xc`. The initial
 stable release of WebAssembly will set it to `0x0`.
 
 Modules also contain a sequence of sections. Each section has a [string] *name*

--- a/md-proto/WebAssembly.md
+++ b/md-proto/WebAssembly.md
@@ -515,13 +515,14 @@ complement signed integers aren't symmetric around zero.
 
 #### Booleans
 
-[Boolean] values are represented as values of type `i32`. In a boolean context,
-any non-zero value is interpreted as true and `0` is interpreted as false.
+[Boolean][actual boolean] values are represented as values of type `i32`. In a
+boolean context, such as a `br_if` condition, any non-zero value is interpreted
+as true and `0` is interpreted as false.
 
 Any instruction that produces a boolean value, such as a comparison, produces
 the values `0` and `1` for false and true.
 
-[Boolean]: https://en.wikipedia.org/wiki/Boolean_data_type
+[actual boolean]: https://en.wikipedia.org/wiki/Boolean_data_type
 
 ### Floating-Point Types
 


### PR DESCRIPTION
Pursuant to the desire expressed in [README.md](https://github.com/WebAssembly/spec/blob/master/README.md) for a human-readable specification written in prose, this PR introduces _md-proto_, a specification document written in Github-flavored Markdown.

Markdown is very simple, and doesn't have support for some fancy formatting options like auto-generated tables of contents, footnotes, and so on, however so far in this document I've found it to be just sufficient enough to produce a relatively readable and concise spec.

The document here is not yet complete; most notably it currently focuses on function bodies and doesn't contain all the surrounding contents of modules, and some of the validation logic needs further work, however I hope there's enough content to prove the overall concept here.
