### PR TITLE
Script support for testing dynamic linking

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -226,7 +226,8 @@ cmd:
   ( output <string>? )                      ;; output module to stout or file
 
 action:
-  ( invoke <name> <expr>* )                 ;; invoke export
+  ( invoke <name> <expr>* )                 ;; invoke function export
+  ( get <name> )                            ;; get global export
 ```
 
 Commands are executed in sequence. Invocation, assertions, and output apply to the most recently defined module (the _current_ module), and are only possible after a module has been defined. Note that there only ever is one current module, the different module definitions cannot interact.

--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -215,14 +215,18 @@ In order to be able to check and run modules for testing purposes, the S-express
 script: <cmd>*
 
 cmd:
-  <module>                                             ;; define, validate, and initialize module
-  ( invoke <name> <expr>* )                            ;; invoke export and print result
-  ( assert_return (invoke <name> <expr>* ) <expr> )    ;; assert return with expected result of invocation
-  ( assert_return_nan (invoke <name> <expr>* ))        ;; assert return with floating point nan result of invocation
-  ( assert_trap (invoke <name> <expr>* ) <failure> )   ;; assert invocation traps with given failure string
-  ( assert_invalid <module> <failure> )                ;; assert invalid module with given failure string
-  ( input <string> )                                   ;; read script or module from file
-  ( output <string>? )                                 ;; output module to stout or file
+  <module>                                  ;; define, validate, and initialize module
+  <action>                                  ;; perform action and print results
+  ( assert_return <action> <expr>? )        ;; assert action has expected results
+  ( assert_return_nan <action> )            ;; assert action results in NaN
+  ( assert_trap <action> <failure> )        ;; assert action traps with given failure string
+  ( assert_invalid <module> <failure> )     ;; assert module is invalid with given failure string
+  ( assert_unlinkable <module> <failure> )  ;; assert module fails to link module with given failure string
+  ( input <string> )                        ;; read script or module from file
+  ( output <string>? )                      ;; output module to stout or file
+
+action:
+  ( invoke <name> <expr>* )                 ;; invoke export
 ```
 
 Commands are executed in sequence. Invocation, assertions, and output apply to the most recently defined module (the _current_ module), and are only possible after a module has been defined. Note that there only ever is one current module, the different module definitions cannot interact.

--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -183,8 +183,8 @@ exkind:  ( func <var> )
          ( table <var> )
          ( memory <var> )
 
-module:  ( module <typedef>* <func>* <import>* <export>* <table>? <memory>? <elem>* <data>* <start>? )
-         ( module <string>+ )
+module:  ( module <name>? <typedef>* <func>* <import>* <export>* <table>? <memory>? <elem>* <data>* <start>? )
+         ( module <name>? <string>+ )
 ```
 
 Here, productions marked with respective comments are abbreviation forms for equivalent expansions (see the explanation of the kernel AST below).
@@ -217,20 +217,23 @@ script: <cmd>*
 cmd:
   <module>                                  ;; define, validate, and initialize module
   <action>                                  ;; perform action and print results
+  ( register <string> <name>? )             ;; register module for imports
   ( assert_return <action> <expr>? )        ;; assert action has expected results
   ( assert_return_nan <action> )            ;; assert action results in NaN
   ( assert_trap <action> <failure> )        ;; assert action traps with given failure string
   ( assert_invalid <module> <failure> )     ;; assert module is invalid with given failure string
   ( assert_unlinkable <module> <failure> )  ;; assert module fails to link module with given failure string
   ( input <string> )                        ;; read script or module from file
-  ( output <string>? )                      ;; output module to stout or file
+  ( output <name>? <string>? )              ;; output module to stout or file
 
 action:
-  ( invoke <name> <expr>* )                 ;; invoke function export
-  ( get <name> )                            ;; get global export
+  ( invoke <name>? <string> <expr>* )       ;; invoke function export
+  ( get <name>? <string> )                  ;; get global export
 ```
 
-Commands are executed in sequence. Invocation, assertions, and output apply to the most recently defined module (the _current_ module), and are only possible after a module has been defined. Note that there only ever is one current module, the different module definitions cannot interact.
+Commands are executed in sequence. Commands taking an optional module name refer to the most recently defined module if no name is given. They are only possible after a module has been defined.
+
+After a module is _registered_ under a string name it is available for importing in other modules.
 
 The input and output commands determine the requested file format from the file name extension. They can handle both `.wast` and `.wasm` files. In the case of input, a `.wast` script will be recursively executed.
 

--- a/ml-proto/given/lib.ml
+++ b/ml-proto/given/lib.ml
@@ -1,3 +1,9 @@
+module Fun =
+struct
+  let rec repeat n f x =
+    if n = 0 then () else (f x; repeat (n - 1) f x)
+end
+
 module List =
 struct
   let rec make n x =

--- a/ml-proto/given/lib.mli
+++ b/ml-proto/given/lib.mli
@@ -1,5 +1,10 @@
 (* Things that should be in the OCaml library... *)
 
