### PR TITLE
A couple of simple 0xc binary changes

### DIFF
--- a/ml-proto/given/lib.ml
+++ b/ml-proto/given/lib.ml
@@ -19,6 +19,14 @@ struct
     | n, _::xs' when n > 0 -> drop (n - 1) xs'
     | _ -> failwith "drop"
 
+  let length32 xs = Int32.of_int (List.length xs)
+
+  let rec nth32 xs n =
+  match n, xs with
+    | 0l, x::_ -> x
+    | n, _::xs' when n > 0l -> nth32 xs' (Int32.sub n 1l)
+    | _ -> failwith "nth32"
+
   let rec last = function
     | x::[] -> x
     | _::xs -> last xs

--- a/ml-proto/given/lib.mli
+++ b/ml-proto/given/lib.mli
@@ -7,6 +7,9 @@ sig
   val take : int -> 'a list -> 'a list (* raise Failure *)
   val drop : int -> 'a list -> 'a list (* raise Failure *)
 
+  val length32 : 'a list -> int32
+  val nth32 : 'a list -> int32 -> 'a (* raise Failure *)
+
   val last : 'a list -> 'a (* raise Failure *)
   val split_last : 'a list -> 'a list * 'a (* raise Failure *)
 

--- a/ml-proto/host/arrange.ml
+++ b/ml-proto/host/arrange.ml
@@ -192,7 +192,7 @@ let storeop op =
 
 (* Expressions *)
 
-let var x = string_of_int x.it
+let var x = Int32.to_string x.it
 let value v = string_of_value v.it
 let constop v = value_type (type_of v.it) ^ ".const"
 

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -99,8 +99,7 @@ let encode m =
     let op n = u8 n
     let memop {align; offset; _} = vu align; vu64 offset  (*TODO: to be resolved*)
 
-    let var x = vu x.it
-    let var32 x = vu32 (Int32.of_int x.it)
+    let var x = vu32 x.it
 
     let rec instr e =
       match e.it with
@@ -114,7 +113,7 @@ let encode m =
       | Select -> op 0x05
       | Br (n, x) -> op 0x06; vu n; var x
       | BrIf (n, x) -> op 0x07; vu n; var x
-      | BrTable (n, xs, x) -> op 0x08; vu n; vec var32 xs; var32 x
+      | BrTable (n, xs, x) -> op 0x08; vu n; vec var xs; var x
       | Return -> op 0x09
       | Nop -> op 0x0a
       | Drop -> op 0x0b

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -455,8 +455,8 @@ let encode m =
       global_section m.it.globals;
       export_section m.it.exports;
       start_section m.it.start;
-      code_section m.it.funcs;
       elem_section m.it.elems;
+      code_section m.it.funcs;
       data_section m.it.data
   end
   in E.module_ m; to_string s

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -334,7 +334,7 @@ let encode m =
 
     let section id f x needed =
       if needed then begin
-        string id;
+        u8 id;
         let g = gap () in
         let p = pos s in
         f x;
@@ -343,7 +343,7 @@ let encode m =
 
     (* Type section *)
     let type_section ts =
-      section "type" (vec func_type) ts (ts <> [])
+      section 1 (vec func_type) ts (ts <> [])
 
     (* Import section *)
     let import imp =
@@ -351,13 +351,13 @@ let encode m =
       var itype; string module_name; string func_name
 
     let import_section imps =
-      section "import" (vec import) imps (imps <> [])
+      section 2 (vec import) imps (imps <> [])
 
     (* Function section *)
     let func f = var f.it.ftype
 
     let func_section fs =
-      section "function" (vec func) fs (fs <> [])
+      section 3 (vec func) fs (fs <> [])
 
     (* Table section *)
     let limits vu lim =
@@ -369,7 +369,7 @@ let encode m =
       elem_type etype; limits vu32 tlimits
 
     let table_section tabo =
-      section "table" (opt table) tabo (tabo <> None)
+      section 4 (opt table) tabo (tabo <> None)
 
     (* Memory section *)
     let memory mem =
