### PR TITLE
Implement globals

### DIFF
--- a/ml-proto/host/arrange.ml
+++ b/ml-proto/host/arrange.ml
@@ -278,8 +278,9 @@ let import i im =
     [atom string module_name; atom string func_name; ty]
   )
 
-let global t =
-  Node ("global", [atom value_type t])
+let global g =
+  let {gtype; init} = g.it in
+  Node ("global", [atom value_type gtype; expr init])
 
 let export ex =
   let {name; kind} = ex.it in

--- a/ml-proto/host/arrange.ml
+++ b/ml-proto/host/arrange.ml
@@ -217,6 +217,8 @@ let rec expr e =
     | GetLocal x -> "get_local " ^ var x, []
     | SetLocal (x, e) -> "set_local " ^ var x, [expr e]
     | TeeLocal (x, e) -> "tee_local " ^ var x, [expr e]
+    | GetGlobal x -> "get_global " ^ var x, []
+    | SetGlobal (x, e) -> "set_global " ^ var x, [expr e]
     | Load (op, e) -> memop "load" op, [expr e]
     | Store (op, e1, e2) -> memop "store" op, [expr e1; expr e2]
     | LoadExtend (op, e) -> extop op, [expr e]
@@ -276,6 +278,9 @@ let import i im =
     [atom string module_name; atom string func_name; ty]
   )
 
+let global t =
+  Node ("global", [atom value_type t])
+
 let export ex =
   let {name; kind} = ex.it in
   let desc = match kind with `Func x -> var x | `Memory -> "memory" in
@@ -291,6 +296,7 @@ let module_ m =
     listi func m.it.funcs @
     table m.it.table @
     opt memory m.it.memory @
+    list global m.it.globals @
     list export m.it.exports @
     opt start m.it.start
   )

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -342,7 +342,7 @@ let encode m =
       value_type t; expr e; op 0x0f
 
     let global_section gs =
-      section "code" (vec global) gs (gs <> [])
+      section "global" (vec global) gs (gs <> [])
 
     (* Export section *)
     let export exp =

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -337,16 +337,12 @@ let encode m =
       section "memory" (opt memory) memo (memo <> None)
 
     (* Global section *)