+module Fun :
+sig
+  val repeat : int -> ('a -> unit) -> 'a -> unit
+end
+
 module List :
 sig
   val make : int -> 'a -> 'a list

--- a/ml-proto/host/import.mli
+++ b/ml-proto/host/import.mli
@@ -2,4 +2,7 @@ exception Unknown of Source.region * string
 
 val link : Kernel.module_ -> Instance.extern list (* raises Unknown *)
 
-val register : string -> (string -> Types.external_type -> Instance.extern) -> unit
+val register :
+  string ->
+  (string -> Types.external_type -> Instance.extern (* raise Not_found *)) ->
+  unit

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -371,12 +371,13 @@ rule token = parse
   | "import" { IMPORT }
   | "export" { EXPORT }
 
+  | "invoke" { INVOKE }
+  | "get" { GET }
   | "assert_invalid" { ASSERT_INVALID }
   | "assert_unlinkable" { ASSERT_UNLINKABLE }
   | "assert_return" { ASSERT_RETURN }
   | "assert_return_nan" { ASSERT_RETURN_NAN }
   | "assert_trap" { ASSERT_TRAP }
-  | "invoke" { INVOKE }
   | "input" { INPUT }
   | "output" { OUTPUT }
 

--- a/ml-proto/host/lexer.mll
+++ b/ml-proto/host/lexer.mll
@@ -371,6 +371,7 @@ rule token = parse
   | "import" { IMPORT }
   | "export" { EXPORT }
 
+  | "register" { REGISTER }
   | "invoke" { INVOKE }
   | "get" { GET }
   | "assert_invalid" { ASSERT_INVALID }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -151,8 +151,9 @@ let inline_type c t at =
 %token UNREACHABLE CURRENT_MEMORY GROW_MEMORY
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token MODULE TABLE ELEM MEMORY DATA IMPORT EXPORT TABLE
+%token INVOKE GET
 %token ASSERT_INVALID ASSERT_UNLINKABLE
-%token ASSERT_RETURN ASSERT_RETURN_NAN ASSERT_TRAP INVOKE
+%token ASSERT_RETURN ASSERT_RETURN_NAN ASSERT_TRAP
 %token INPUT OUTPUT
 %token EOF
 
@@ -607,6 +608,7 @@ module_ :
 
 action :
   | LPAR INVOKE TEXT const_list RPAR { Invoke ($3, $4) @@ at () }
+  | LPAR GET TEXT RPAR { Get $3 @@ at() }
 
 cmd :
   | module_ { Define $1 @@ at () }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -154,7 +154,7 @@ let inline_type c t at =
 %token UNREACHABLE CURRENT_MEMORY GROW_MEMORY
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token MODULE TABLE ELEM MEMORY DATA IMPORT EXPORT TABLE
-%token INVOKE GET
+%token REGISTER INVOKE GET
 %token ASSERT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_RETURN_NAN ASSERT_TRAP
 %token INPUT OUTPUT
@@ -623,6 +623,7 @@ action :
 cmd :
   | module_ { Define (fst $1, snd $1) @@ at () }
   | action { Action $1 @@ at () }
+  | LPAR REGISTER TEXT module_var_opt RPAR { Register ($3, $4) @@ at () }
   | LPAR ASSERT_INVALID module_ TEXT RPAR
     { AssertInvalid (snd $3, $4) @@ at () }
   | LPAR ASSERT_UNLINKABLE module_ TEXT RPAR

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -605,17 +605,17 @@ module_ :
 
 /* Scripts */
 
+action :
+  | LPAR INVOKE TEXT const_list RPAR { Invoke ($3, $4) @@ at () }
+
 cmd :
   | module_ { Define $1 @@ at () }
-  | LPAR INVOKE TEXT const_list RPAR { Invoke ($3, $4) @@ at () }
+  | action { Action $1 @@ at () }
   | LPAR ASSERT_INVALID module_ TEXT RPAR { AssertInvalid ($3, $4) @@ at () }
   | LPAR ASSERT_UNLINKABLE module_ TEXT RPAR { AssertUnlinkable ($3, $4) @@ at () }
-  | LPAR ASSERT_RETURN LPAR INVOKE TEXT const_list RPAR const_opt RPAR
-    { AssertReturn ($5, $6, $8) @@ at () }
-  | LPAR ASSERT_RETURN_NAN LPAR INVOKE TEXT const_list RPAR RPAR
-    { AssertReturnNaN ($5, $6) @@ at () }
-  | LPAR ASSERT_TRAP LPAR INVOKE TEXT const_list RPAR TEXT RPAR
-    { AssertTrap ($5, $6, $8) @@ at () }
+  | LPAR ASSERT_RETURN action const_opt RPAR { AssertReturn ($3, $4) @@ at () }
+  | LPAR ASSERT_RETURN_NAN action RPAR { AssertReturnNaN $3 @@ at () }
+  | LPAR ASSERT_TRAP action TEXT RPAR { AssertTrap ($3, $4) @@ at () }
   | LPAR INPUT TEXT RPAR { Input $3 @@ at () }
   | LPAR OUTPUT TEXT RPAR { Output (Some $3) @@ at () }
   | LPAR OUTPUT RPAR { Output None @@ at () }

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -63,15 +63,15 @@ type types = {mutable tmap : int VarMap.t; mutable tlist : Types.func_type list}
 let empty_types () = {tmap = VarMap.empty; tlist = []}
 
 type context =
-  {types : types; tables : space; memories : space; funcs : space;
-   locals : space; globals : space; labels : int VarMap.t}
+  { types : types; tables : space; memories : space;
+    funcs : space; locals : space; globals : space; labels : int VarMap.t }
 
 let empty_context () =
-  {types = empty_types (); tables = empty (); memories = empty ();
-   funcs = empty (); locals = empty (); globals = empty (); labels = VarMap.empty}
+  { types = empty_types (); tables = empty (); memories = empty ();
+    funcs = empty (); locals = empty (); globals = empty ();
+    labels = VarMap.empty }
 
 let enter_func c =
-  assert (VarMap.is_empty c.labels);
   {c with labels = VarMap.empty; locals = empty ()}
 
 let type_ c x =
@@ -91,10 +91,16 @@ let label c x =
   try VarMap.find x.it c.labels
   with Not_found -> error x.at ("unknown label " ^ x.it)
 
+let bind_module () x = Some x
+let anon_module () = None
+
 let bind_type c x ty =
   if VarMap.mem x.it c.types.tmap then
     error x.at ("duplicate type " ^ x.it);
   c.types.tmap <- VarMap.add x.it (List.length c.types.tlist) c.types.tmap;
+  c.types.tlist <- c.types.tlist @ [ty]
+
+let anon_type c ty =
   c.types.tlist <- c.types.tlist @ [ty]
 
 let bind category space x =
@@ -110,9 +116,6 @@ let bind_table c x = bind "table" c.tables x
 let bind_memory c x = bind "memory" c.memories x
 let bind_label c x =
   {c with labels = VarMap.add x.it 0 (VarMap.map ((+) 1) c.labels)}
-
-let anon_type c ty =
-  c.types.tlist <- c.types.tlist @ [ty]
 
 let anon space n = space.count <- space.count + n
 
@@ -598,29 +601,38 @@ module_fields :
       {m with exports = $1 c :: m.exports} }
 ;
 module_ :
