### PR TITLE
Refine and extend tests for function signatures

### DIFF
--- a/ml-proto/test/call_indirect.wast
+++ b/ml-proto/test/call_indirect.wast
@@ -15,6 +15,7 @@
   (type $i32-i64 (func (param i32 i64) (result i64)))
   (type $f64-f32 (func (param f64 f32) (result f32)))
   (type $i64-f64 (func (param i64 f64) (result f64)))
+  (type $over-i64-duplicate (func (param i64) (result i64)))
 
   (func $const-i32 (type $out-i32) (i32.const 0x132))
   (func $const-i64 (type $out-i64) (i64.const 0x164))
@@ -31,12 +32,15 @@
   (func $f64-f32 (type $f64-f32) (get_local 1))
   (func $i64-f64 (type $i64-f64) (get_local 1))
 
+  (func $over-i64-duplicate (type $over-i64-duplicate) (get_local 0))
+
   (table
     $const-i32 $const-i64 $const-f32 $const-f64
     $id-i32 $id-i64 $id-f32 $id-f64
     $f32-i32 $i32-i64 $f64-f32 $i64-f64
     $fac $fib $even $odd
     $runaway $mutual-runaway1 $mutual-runaway2
+    $over-i64-duplicate
   )
 
   ;; Typing
@@ -82,9 +86,13 @@
     (call_indirect $over-i64 (get_local 0) (get_local 1))
   )
 
+  (func "dispatch-nominal" (param i32) (result i64)
+    (call_indirect $over-i64-duplicate (get_local 0) (i64.const 66))
+  )
+
   ;; Recursion
 
-  (func "fac" $fac (param i64) (result i64)
+  (func "fac" $fac (type $over-i64)
     (if (i64.eqz (get_local 0))
       (i64.const 1)
       (i64.mul
@@ -96,7 +104,7 @@
     )
   )
 
-  (func "fib" $fib (param i64) (result i64)
+  (func "fib" $fib (type $over-i64)
     (if (i64.le_u (get_local 0) (i64.const 1))
       (i64.const 1)
       (i64.add
@@ -110,7 +118,7 @@
     )
   )
 
-  (func "even" $even (param i32) (result i32)
+  (func "even" $even (type $over-i32)
     (if (i32.eqz (get_local 0))
       (i32.const 44)
       (call_indirect $over-i32 (i32.const 15)
@@ -118,7 +126,7 @@
       )
     )
   )
-  (func "odd" $odd (param i32) (result i32)
+  (func "odd" $odd (type $over-i32)
     (if (i32.eqz (get_local 0))
       (i32.const 99)
       (call_indirect $over-i32 (i32.const 14)
@@ -136,10 +144,16 @@
   ;; implementations and be incompatible with implementations that don't do
   ;; it (or don't do it under the same circumstances).
 
-  (func "runaway" $runaway (call_indirect $proc (i32.const 16)))
+  (func "runaway" $runaway (type $proc)
+    (call_indirect $proc (i32.const 16))
+  )
 
-  (func "mutual-runaway" $mutual-runaway1 (call_indirect $proc (i32.const 18)))
-  (func $mutual-runaway2 (call_indirect $proc (i32.const 17)))
+  (func "mutual-runaway" $mutual-runaway1 (type $proc)
+    (call_indirect $proc (i32.const 18))
+  )
+  (func $mutual-runaway2 (type $proc)
+    (call_indirect $proc (i32.const 17))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -165,9 +179,15 @@
 (assert_return (invoke "dispatch" (i32.const 13) (i64.const 5)) (i64.const 8))
 (assert_trap (invoke "dispatch" (i32.const 0) (i64.const 2)) "indirect call signature mismatch")
 (assert_trap (invoke "dispatch" (i32.const 15) (i64.const 2)) "indirect call signature mismatch")
+(assert_trap (invoke "dispatch" (i32.const 19) (i64.const 2)) "indirect call signature mismatch")
 (assert_trap (invoke "dispatch" (i32.const 20) (i64.const 2)) "undefined table index")
 (assert_trap (invoke "dispatch" (i32.const -1) (i64.const 2)) "undefined table index")
 (assert_trap (invoke "dispatch" (i32.const 1213432423) (i64.const 2)) "undefined table index")
+
+(assert_trap (invoke "dispatch-nominal" (i32.const 5)) "indirect call signature mismatch")
+(assert_trap (invoke "dispatch-nominal" (i32.const 12)) "indirect call signature mismatch")
+(assert_trap (invoke "dispatch-nominal" (i32.const 15)) "indirect call signature mismatch")
+(assert_return (invoke "dispatch-nominal" (i32.const 19)) (i64.const 66))
 
 (assert_return (invoke "fac" (i64.const 0)) (i64.const 1))
 (assert_return (invoke "fac" (i64.const 1)) (i64.const 1))

--- a/ml-proto/test/func.wast
+++ b/ml-proto/test/func.wast
@@ -157,6 +157,51 @@
   (func "init-local-i64" (result i64) (local i64) (get_local 0))
   (func "init-local-f32" (result f32) (local f32) (get_local 0))
   (func "init-local-f64" (result f64) (local f64) (get_local 0))
+
+
+  ;; Desugaring of implicit type signature
+  (func $empty-sig-1)  ;; should be assigned type $sig
+  (func $complex-sig-1 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $empty-sig-2)  ;; should be assigned type $sig
+  (func $complex-sig-2 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-3 (param f64 i64 f64 i64 f64 i64 f32 i32))
+
+  (type $empty-sig-duplicate (func))
+  (type $complex-sig-duplicate (func (param f64 i64 f64 i64 f64 i64 f32 i32)))
+  (table $complex-sig-3 $empty-sig-2 $complex-sig-1 $complex-sig-3 $empty-sig-1)
+
+  (func "signature-explicit-reused"
+    (call_indirect $sig (i32.const 1))
+    (call_indirect $sig (i32.const 4))
+  )
+
+  (func "signature-implicit-reused"
+    ;; The implicit index 16 in this test depends on the function and
+    ;; type definitions, and may need adapting if they change.
+    (call_indirect 16 (i32.const 0)
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+    )
+    (call_indirect 16 (i32.const 2)
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+    )
+    (call_indirect 16 (i32.const 3)
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+    )
+  )
+
+  (func "signature-explicit-duplicate"
+    (call_indirect $empty-sig-duplicate (i32.const 1))
+  )
+
+  (func "signature-implicit-duplicate"
+    (call_indirect $complex-sig-duplicate (i32.const 0)
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+    )
+  )
 )
 
 (assert_return (invoke "local-first-i32") (i32.const 0))
@@ -275,6 +320,15 @@
 (assert_return (invoke "init-local-i64") (i64.const 0))
 (assert_return (invoke "init-local-f32") (f32.const 0))
 (assert_return (invoke "init-local-f64") (f64.const 0))
+
+(assert_return (invoke "signature-explicit-reused"))
+(assert_return (invoke "signature-implicit-reused"))
+(assert_trap (invoke "signature-explicit-duplicate")
+  "indirect call signature mismatch"
+)
+(assert_trap (invoke "signature-implicit-duplicate")
+  "indirect call signature mismatch"
+)
 
 
 ;; Invalid typing of locals


### PR DESCRIPTION
- Extend call_indirect test to check that signature is nominal.
- Avoid use of implicit signatures in call_indirect.wast tests.
- Add tests to func.wast to verify correct implicit signature desugaring.