-    let compress ts =
-      let combine t = function
-        | (t', n) :: ts when t = t' -> (t, n + 1) :: ts
-        | ts -> (t, 1) :: ts
-      in List.fold_right combine ts []
+    let global g =
+      let {gtype = t; init = e} = g.it in
+      value_type t; expr e; op 0x0f
 
-    let global (t, n) = vu n; value_type t
-
-    let global_section ts =
-      section "code" (vec global) (compress ts) (ts <> [])
+    let global_section gs =
+      section "code" (vec global) gs (gs <> [])
 
     (* Export section *)
     let export exp =
@@ -366,6 +362,12 @@ let encode m =
       section "start" (opt var) xo (xo <> None)
 
     (* Code section *)
+    let compress ts =
+      let combine t = function
+        | (t', n) :: ts when t = t' -> (t, n + 1) :: ts
+        | ts -> (t, 1) :: ts
+      in List.fold_right combine ts []
+
     let local (t, n) = vu n; value_type t
 
     let code f =

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -127,8 +127,8 @@ let encode m =
       | Ast.Get_local x -> op 0x14; var x
       | Ast.Set_local (x, e) -> unary e 0x15; var x
       | Ast.Tee_local (x, e) -> unary e 0x19; var x
-      | Ast.Get_global x -> op 0x1a; var x
-      | Ast.Set_global (x, e) -> unary e 0x1b; var x
+      | Ast.Get_global x -> op 0xbb; var x
+      | Ast.Set_global (x, e) -> unary e 0xbc; var x
 
       | Ast.Call (x, es) -> nary es 0x16; var x
       | Ast.Call_indirect (x, e, es) -> expr e; nary es 0x17; var x

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -160,6 +160,8 @@ rule token = parse
   | "get_local" { GET_LOCAL }
   | "set_local" { SET_LOCAL }
   | "tee_local" { TEE_LOCAL }
+  | "get_global" { GET_GLOBAL }
+  | "set_global" { SET_GLOBAL }
 
   | (nxx as t)".load"
     { LOAD (fun (o, a, e) ->
@@ -360,6 +362,7 @@ rule token = parse
   | "param" { PARAM }
   | "result" { RESULT }
   | "local" { LOCAL }
+  | "global" { GLOBAL }
   | "module" { MODULE }
   | "memory" { MEMORY }
   | "segment" { SEGMENT }

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -26,10 +26,12 @@ and expr' =
   | Call_import of var * expr list
   | Call_indirect of var * expr * expr list
 
-  (* Locals *)
+  (* Variables *)
   | Get_local of var
   | Set_local of var * expr
   | Tee_local of var * expr
+  | Get_global of var
+  | Set_global of var * expr
 
   (* Memory access *)
   | I32_load of Memory.offset * int * expr
@@ -212,6 +214,7 @@ and module' =
 {
   memory : Kernel.memory option;
   types : Types.func_type list;
+  globals : Types.value_type list;
   funcs : func list;
   start : var option;
   imports : Kernel.import list;

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -196,7 +196,14 @@ and expr' =
   | Grow_memory of expr
 
 
-(* Functions *)
+(* Globals and Functions *)
+
+type global = global' Source.phrase
+and global' =
+{
+  gtype : Types.value_type;
+  init : expr;
+}
 
 type func = func' Source.phrase
 and func' =
@@ -214,7 +221,7 @@ and module' =
 {
   memory : Kernel.memory option;
   types : Types.func_type list;
-  globals : Types.value_type list;
+  globals : global list;
   funcs : func list;
   start : var option;
   imports : Kernel.import list;

--- a/ml-proto/spec/decode.ml
+++ b/ml-proto/spec/decode.ml
@@ -513,12 +513,15 @@ let memory_section s =
 (* Global section *)
 
 let global s =
-  let n = vu s in
   let t = value_type s in
-  Lib.List.make n t
+  let pos = pos s in
+  let es = expr_block s in
+  require (List.length es = 1) s pos "single expression expected";
+  expect 0x0f s "`end` opcode expected";
+  {gtype = t; init = List.hd es}
 
 let global_section s =
-  section `GlobalSection (fun s -> List.flatten (vec global s)) [] s
+  section `GlobalSection (vec (at global)) [] s
 
 
 (* Export section *)

--- a/ml-proto/spec/decode.ml
+++ b/ml-proto/spec/decode.ml
@@ -249,12 +249,6 @@ let rec expr stack s =
   | 0x19, e :: es ->
     let x = at var s in
     Tee_local (x, e), es
-  | 0x1a, es ->
-    let x = at var s in
-    Get_global x, es
-  | 0x1b, e :: es ->
-    let x = at var s in
-    Set_global (x, e), es
 
   | 0x1c | 0x1d | 0x1e | 0x1f as b, _ ->
     illegal s pos b
@@ -421,7 +415,14 @@ let rec expr stack s =
   | 0xb9, e2 :: e1 :: es -> I64_rotr (e1, e2), es
   | 0xba, e :: es -> I64_eqz e, es
 
-  | b, _ when b > 0xba -> illegal s pos b
+  | 0xbb, es ->
+    let x = at var s in
+    Get_global x, es
+  | 0xbc, e :: es ->
+    let x = at var s in
+    Set_global (x, e), es
+
+  | b, _ when b > 0xbc -> illegal s pos b
 
   | b, _ -> error s pos "too few operands for operator"
 

--- a/ml-proto/spec/desugar.ml
+++ b/ml-proto/spec/desugar.ml
@@ -33,6 +33,8 @@ and relabel' f n = function
   | GetLocal x -> GetLocal x
   | SetLocal (x, e) -> SetLocal (x, relabel f n e)
   | TeeLocal (x, e) -> TeeLocal (x, relabel f n e)
+  | GetGlobal x -> GetGlobal x
+  | SetGlobal (x, e) -> SetGlobal (x, relabel f n e)
   | Load (memop, e) -> Load (memop, relabel f n e)
   | Store (memop, e1, e2) -> Store (memop, relabel f n e1, relabel f n e2)
   | LoadExtend (extop, e) -> LoadExtend (extop, relabel f n e)
@@ -83,6 +85,8 @@ and expr' at = function
   | Ast.Get_local x -> GetLocal x
   | Ast.Set_local (x, e) -> SetLocal (x, expr e)
   | Ast.Tee_local (x, e) -> TeeLocal (x, expr e)
+  | Ast.Get_global x -> GetGlobal x
+  | Ast.Set_global (x, e) -> SetGlobal (x, expr e)
 
   | Ast.I32_load (offset, align, e) ->
     Load ({ty = Int32Type; offset; align}, expr e)
@@ -301,7 +305,8 @@ and func' = function
 
 let rec module_ m = module' m.it @@ m.at
 and module' = function
-  | {Ast.funcs = fs; start; memory; types; imports; exports; table} ->
-    {funcs = List.map func fs; start; memory; types; imports; exports; table}
+  | {Ast.funcs = fs; start; globals; memory; types; imports; exports; table} ->
+    let funcs = List.map func fs in
+    {funcs; start; globals; memory; types; imports; exports; table}
 
 let desugar = module_

--- a/ml-proto/spec/desugar.ml
+++ b/ml-proto/spec/desugar.ml
@@ -299,13 +299,18 @@ and block = function
 
 (* Functions and Modules *)
 
+let rec global g = global' g.it @@ g.at
+and global' = function
+  | {Ast.gtype = t; init = e} -> {gtype = t; init = expr e}
+
 let rec func f = func' f.it @@ f.at
 and func' = function
   | {Ast.body = es; ftype; locals} -> {body = return (seq es); ftype; locals}
 
 let rec module_ m = module' m.it @@ m.at
 and module' = function
-  | {Ast.funcs = fs; start; globals; memory; types; imports; exports; table} ->
+  | {Ast.funcs = fs; start; globals = gs; memory; types; imports; exports; table} ->
+    let globals = List.map global gs in
     let funcs = List.map func fs in
     {funcs; start; globals; memory; types; imports; exports; table}
 

--- a/ml-proto/spec/kernel.ml
+++ b/ml-proto/spec/kernel.ml
@@ -120,6 +120,13 @@ and func' =
 
 (* Modules *)
 
+type global = global' Source.phrase
+and global' =
+{
+  gtype : Types.value_type;
+  init : expr;
+}
+
 type memory = memory' Source.phrase
 and memory' =
 {
@@ -149,7 +156,7 @@ and module_' =
 {
   memory : memory option;
   types : Types.func_type list;
-  globals : Types.value_type list;
+  globals : global list;
   funcs : func list;
   start : var option;
   imports : import list;

--- a/ml-proto/spec/kernel.ml
+++ b/ml-proto/spec/kernel.ml
@@ -92,6 +92,8 @@ and expr' =
   | GetLocal of var                         (* read local variable *)
   | SetLocal of var * expr                  (* write local variable *)
   | TeeLocal of var * expr                  (* write local variable and keep value *)
+  | GetGlobal of var                        (* read global variable *)
+  | SetGlobal of var * expr                 (* write global variable *)
   | Load of memop * expr                    (* read memory at address *)
   | Store of memop * expr * expr            (* write memory at address *)
   | LoadExtend of extop * expr              (* read memory at address and extend *)
@@ -147,6 +149,7 @@ and module_' =
 {
   memory : memory option;
   types : Types.func_type list;
+  globals : Types.value_type list;
   funcs : func list;
   start : var option;
   imports : import list;

--- a/ml-proto/test/globals.wast
+++ b/ml-proto/test/globals.wast
@@ -1,0 +1,32 @@
+;; TODO: more tests
+
+(module
+  (global $x i32)
+  (global f32 f64)
+  (global $y i64)
+
+  (func "get-x" (result i32) (get_global $x))
+  (func "get-y" (result i64) (get_global $y))
+  (func "set-x" (param i32) (set_global $x (get_local 0)))
+  (func "set-y" (param i64) (set_global $y (get_local 0)))
+
+  (func "get-1" (result f32) (get_global 1))
+  (func "get-2" (result f64) (get_global 2))
+  (func "set-1" (param f32) (set_global 1 (get_local 0)))
+  (func "set-2" (param f64) (set_global 2 (get_local 0)))
+)
+
+(assert_return (invoke "get-x") (i32.const 0))
+(assert_return (invoke "get-y") (i64.const 0))
+(assert_return (invoke "get-1") (f32.const 0))
+(assert_return (invoke "get-2") (f64.const 0))
+
+(assert_return (invoke "set-x" (i32.const 6)))
+(assert_return (invoke "set-y" (i64.const 7)))
+(assert_return (invoke "set-1" (f32.const 8)))
+(assert_return (invoke "set-2" (f64.const 9)))
+
+(assert_return (invoke "get-x") (i32.const 6))
+(assert_return (invoke "get-y") (i64.const 7))
+(assert_return (invoke "get-1") (f32.const 8))
+(assert_return (invoke "get-2") (f64.const 9))

--- a/ml-proto/test/globals.wast
+++ b/ml-proto/test/globals.wast
@@ -1,9 +1,10 @@
 ;; TODO: more tests
 
 (module
-  (global $x i32)
-  (global f32 f64)
-  (global $y i64)
+  (global $x i32 (i32.const -2))
+  (global f32 (f32.const -3))
+  (global f64 (f64.const -4))
+  (global $y i64 (i64.const -5))
 
   (func "get-x" (result i32) (get_global $x))
   (func "get-y" (result i64) (get_global $y))
@@ -16,10 +17,10 @@
   (func "set-2" (param f64) (set_global 2 (get_local 0)))
 )
 
-(assert_return (invoke "get-x") (i32.const 0))
-(assert_return (invoke "get-y") (i64.const 0))
-(assert_return (invoke "get-1") (f32.const 0))
-(assert_return (invoke "get-2") (f64.const 0))
+(assert_return (invoke "get-x") (i32.const -2))
+(assert_return (invoke "get-y") (i64.const -5))
+(assert_return (invoke "get-1") (f32.const -3))
+(assert_return (invoke "get-2") (f64.const -4))
 
 (assert_return (invoke "set-x" (i32.const 6)))
 (assert_return (invoke "set-y" (i64.const 7)))
@@ -30,3 +31,23 @@
 (assert_return (invoke "get-y") (i64.const 7))
 (assert_return (invoke "get-1") (f32.const 8))
 (assert_return (invoke "get-2") (f64.const 9))
+
+(assert_invalid
+  (module (global f32 (f32.neg (f32.const 0))))
+  "not an initialization expression"
+)
+
+(assert_invalid
+  (module (global f32 (get_local 0)))
+  "not an initialization expression"
+)
+
+(assert_invalid
+  (module (global i32 (f32.const 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global i32 (get_global 0)))
+  "unknown global"
+)


### PR DESCRIPTION
Implements global declarations as of WebAssembly/design#682. Still missing: mutability, import/export.

Also, binary opcodes currently don't match WebAssembly/design#727, due to conflicts with WebAssembly/design#711.