-  | LPAR MODULE module_fields RPAR
-    { Textual ($3 (empty_context ()) @@ at ()) @@ at() }
-  | LPAR MODULE TEXT text_list RPAR { Binary ($3 ^ $4) @@ at() }
+  | LPAR MODULE module_var_opt module_fields RPAR
+    { $3, Textual ($4 (empty_context ()) @@ at ()) @@ at () }
+  | LPAR MODULE module_var_opt TEXT text_list RPAR
+    { $3, Binary ($4 ^ $5) @@ at() }
 ;
 
 
 /* Scripts */
 
+module_var_opt :
+  | /* empty */ { None }
+  | VAR { Some ($1 @@ at ()) }  /* Sugar */
+;
 action :
-  | LPAR INVOKE TEXT const_list RPAR { Invoke ($3, $4) @@ at () }
-  | LPAR GET TEXT RPAR { Get $3 @@ at() }
-
+  | LPAR INVOKE module_var_opt TEXT const_list RPAR
+    { Invoke ($3, $4, $5) @@ at () }
+  | LPAR GET module_var_opt TEXT RPAR
+    { Get ($3, $4) @@ at() }
+;
 cmd :
-  | module_ { Define $1 @@ at () }
+  | module_ { Define (fst $1, snd $1) @@ at () }
   | action { Action $1 @@ at () }
-  | LPAR ASSERT_INVALID module_ TEXT RPAR { AssertInvalid ($3, $4) @@ at () }
-  | LPAR ASSERT_UNLINKABLE module_ TEXT RPAR { AssertUnlinkable ($3, $4) @@ at () }
+  | LPAR ASSERT_INVALID module_ TEXT RPAR
+    { AssertInvalid (snd $3, $4) @@ at () }
+  | LPAR ASSERT_UNLINKABLE module_ TEXT RPAR
+    { AssertUnlinkable (snd $3, $4) @@ at () }
   | LPAR ASSERT_RETURN action const_opt RPAR { AssertReturn ($3, $4) @@ at () }
   | LPAR ASSERT_RETURN_NAN action RPAR { AssertReturnNaN $3 @@ at () }
   | LPAR ASSERT_TRAP action TEXT RPAR { AssertTrap ($3, $4) @@ at () }
   | LPAR INPUT TEXT RPAR { Input $3 @@ at () }
-  | LPAR OUTPUT TEXT RPAR { Output (Some $3) @@ at () }
-  | LPAR OUTPUT RPAR { Output None @@ at () }
+  | LPAR OUTPUT module_var_opt TEXT RPAR { Output ($3, Some $4) @@ at () }
+  | LPAR OUTPUT module_var_opt RPAR { Output ($3, None) @@ at () }
 ;
 cmd_list :
   | /* empty */ { [] }
