### PR TITLE
Add tests for conflicting-but-ultimately-dropped values.

### DIFF
--- a/ml-proto/test/br.wast
+++ b/ml-proto/test/br.wast
@@ -418,7 +418,7 @@
   "unknown label"
 )
 
-;; Test that the value operand of br_if matches the result type of the block
+;; Test that the value operand of br matches the result type of the block
 ;; it branches to, even if the result of the block is dropped.
 (assert_invalid
   (module

--- a/ml-proto/test/br.wast
+++ b/ml-proto/test/br.wast
@@ -417,3 +417,26 @@
   (module (func $large-label (br 0x100000001)))
   "unknown label"
 )
+
+;; Test that the value operand of br_if matches the result type of the block
+;; it branches to, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32)
+      (drop
+        (block $green
+          (br $green (get_local $x))
+          (get_local $y)))))
+  "type mismatch")
+
+;; Test that the value operand of br matches the result type of other
+;; branches to the same block, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32)
+      (drop
+        (block $green
+          (br $green (get_local $x))
+          (br $green (get_local $y))
+          (get_local $x)))))
+  "type mismatch")

--- a/ml-proto/test/br_if.wast
+++ b/ml-proto/test/br_if.wast
@@ -306,3 +306,25 @@
   "unknown label"
 )
 
+;; Test that the value operand of br_if matches the result type of the block
+;; it branches to, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32) (param $cond i32)
+      (drop
+        (block $green
+          (br_if $green (get_local $x) (get_local $cond))
+          (get_local $y)))))
+  "type mismatch")
+
+;; Test that the value operand of br_if matches the result type of other
+;; branches to the same block, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32) (param $cond i32)
+      (drop
+        (block $green
+          (br_if $green (get_local $x) (get_local $cond))
+          (br_if $green (get_local $y) (get_local $cond))
+          (get_local $x)))))
+  "type mismatch")

--- a/ml-proto/test/br_table.wast
+++ b/ml-proto/test/br_table.wast
@@ -1385,3 +1385,25 @@
   "unknown label"
 )
 
+;; Test that the value operand of br_if matches the result type of the block
+;; it branches to, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32) (param $index i32)
+      (drop
+        (block $green
+          (br_table $green $green (get_local $x) (get_local $index))
+          (get_local $y)))))
+  "type mismatch")
+
+;; Test that the value operand of br_table matches the result type of other
+;; branches to the same block, even if the result of the block is dropped.
+(assert_invalid
+  (module
+    (func $bar (param $x i32) (param $y f32) (param $index i32)
+      (drop
+        (block $green
+          (br_table $green $green (get_local $x) (get_local $index))
+          (br_table $green $green (get_local $y) (get_local $index))
+          (get_local $x)))))
+  "type mismatch")

--- a/ml-proto/test/br_table.wast
+++ b/ml-proto/test/br_table.wast
@@ -1385,7 +1385,7 @@
   "unknown label"
 )
 
-;; Test that the value operand of br_if matches the result type of the block
+;; Test that the value operand of br_table matches the result type of the block
 ;; it branches to, even if the result of the block is dropped.
 (assert_invalid
   (module

--- a/ml-proto/test/typecheck.wast
+++ b/ml-proto/test/typecheck.wast
@@ -4,6 +4,16 @@
 ;; if condition
 (assert_invalid (module (func (if (f32.const 0) (nop) (nop)))) "type mismatch")
 
+;; if arms
+(assert_invalid
+  (module
+    (func $foo (param $x i32) (param $y f32) (param $cond f32)
+      (drop
+        (if (get_local $cond)
+          (get_local $y)
+          (get_local $x)))))
+  "type mismatch")
+
 ;; br_if condition
 (assert_invalid (module (func (block (br_if 0 (f32.const 0))))) "type mismatch")
 

--- a/ml-proto/test/typecheck.wast
+++ b/ml-proto/test/typecheck.wast
@@ -7,7 +7,7 @@
 ;; if arms
 (assert_invalid
   (module
-    (func $foo (param $x i32) (param $y f32) (param $cond f32)
+    (func $foo (param $x i32) (param $y f32) (param $cond i32)
       (drop
         (if (get_local $cond)
           (get_local $y)


### PR DESCRIPTION
This is a PR against the void branch, which adds a few more tests.

Specifically, this tests constructs which merge values from two control paths, to ensure that the types match even when the resulting value is dropped.