@@ -377,7 +377,7 @@ let encode m =
       limits vu32 mlimits
 
     let memory_section memo =
-      section "memory" (opt memory) memo (memo <> None)
+      section 5 (opt memory) memo (memo <> None)
 
     (* Global section *)
     let global g =
@@ -385,7 +385,7 @@ let encode m =
       value_type gtype; const value
 
     let global_section gs =
-      section "global" (vec global) gs (gs <> [])
+      section 6 (vec global) gs (gs <> [])
 
     (* Export section *)
     let export exp =
@@ -398,11 +398,11 @@ let encode m =
     let export_section exps =
       (*TODO: pending resolution*)
       let exps = List.filter (fun exp -> exp.it.kind <> `Memory) exps in
-      section "export" (vec export) exps (exps <> [])
+      section 7 (vec export) exps (exps <> [])
 
     (* Start section *)
     let start_section xo =
-      section "start" (opt var) xo (xo <> None)
+      section 8 (opt var) xo (xo <> None)
 
     (* Code section *)
     let compress ts =
@@ -422,7 +422,7 @@ let encode m =
       patch_gap g (pos s - p)
 
     let code_section fs =
-      section "code" (vec code) fs (fs <> [])
+      section 9 (vec code) fs (fs <> [])
 
     (* Element section *)
     let segment dat seg =
@@ -433,14 +433,14 @@ let encode m =
       segment (vec var) seg
 
     let elem_section elems =
-      section "element" (vec table_segment) elems (elems <> [])
+      section 10 (vec table_segment) elems (elems <> [])
 
     (* Data section *)
     let memory_segment seg =
       segment string seg
 
     let data_section data =
-      section "data" (vec memory_segment) data (data <> [])
+      section 11 (vec memory_segment) data (data <> [])
 
     (* Module *)
 

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -415,10 +415,11 @@ let encode m =
 
     let code f =
       let {locals; body; _} = f.it in
-      vec local (compress locals);
       let g = gap () in
       let p = pos s in
+      vec local (compress locals);
       list instr body;
+      u8 0x0f;
       patch_gap g (pos s - p)
 
     let code_section fs =

--- a/ml-proto/host/import.ml
+++ b/ml-proto/host/import.ml
@@ -13,7 +13,7 @@ let register name lookup = registry := Registry.add name lookup !registry
 
 let lookup m import =
   let {module_name; func_name; itype} = import.it in
-  let ty = List.nth m.it.types itype.it in
+  let ty = Lib.List.nth32 m.it.types itype.it in
   try Registry.find module_name !registry func_name ty with Not_found ->
     Unknown.error import.at
       ("no function \"" ^ module_name ^ "." ^ func_name ^

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -35,21 +35,16 @@ let ati i =
 (* Literals *)
 
 let literal f s =
-  try f s with
-  | Failure msg -> error s.at ("constant out of range: " ^ msg)
-  | _ -> error s.at "constant out of range"
+  try f s with Failure _ -> error s.at ("constant out of range")
 
 let int s at =
-  try int_of_string s with Failure _ ->
-    error at "int constant out of range"
+  try int_of_string s with Failure _ -> error at "int constant out of range"
 
 let int32 s at =
-  try I32.of_string s with Failure _ ->
-    error at "i32 constant out of range"
+  try I32.of_string s with Failure _ -> error at "i32 constant out of range"
 
 let int64 s at =
-  try I64.of_string s with Failure _ ->
-    error at "i64 constant out of range"
+  try I64.of_string s with Failure _ -> error at "i64 constant out of range"
 
 
 (* Symbolic variables *)

--- a/ml-proto/host/print.ml
+++ b/ml-proto/host/print.ml
@@ -8,7 +8,7 @@ open Printf
 open Types
 
 let func_type m f =
-  List.nth m.it.types f.it.ftype.it
+  Lib.List.nth32 m.it.types f.it.ftype.it
 
 let string_of_table_type = function
   | None -> "()"
@@ -25,12 +25,12 @@ let print_export m i ex =
   let {name; kind} = ex.it in
   let ascription =
     match kind with
-    | `Func x -> string_of_func_type (func_type m (List.nth m.it.funcs x.it))
+    | `Func x -> string_of_func_type (func_type m (Lib.List.nth32 m.it.funcs x.it))
     | `Memory -> "memory"
   in printf "export \"%s\" : %s\n" name ascription
 
 let print_start start =
-  Lib.Option.app (fun x -> printf "start = func %d\n" x.it) start
+  Lib.Option.app (fun x -> printf "start = func %ld\n" x.it) start
 
 
 (* Ast *)

--- a/ml-proto/spec/ast.ml
+++ b/ml-proto/spec/ast.ml
@@ -70,7 +70,7 @@ type storeop = Memory.mem_size memop
 
 (* Expressions *)
 
-type var = int Source.phrase
+type var = int32 Source.phrase
 type literal = value Source.phrase
 
 type instr = instr' Source.phrase

--- a/ml-proto/spec/check.ml
+++ b/ml-proto/spec/check.ml
@@ -36,8 +36,8 @@ type context =
 }
 
 let lookup category list x =