@@ -646,6 +658,6 @@ script1 :
   | cmd { [$1] }
 ;
 module1 :
-  | module_ EOF { $1 }
+  | module_ EOF { snd $1 }
 ;
 %%

--- a/ml-proto/host/run.ml
+++ b/ml-proto/host/run.ml
@@ -45,7 +45,7 @@ let run_binary name buf =
   run_from
     (fun _ ->
       let m = Decode.decode name buf in
-      [Script.Define (Script.Textual m @@ m.at) @@ m.at])
+      [Script.Define (None, Script.Textual m @@ m.at) @@ m.at])
 
 let run_sexpr_file file =
   Script.trace ("Loading (" ^ file ^ ")...");

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -13,6 +13,7 @@ and action' =
 type command = command' Source.phrase
 and command' =
   | Define of var option * definition
+  | Register of string * var option
   | Action of action
   | AssertInvalid of definition * string
   | AssertUnlinkable of definition * string

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -3,15 +3,19 @@ and definition' =
   | Textual of Ast.module_
   | Binary of string
 
+type action = action' Source.phrase
+and action' =
+  | Invoke of string * Kernel.literal list
+
 type command = command' Source.phrase
 and command' =
   | Define of definition
-  | Invoke of string * Kernel.literal list
+  | Action of action
   | AssertInvalid of definition * string
   | AssertUnlinkable of definition * string
-  | AssertReturn of string * Kernel.literal list * Kernel.literal option
-  | AssertReturnNaN of string * Kernel.literal list
-  | AssertTrap of string * Kernel.literal list * string
+  | AssertReturn of action * Kernel.literal option
+  | AssertReturnNaN of action
+  | AssertTrap of action * string
   | Input of string
   | Output of string option
 

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -6,6 +6,7 @@ and definition' =
 type action = action' Source.phrase
 and action' =
   | Invoke of string * Kernel.literal list
+  | Get of string
 
 type command = command' Source.phrase
 and command' =

--- a/ml-proto/host/script.mli
+++ b/ml-proto/host/script.mli
@@ -1,3 +1,5 @@
+type var = string Source.phrase
+
 type definition = definition' Source.phrase
 and definition' =
   | Textual of Ast.module_
@@ -5,12 +7,12 @@ and definition' =
 
 type action = action' Source.phrase
 and action' =
-  | Invoke of string * Kernel.literal list
-  | Get of string
+  | Invoke of var option * string * Kernel.literal list
+  | Get of var option * string
 
 type command = command' Source.phrase
 and command' =
-  | Define of definition
+  | Define of var option * definition
   | Action of action
   | AssertInvalid of definition * string
   | AssertUnlinkable of definition * string
@@ -18,7 +20,7 @@ and command' =
   | AssertReturnNaN of action
   | AssertTrap of action * string
   | Input of string
-  | Output of string option
+  | Output of var option * string option
 
 type script = command list
 

--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -50,23 +50,23 @@ class RunTests(unittest.TestCase):
     if expectedExitCode != 0:
       return
 
-    # Convert to binary and run again
+    # Convert to binary and validate again
     wasmPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.log"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, fileName, wasmPath))
-    self._runCommand(("%s %s") % (interpreterPath, wasmPath), logPath)
+    self._runCommand(("%s -d %s") % (interpreterPath, wasmPath), logPath)
 
-    # Convert back to text and run again
+    # Convert back to text and validate again
     wastPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.log"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, wasmPath, wastPath))
-    self._runCommand(("%s %s ") % (interpreterPath, wastPath), logPath)
+    self._runCommand(("%s -d %s ") % (interpreterPath, wastPath), logPath)
 
     #return
     # Convert back to binary once more and compare
     wasm2Path = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.wasm"))
     self._runCommand(("%s -d %s -o %s") % (interpreterPath, wastPath, wasm2Path))
-    self._runCommand(("%s %s") % (interpreterPath, wasm2Path), logPath)
+    self._runCommand(("%s -d %s") % (interpreterPath, wasm2Path), logPath)
     # TODO: Ultimately, the binary should stay the same, but currently desugaring gets in the way.
     # self._compareFile(wasmPath, wasm2Path)
 

--- a/ml-proto/spec/eval.mli
+++ b/ml-proto/spec/eval.mli
@@ -6,6 +6,5 @@ exception Trap of Source.region * string
 exception Crash of Source.region * string
 
 val init : Kernel.module_ -> extern list -> instance
-val invoke : instance -> string -> value list -> value option
-  (* raises Trap, Crash *)
+val invoke : func -> value list -> value option  (* raises Trap *)
 val const : Kernel.module_ -> Kernel.expr -> value

--- a/ml-proto/spec/instance.ml
+++ b/ml-proto/spec/instance.ml
@@ -27,3 +27,6 @@ and instance =
 let instance m =
   { module_ = m; funcs = []; tables = []; memories = []; globals = [];
     exports = ExportMap.empty }
+
+let export inst name =
+  try Some (ExportMap.find name inst.exports) with Not_found -> None

--- a/ml-proto/spec/instance.ml
+++ b/ml-proto/spec/instance.ml
@@ -24,6 +24,8 @@ and instance =
   exports : extern ExportMap.t;
 }
 
+exception Func of func
+
 let instance m =
   { module_ = m; funcs = []; tables = []; memories = []; globals = [];
     exports = ExportMap.empty }

--- a/ml-proto/spec/table.ml
+++ b/ml-proto/spec/table.ml
@@ -4,7 +4,7 @@ open Values
 type size = int32
 type index = int32
 
-type elem = int option
+type elem = exn option
 type elem_type = Types.elem_type
 type 'a limits = 'a Types.limits
 

--- a/ml-proto/spec/table.mli
+++ b/ml-proto/spec/table.mli
@@ -4,7 +4,7 @@ type t = table
 type size = int32
 type index = int32
 
-type elem = int option
+type elem = exn option
 type elem_type = Types.elem_type
 type 'a limits = 'a Types.limits
 

--- a/ml-proto/test/binary.wast
+++ b/ml-proto/test/binary.wast
@@ -1,5 +1,7 @@
 (module "\00asm\0c\00\00\00")
 (module "\00asm" "\0c\00\00\00")
+(module $M "\00asm\0c\00\00\00")
+(module $M "\00asm" "\0c\00\00\00")
 
 (assert_invalid (module "") "unexpected end")
 (assert_invalid (module "\01") "unexpected end")

--- a/ml-proto/test/exports.wast
+++ b/ml-proto/test/exports.wast
@@ -33,11 +33,10 @@
 )
 
 (module
+  (export "e" (func $f))
   (func $f (param $n i32) (result i32)
     (return (i32.add (get_local $n) (i32.const 1)))
   )
-
-  (export "e" (func $f))
 )
 
 (assert_return (invoke "e" (i32.const 42)) (i32.const 43))
@@ -77,7 +76,12 @@
   "duplicate export name"
 )
 
-(; TODO: get global value ;)
+(module
+  (export "e" (global $g))
+  (global $g i32 (i32.const 42))
+)
+
+(assert_return (get "e") (i32.const 42))
 
 
 ;; Tables

--- a/ml-proto/test/exports.wast
+++ b/ml-proto/test/exports.wast
@@ -7,6 +7,18 @@
 (module (func (export "a")))
 (module (func $a (export "a")))
 
+(module $Func
+  (export "e" (func $f))
+  (func $f (param $n i32) (result i32)
+    (return (i32.add (get_local $n) (i32.const 1)))
+  )
+)
+(assert_return (invoke "e" (i32.const 42)) (i32.const 43))
+(assert_return (invoke $Func "e" (i32.const 42)) (i32.const 43))
+(module)
+(module $Other)
+(assert_return (invoke $Func "e" (i32.const 42)) (i32.const 43))
+
 (assert_invalid
   (module (func) (export "a" (func 1)))
   "unknown function"
@@ -32,15 +44,6 @@
   "duplicate export name"
 )
 
-(module
-  (export "e" (func $f))
-  (func $f (param $n i32) (result i32)
-    (return (i32.add (get_local $n) (i32.const 1)))
-  )
-)
-
-(assert_return (invoke "e" (i32.const 42)) (i32.const 43))
-
 
 ;; Globals
 
@@ -50,6 +53,16 @@
 
 (module (global (export "a") i32 (i32.const 0)))
 (module (global $a (export "a") i32 (i32.const 0)))
+
+(module $Global
+  (export "e" (global $g))
+  (global $g i32 (i32.const 42))
+)
+(assert_return (get "e") (i32.const 42))
+(assert_return (get $Global "e") (i32.const 42))
+(module)
+(module $Other)
+(assert_return (get $Global "e") (i32.const 42))
 
 (assert_invalid
   (module (global i32 (i32.const 0)) (export "a" (global 1)))
@@ -76,13 +89,6 @@
   "duplicate export name"
 )
 
-(module
-  (export "e" (global $g))
-  (global $g i32 (i32.const 42))
-)
-
-(assert_return (get "e") (i32.const 42))
-
 
 ;; Tables
 
@@ -95,6 +101,8 @@
 (module (table (export "a") 0 1 anyfunc))
 (module (table $a (export "a") 0 anyfunc))
 (module (table $a (export "a") 0 1 anyfunc))
+
+(; TODO: access table ;)
 
 (assert_invalid
   (module (table 0 anyfunc) (export "a" (table 1)))
@@ -122,8 +130,6 @@
   "duplicate export name"
 )
 
-(; TODO: access table ;)
-
 
 ;; Memories
 
@@ -136,6 +142,8 @@
 (module (memory (export "a") 0 1))
 (module (memory $a (export "a") 0))
 (module (memory $a (export "a") 0 1))
+
+(; TODO: access memory ;)
 
 (assert_invalid
   (module (memory 0) (export "a" (memory 1)))
@@ -162,6 +170,3 @@
   (module (memory 0) (table 0 anyfunc) (export "a" (memory 0)) (export "a" (table 0)))
   "duplicate export name"
 )