-  try List.nth list x.it with Failure _ ->
-    error x.at ("unknown " ^ category ^ " " ^ string_of_int x.it)
+  try Lib.List.nth32 list x.it with Failure _ ->
+    error x.at ("unknown " ^ category ^ " " ^ Int32.to_string x.it)
 
 let type_ types x = lookup "function type" types x
 let func c x = lookup "function" c.funcs x

--- a/ml-proto/spec/decode.ml
+++ b/ml-proto/spec/decode.ml
@@ -163,7 +163,7 @@ let memop s =
   let offset = vu64 s in
   align, offset
 
-let var s = len32 s
+let var s = vu32 s
 
 let rec args n stack s pos = args' n stack [] s pos
 and args' n stack es s pos =
@@ -544,7 +544,7 @@ let code s =
   let locals = List.flatten (vec local s) in
   let body = instr_block s in
   expect 0x0f s "END opcode expected";
-  {locals; body; ftype = Source.((-1) @@ Source.no_region)}
+  {locals; body; ftype = Source.((-1l) @@ Source.no_region)}
 
 let code_section s =
   section `CodeSection (vec (at (sized code))) [] s

--- a/ml-proto/spec/decode.ml
+++ b/ml-proto/spec/decode.ml
@@ -593,9 +593,9 @@ let module_ s =
   iterate user_section s;
   let start = start_section s in
   iterate user_section s;
-  let func_bodies = code_section s in
-  iterate user_section s;
   let elems = elem_section s in
+  iterate user_section s;
+  let func_bodies = code_section s in
   iterate user_section s;
   let data = data_section s in
   iterate user_section s;

--- a/ml-proto/spec/eval.ml
+++ b/ml-proto/spec/eval.ml
@@ -16,8 +16,8 @@ type 'a map = 'a Map.t
 type instance =
 {
   module_ : module_;
-  imports : (int * import) list;
-  exports : int map;
+  imports : (int32 * import) list;
+  exports : int32 map;
   table : Table.t option;
   memory : Memory.t option;
   globals : value ref list;
@@ -65,8 +65,8 @@ type config =
 let resource_limit = 1000
 
 let lookup category list x =
-  try List.nth list x.it with Failure _ ->
-    Crash.error x.at ("undefined " ^ category ^ " " ^ string_of_int x.it)
+  try Lib.List.nth32 list x.it with Failure _ ->
+    Crash.error x.at ("undefined " ^ category ^ " " ^ Int32.to_string x.it)
 
 let type_ c x = lookup "type" c.instance.module_.it.types x
 let func c x = lookup "function" c.instance.module_.it.funcs x
@@ -270,11 +270,11 @@ let rec step_instr (c : config) (vs : value stack) (e : instr)
   | Label (es_cont, vs', []), vs ->
     vs' @ vs, []
 
-  | Label (es_cont, vs', {it = Br (n, i); _} :: es), vs when i.it = 0 ->
+  | Label (es_cont, vs', {it = Br (n, i); _} :: es), vs when i.it = 0l ->
     keep n vs' e.at @ vs, es_cont
 
   | Label (es_cont, vs', {it = Br (n, i); at} :: es), vs ->
-    vs', [Br (n, (i.it - 1) @@ i.at) @@ e.at]
+    vs', [Br (n, (Int32.sub i.it 1l) @@ i.at) @@ e.at]
 
   | Label (es_cont, vs', {it = Return; at} :: es), vs ->
     vs', [Return @@ at]
@@ -289,7 +289,7 @@ let rec step_instr (c : config) (vs : value stack) (e : instr)
   | Local (n, vs_local, vs', []), vs ->
     vs' @ vs, []
 
-  | Local (n, vs_local, vs', {it = Br (n', i); at} :: es), vs when i.it = 0 ->
+  | Local (n, vs_local, vs', {it = Br (n', i); at} :: es), vs when i.it = 0l ->
     if n <> n' then Crash.error at "inconsistent result arity";
     keep n vs' at @ vs, []
 

--- a/ml-proto/spec/kernel.ml
+++ b/ml-proto/spec/kernel.ml
@@ -67,7 +67,7 @@ type hostop =
 
 (* Expressions *)
 
-type var = int Source.phrase
+type var = int32 Source.phrase
 type literal = value Source.phrase
 
 type expr = expr' Source.phrase

--- a/ml-proto/spec/table.ml
+++ b/ml-proto/spec/table.ml
@@ -4,7 +4,7 @@ open Values
 type size = int32
 type index = int32
 
-type elem = int option
+type elem = int32 option
 type elem_type = Types.elem_type
 
 type table' = elem array

--- a/ml-proto/spec/table.mli
+++ b/ml-proto/spec/table.mli
@@ -4,7 +4,7 @@ type t = table
 type size = int32
 type index = int32
 
-type elem = int option
+type elem = int32 option
 type elem_type = Types.elem_type
 
 exception Bounds

--- a/ml-proto/test/br.wast
+++ b/ml-proto/test/br.wast
@@ -429,6 +429,6 @@
   "unknown label"
 )
 (assert_invalid
-  (module (func $large-label (br 0x100000001)))
+  (module (func $large-label (br 0x10000001)))
   "unknown label"
 )

--- a/ml-proto/test/br_if.wast
+++ b/ml-proto/test/br_if.wast
@@ -319,7 +319,7 @@
   "unknown label"
 )
 (assert_invalid
-  (module (func $large-label (br_if 0x100000001 (i32.const 1))))
+  (module (func $large-label (br_if 0x10000001 (i32.const 1))))
   "unknown label"
 )
 

--- a/ml-proto/test/br_table.wast
+++ b/ml-proto/test/br_table.wast
@@ -1378,7 +1378,7 @@
 )
 (assert_invalid
   (module (func $large-label
-    (block (br_table 0 0x100000001 0 (i32.const 1)))
+    (block (br_table 0 0x10000001 0 (i32.const 1)))
   ))
   "unknown label"
 )
@@ -1397,7 +1397,7 @@
 )
 (assert_invalid
   (module (func $large-label-default
-    (block (br_table 0 0 0x100000001 (i32.const 1)))
+    (block (br_table 0 0 0x10000001 (i32.const 1)))
   ))
   "unknown label"
 )

--- a/ml-proto/test/call.wast
+++ b/ml-proto/test/call.wast
@@ -236,6 +236,6 @@
   "unknown function"
 )
 (assert_invalid
-  (module (func $large-func (call 10001232130000)))
+  (module (func $large-func (call 1012321300)))
   "unknown function"
 )

--- a/ml-proto/test/call_indirect.wast
+++ b/ml-proto/test/call_indirect.wast
@@ -371,7 +371,7 @@
 (assert_invalid
   (module
     (table 0 anyfunc)
-    (func $large-type (call_indirect 10001232130000 (i32.const 0)))
+    (func $large-type (call_indirect 1012321300 (i32.const 0)))
   )
   "unknown function type"
 )


### PR DESCRIPTION
- Numeric section names
- Element section before code section
- END opcode for functions (plus enabled simplification of decoding stream)
- Limit length of LEBs