-
-(; TODO: access memory ;)
-

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -194,16 +194,6 @@
 (assert_return (invoke "load" (i32.const 8)) (i32.const 0x100000))
 (assert_trap (invoke "load" (i32.const 1000000)) "out of bounds memory access")
 
-(module
-  (import "spectest" "memory" (memory 0 3))  ;; actual has max size 2
-  (func (export "grow") (param i32) (result i32) (grow_memory (get_local 0)))
-)
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 1))
-(assert_return (invoke "grow" (i32.const 1)) (i32.const 1))
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
-(assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
-
 (assert_invalid
   (module (import "" "" (memory 1)) (import "" "" (memory 1)))
   "multiple memories"
@@ -233,3 +223,13 @@
   (module (import "spectest" "memory" (memory 1 1)))
   "maximum size larger than declared"
 )
+
+(module
+  (import "spectest" "memory" (memory 0 3))  ;; actual has max size 2
+  (func (export "grow") (param i32) (result i32) (grow_memory (get_local 0)))
+)
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))

--- a/ml-proto/test/imports.wast
+++ b/ml-proto/test/imports.wast
@@ -189,12 +189,20 @@
 
   (func (export "load") (param i32) (result i32) (i32.load (get_local 0)))
 )
-
 (assert_return (invoke "load" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "load" (i32.const 10)) (i32.const 16))
 (assert_return (invoke "load" (i32.const 8)) (i32.const 0x100000))
 (assert_trap (invoke "load" (i32.const 1000000)) "out of bounds memory access")
 
+(module
+  (import "spectest" "memory" (memory 0 3))  ;; actual has max size 2
+  (func (export "grow") (param i32) (result i32) (grow_memory (get_local 0)))
+)
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
+(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
 
 (assert_invalid
   (module (import "" "" (memory 1)) (import "" "" (memory 1)))
@@ -225,13 +233,3 @@
   (module (import "spectest" "memory" (memory 1 1)))
   "maximum size larger than declared"
 )
-
-(module
-  (import "spectest" "memory" (memory 0 3))  ;; actual has max size 2
-  (func (export "grow") (param i32) (result i32) (grow_memory (get_local 0)))
-)
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 1))
-(assert_return (invoke "grow" (i32.const 1)) (i32.const 1))
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
-(assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
-(assert_return (invoke "grow" (i32.const 0)) (i32.const 2))

--- a/ml-proto/test/linking.wast
+++ b/ml-proto/test/linking.wast
@@ -1,0 +1,197 @@
+;; Functions
+
+(module $M
+  (func (export "call") (result i32) (call $g))
+  (func $g (result i32) (i32.const 2))
+)
+(register "M" $M)
+
+(module $N
+  (func $f (import "M" "call") (result i32))
+  (export "M.call" (func $f))
+  (func (export "call M.call") (result i32) (call $f))
+  (func (export "call") (result i32) (call $g))
+  (func $g (result i32) (i32.const 3))
+)
+
+(assert_return (invoke $M "call") (i32.const 2))
+(assert_return (invoke $N "M.call") (i32.const 2))
+(assert_return (invoke $N "call") (i32.const 3))
+(assert_return (invoke $N "call M.call") (i32.const 2))
+
+
+;; Globals
+
+(module $M
+  (global $glob (export "glob") i32 (i32.const 42))
+  (func (export "get") (result i32) (get_global $glob))
+)
+(register "M" $M)
+
+(module $N
+  (global $x (import "M" "glob") i32)
+  (func $f (import "M" "get") (result i32))
+  (export "M.glob" (global $x))
+  (export "M.get" (func $f))
+  (global $glob (export "glob") i32 (i32.const 43))
+  (func (export "get") (result i32) (get_global $glob))
+)
+
+(assert_return (get $M "glob") (i32.const 42))
+(assert_return (get $N "M.glob") (i32.const 42))
+(assert_return (get $N "glob") (i32.const 43))
+(assert_return (invoke $M "get") (i32.const 42))
+(assert_return (invoke $N "M.get") (i32.const 42))
+(assert_return (invoke $N "get") (i32.const 43))
+
+
+;; Tables
+
+(module $M
+  (type (func (result i32)))
+  (type (func))
+
+  (table (export "tab") 10 anyfunc)
+  (elem (i32.const 2) $g $g $g $g)
+  (func $g (result i32) (i32.const 4))
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect 0 (get_local 0))
+  )
+)
+(register "M" $M)
+
+(module $N
+  (type (func))
+  (type (func (result i32)))
+
+  (func $f (import "M" "call") (param i32) (result i32))
+
+  (table anyfunc (elem $g $g $g))
+  (func $g (result i32) (i32.const 5))
+
+  (export "M.call" (func $f))
+  (func (export "call M.call") (param i32) (result i32)
+    (call $f (get_local 0))
+  )
+  (func (export "call") (param i32) (result i32)
+    (call_indirect 1 (get_local 0))
+  )
+)
+
+(assert_return (invoke $M "call" (i32.const 2)) (i32.const 4))
+(assert_return (invoke $N "M.call" (i32.const 2)) (i32.const 4))
+(assert_return (invoke $N "call" (i32.const 2)) (i32.const 5))
+(assert_return (invoke $N "call M.call" (i32.const 2)) (i32.const 4))
+
+(assert_trap (invoke $M "call" (i32.const 1)) "uninitialized")
+(assert_trap (invoke $N "M.call" (i32.const 1)) "uninitialized")
+(assert_return (invoke $N "call" (i32.const 1)) (i32.const 5))
+(assert_trap (invoke $N "call M.call" (i32.const 1)) "uninitialized")
+
+(assert_trap (invoke $M "call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $N "M.call" (i32.const 0)) "uninitialized")
+(assert_return (invoke $N "call" (i32.const 0)) (i32.const 5))
+(assert_trap (invoke $N "call M.call" (i32.const 0)) "uninitialized")
+
+(assert_trap (invoke $M "call" (i32.const 20)) "undefined")
+(assert_trap (invoke $N "M.call" (i32.const 20)) "undefined")
+(assert_trap (invoke $N "call" (i32.const 4)) "undefined")
+(assert_trap (invoke $N "call M.call" (i32.const 20)) "undefined")
+
+(module $O
+  (type (func (result i32)))
+
+  (table (import "M" "tab") 5 anyfunc)
+  (elem (i32.const 1) $h $h)
+  (func $h (result i32) (i32.const 6))
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect 0 (get_local 0))
+  )
+)
+
+(assert_return (invoke $M "call" (i32.const 3)) (i32.const 4))
+(assert_return (invoke $N "M.call" (i32.const 3)) (i32.const 4))
+(assert_return (invoke $N "call M.call" (i32.const 3)) (i32.const 4))
+(assert_return (invoke $O "call" (i32.const 3)) (i32.const 4))
+
+(assert_return (invoke $M "call" (i32.const 2)) (i32.const 6))
+(assert_return (invoke $N "M.call" (i32.const 2)) (i32.const 6))
+(assert_return (invoke $N "call" (i32.const 2)) (i32.const 5))
+(assert_return (invoke $N "call M.call" (i32.const 2)) (i32.const 6))
+(assert_return (invoke $O "call" (i32.const 2)) (i32.const 6))
+
+(assert_return (invoke $M "call" (i32.const 1)) (i32.const 6))
+(assert_return (invoke $N "M.call" (i32.const 1)) (i32.const 6))
+(assert_return (invoke $N "call" (i32.const 1)) (i32.const 5))
+(assert_return (invoke $N "call M.call" (i32.const 1)) (i32.const 6))
+(assert_return (invoke $O "call" (i32.const 1)) (i32.const 6))
+
+(assert_trap (invoke $M "call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $N "M.call" (i32.const 0)) "uninitialized")
+(assert_return (invoke $N "call" (i32.const 0)) (i32.const 5))
+(assert_trap (invoke $N "call M.call" (i32.const 0)) "uninitialized")
+(assert_trap (invoke $O "call" (i32.const 0)) "uninitialized")
+
+(assert_trap (invoke $O "call" (i32.const 20)) "undefined")
+
+
+;; Memories
+
+(module $M
+  (memory (export "mem") 1 5)
+  (data (i32.const 10) "\00\01\02\03\04\05\06\07\08\09")
+
+  (func (export "load") (param $a i32) (result i32)
+    (i32.load8_u (get_local 0))
+  )
+)
+(register "M" $M)
+
+(module $N
+  (func $loadM (import "M" "load") (param i32) (result i32))
+
+  (memory 1)
+  (data (i32.const 10) "\f0\f1\f2\f3\f4\f5")
+
+  (export "M.load" (func $loadM))
+  (func (export "load") (param $a i32) (result i32)
+    (i32.load8_u (get_local 0))
+  )
+)
+
+(assert_return (invoke $M "load" (i32.const 12)) (i32.const 2))
+(assert_return (invoke $N "M.load" (i32.const 12)) (i32.const 2))
+(assert_return (invoke $N "load" (i32.const 12)) (i32.const 0xf2))
+
+(module $O
+  (memory (import "M" "mem") 1)
+  (data (i32.const 5) "\a0\a1\a2\a3\a4\a5\a6\a7")
+
+  (func (export "load") (param $a i32) (result i32)
+    (i32.load8_u (get_local 0))
+  )
+)
+
+(assert_return (invoke $M "load" (i32.const 12)) (i32.const 0xa7))
+(assert_return (invoke $N "M.load" (i32.const 12)) (i32.const 0xa7))
+(assert_return (invoke $N "load" (i32.const 12)) (i32.const 0xf2))
+(assert_return (invoke $O "load" (i32.const 12)) (i32.const 0xa7))
+
+(module $P
+  (memory (import "M" "mem") 1 8)
+
+  (func (export "grow") (param $a i32) (result i32)
+    (grow_memory (get_local 0))
+  )
+)
+
+(assert_return (invoke $P "grow" (i32.const 0)) (i32.const 1))
+(assert_return (invoke $P "grow" (i32.const 2)) (i32.const 1))
+(assert_return (invoke $P "grow" (i32.const 0)) (i32.const 3))
+(assert_return (invoke $P "grow" (i32.const 1)) (i32.const 3))
+(assert_return (invoke $P "grow" (i32.const 1)) (i32.const 4))
+(assert_return (invoke $P "grow" (i32.const 0)) (i32.const 5))
+(assert_return (invoke $P "grow" (i32.const 1)) (i32.const -1))
+(assert_return (invoke $P "grow" (i32.const 0)) (i32.const 5))

--- a/ml-proto/test/linking.wast
+++ b/ml-proto/test/linking.wast
@@ -54,6 +54,7 @@
   (table (export "tab") 10 anyfunc)
   (elem (i32.const 2) $g $g $g $g)
   (func $g (result i32) (i32.const 4))
+  (func (export "h") (result i32) (i32.const -4))
 
   (func (export "call") (param i32) (result i32)
     (call_indirect 0 (get_local 0))
@@ -66,8 +67,9 @@
   (type (func (result i32)))
 
   (func $f (import "M" "call") (param i32) (result i32))
+  (func $h (import "M" "h") (result i32))
 
-  (table anyfunc (elem $g $g $g))
+  (table anyfunc (elem $g $g $g $h $f))
   (func $g (result i32) (i32.const 5))
 
   (export "M.call" (func $f))
@@ -96,15 +98,19 @@
 
 (assert_trap (invoke $M "call" (i32.const 20)) "undefined")
 (assert_trap (invoke $N "M.call" (i32.const 20)) "undefined")
-(assert_trap (invoke $N "call" (i32.const 4)) "undefined")
+(assert_trap (invoke $N "call" (i32.const 7)) "undefined")
 (assert_trap (invoke $N "call M.call" (i32.const 20)) "undefined")
+
+(assert_return (invoke $N "call" (i32.const 3)) (i32.const -4))
+(assert_trap (invoke $N "call" (i32.const 4)) "indirect call")
 
 (module $O
   (type (func (result i32)))
 
+  (func $h (import "M" "h") (result i32))
   (table (import "M" "tab") 5 anyfunc)
-  (elem (i32.const 1) $h $h)
-  (func $h (result i32) (i32.const 6))
+  (elem (i32.const 1) $i $h)
+  (func $i (result i32) (i32.const 6))
 
   (func (export "call") (param i32) (result i32)
     (call_indirect 0 (get_local 0))
@@ -116,11 +122,11 @@
 (assert_return (invoke $N "call M.call" (i32.const 3)) (i32.const 4))
 (assert_return (invoke $O "call" (i32.const 3)) (i32.const 4))
 
-(assert_return (invoke $M "call" (i32.const 2)) (i32.const 6))
-(assert_return (invoke $N "M.call" (i32.const 2)) (i32.const 6))
+(assert_return (invoke $M "call" (i32.const 2)) (i32.const -4))
+(assert_return (invoke $N "M.call" (i32.const 2)) (i32.const -4))
 (assert_return (invoke $N "call" (i32.const 2)) (i32.const 5))
-(assert_return (invoke $N "call M.call" (i32.const 2)) (i32.const 6))
-(assert_return (invoke $O "call" (i32.const 2)) (i32.const 6))
+(assert_return (invoke $N "call M.call" (i32.const 2)) (i32.const -4))
+(assert_return (invoke $O "call" (i32.const 2)) (i32.const -4))
 
 (assert_return (invoke $M "call" (i32.const 1)) (i32.const 6))
 (assert_return (invoke $N "M.call" (i32.const 1)) (i32.const 6))


### PR DESCRIPTION
This adds script facilities for defining multiple modules, naming them, and _registering_ them. It also refactors the command grammar slightly and adds an "action" to `get` the value of an exported global (analogous to `invoke` for functions).
```
cmd:
  <module>                                  ;; define, validate, and initialize module
  <action>                                  ;; perform action and print results
  ( register <string> <name>? )             ;; register module for imports
  ( assert_return <action> <expr>? )        ;; assert action has expected results
  ( assert_return_nan <action> )            ;; assert action results in NaN
  ( assert_trap <action> <failure> )        ;; assert action traps with given failure string
  ( assert_invalid <module> <failure> )     ;; assert module is invalid with given failure string
  ( assert_unlinkable <module> <failure> )  ;; assert module fails to link module with given failure string
  ( input <string> )                        ;; read script or module from file
  ( output <name>? <string>? )              ;; output module to stout or file

action:
  ( invoke <name>? <string> <expr>* )       ;; invoke function export
  ( get <name>? <string> )                  ;; get global export
```
Module names remain optional. If omitted at use sites, the last defined module is implied as before.

A _registered_ module is available for importing. See `test/linking.wast` for a number of examples.