### PR TITLE
Fixed a spec error in the code section

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -18,7 +18,7 @@ The interpreter can also be run as a REPL, allowing to enter pieces of scripts i
 
 ## Building
 
-You'll need OCaml 4.02. The best way to get this is to download the [source tarball from our mirror of the ocaml website](https://wasm.storage.googleapis.com/ocaml-4.02.2.tar.gz) and do the configure / make dance.  On OSX, with [Homebrew](http://brew.sh/) installed, simply `brew install ocaml`.
+You'll need OCaml 4.02. The best way to get this is to download the [source tarball from our mirror of the ocaml website](https://wasm.storage.googleapis.com/ocaml-4.02.2.tar.gz) and do the configure / make dance.  On OSX, with [Homebrew](http://brew.sh/) installed, simply `brew install ocaml ocamlbuild`.
 
 Once you have OCaml, simply do
 

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -360,9 +360,9 @@ let encode m =
 
     let code f =
       let {locals; body; _} = f.it in
-      vec local (compress locals);
       let g = gap () in
       let p = pos s in
+      vec local (compress locals);
       list expr body;
       patch_gap g (pos s - p)
 

--- a/ml-proto/runtests.py
+++ b/ml-proto/runtests.py
@@ -44,7 +44,7 @@ class RunTests(unittest.TestCase):
 
     # Run original file
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.log"))
-    self._runCommand(("%s %s") % (interpreterPath, fileName), logPath, expectedExitCode)
+    self._runCommand(("'%s' '%s'") % (interpreterPath, fileName), logPath, expectedExitCode)
     self._compareLog(fileName, logPath)
 
     if expectedExitCode != 0:
@@ -53,20 +53,20 @@ class RunTests(unittest.TestCase):
     # Convert to binary and run again
     wasmPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.log"))
-    self._runCommand(("%s -d %s -o %s") % (interpreterPath, fileName, wasmPath))
-    self._runCommand(("%s %s") % (interpreterPath, wasmPath), logPath)
+    self._runCommand(("'%s' -d '%s' -o '%s'") % (interpreterPath, fileName, wasmPath))
+    self._runCommand(("'%s' '%s'") % (interpreterPath, wasmPath), logPath)
 
     # Convert back to text and run again
     wastPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast"))
     logPath = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.log"))
-    self._runCommand(("%s -d %s -o %s") % (interpreterPath, wasmPath, wastPath))
-    self._runCommand(("%s %s ") % (interpreterPath, wastPath), logPath)
+    self._runCommand(("'%s' -d '%s' -o '%s'") % (interpreterPath, wasmPath, wastPath))
+    self._runCommand(("'%s' '%s' ") % (interpreterPath, wastPath), logPath)
 
     #return
     # Convert back to binary once more and compare
     wasm2Path = auxFile(fileName.replace("test/", "test/output/").replace(".wast", ".wast.wasm.wast.wasm"))
-    self._runCommand(("%s -d %s -o %s") % (interpreterPath, wastPath, wasm2Path))
-    self._runCommand(("%s %s") % (interpreterPath, wasm2Path), logPath)
+    self._runCommand(("'%s' -d '%s' -o '%s'") % (interpreterPath, wastPath, wasm2Path))
+    self._runCommand(("'%s' '%s'") % (interpreterPath, wasm2Path), logPath)
     # TODO: Ultimately, the binary should stay the same, but currently desugaring gets in the way.
     # self._compareFile(wasmPath, wasm2Path)
 

--- a/ml-proto/spec/decode.ml
+++ b/ml-proto/spec/decode.ml
@@ -522,9 +522,10 @@ let local s =
   Lib.List.make n t
 
 let code s =
-  let locals = List.flatten (vec local s) in
   let size = vu s in
-  let body = expr_block (substream s (pos s + size)) in
+  let p = pos s in
+  let locals = List.flatten (vec local s) in
+  let body = expr_block (substream s (p + size)) in
   {locals; body; ftype = Source.((-1) @@ Source.no_region)}
 
 let code_section s =

--- a/ml-proto/winmake.bat
+++ b/ml-proto/winmake.bat
@@ -1,80 +1,80 @@
 rem Auto-generated from Makefile!
 set NAME=wasm
 if '%1' neq '' set NAME=%1
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/float.cmo spec/float.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/numerics.cmi spec/numerics.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/int.cmo spec/int.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/types.cmo spec/types.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/f32.cmo spec/f32.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/f64.cmo spec/f64.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/i32.cmo spec/i32.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/i64.cmo spec/i64.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/values.cmo spec/values.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/memory.cmi spec/memory.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/float.cmo spec/float.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/numerics.cmi spec/numerics.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/int.cmo spec/int.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/types.cmo spec/types.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/f32.cmo spec/f32.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/f64.cmo spec/f64.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/i32.cmo spec/i32.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/i64.cmo spec/i64.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/values.cmo spec/values.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/memory.cmi spec/memory.mli
 ocamlc.opt -c -bin-annot -I given -I spec -I host -I host/import -o given/source.cmi given/source.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/kernel.cmo spec/kernel.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/eval.cmi spec/eval.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/ast.cmo spec/ast.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/kernel.cmo spec/kernel.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/eval.cmi spec/eval.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/ast.cmo spec/ast.ml
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/print.cmi host/print.mli
-ocamlc.opt -c -bin-annot -I host/import -I spec -I given -I host -o host/import/env.cmo host/import/env.ml
+ocamlc.opt -c -bin-annot -I host/import -I spec -I host -I given -o host/import/env.cmo host/import/env.ml
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/flags.cmo host/flags.ml
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/import.cmi host/import.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/run.cmi host/run.mli
-ocamlc.opt -c -bin-annot -I host/import -I spec -I given -I host -o host/import/spectest.cmo host/import/spectest.ml
+ocamlc.opt -c -bin-annot -I host/import -I spec -I host -I given -o host/import/spectest.cmo host/import/spectest.ml
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/main.cmo host/main.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/main.d.cmo host/main.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/error.cmi spec/error.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/error.cmi spec/error.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/sexpr.cmi host/sexpr.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/script.cmi host/script.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/arrange.cmi host/arrange.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/check.cmi spec/check.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/decode.cmi spec/decode.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/desugar.cmi spec/desugar.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/check.cmi spec/check.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/decode.cmi spec/decode.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/desugar.cmi spec/desugar.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/encode.cmi host/encode.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/parse.cmi host/parse.mli
-ocamlc.opt -c -g -bin-annot -I host/import -I spec -I given -I host -o host/import/env.d.cmo host/import/env.ml
+ocamlc.opt -c -g -bin-annot -I host/import -I spec -I host -I given -o host/import/env.d.cmo host/import/env.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/flags.d.cmo host/flags.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/import.d.cmo host/import.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/run.d.cmo host/run.ml
-ocamlc.opt -c -g -bin-annot -I host/import -I spec -I given -I host -o host/import/spectest.d.cmo host/import/spectest.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/arithmetic.cmi spec/arithmetic.mli
+ocamlc.opt -c -g -bin-annot -I host/import -I spec -I host -I given -o host/import/spectest.d.cmo host/import/spectest.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/arithmetic.cmi spec/arithmetic.mli
 ocamlc.opt -c -bin-annot -I given -I spec -I host -I host/import -o given/lib.cmi given/lib.mli
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/eval.d.cmo spec/eval.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/eval.d.cmo spec/eval.ml
 ocamlc.opt -c -g -bin-annot -I given -I spec -I host -I host/import -o given/source.d.cmo given/source.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/types.d.cmo spec/types.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/values.d.cmo spec/values.ml
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/f32_convert.cmi spec/f32_convert.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/f64_convert.cmi spec/f64_convert.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/i32_convert.cmi spec/i32_convert.mli
-ocamlc.opt -c -bin-annot -I spec -I given -I host -I host/import -o spec/i64_convert.cmi spec/i64_convert.mli
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/arithmetic.d.cmo spec/arithmetic.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/error.d.cmo spec/error.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/i32.d.cmo spec/i32.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/i64.d.cmo spec/i64.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/kernel.d.cmo spec/kernel.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/types.d.cmo spec/types.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/values.d.cmo spec/values.ml
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/f32_convert.cmi spec/f32_convert.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/f64_convert.cmi spec/f64_convert.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/i32_convert.cmi spec/i32_convert.mli
+ocamlc.opt -c -bin-annot -I spec -I host -I given -I host/import -o spec/i64_convert.cmi spec/i64_convert.mli
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/arithmetic.d.cmo spec/arithmetic.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/error.d.cmo spec/error.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/i32.d.cmo spec/i32.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/i64.d.cmo spec/i64.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/kernel.d.cmo spec/kernel.ml
 ocamlc.opt -c -g -bin-annot -I given -I spec -I host -I host/import -o given/lib.d.cmo given/lib.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/memory.d.cmo spec/memory.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/numerics.d.cmo spec/numerics.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/f32.d.cmo spec/f32.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/f32_convert.d.cmo spec/f32_convert.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/f64.d.cmo spec/f64.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/f64_convert.d.cmo spec/f64_convert.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/i32_convert.d.cmo spec/i32_convert.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/i64_convert.d.cmo spec/i64_convert.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/float.d.cmo spec/float.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/int.d.cmo spec/int.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/memory.d.cmo spec/memory.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/numerics.d.cmo spec/numerics.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/f32.d.cmo spec/f32.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/f32_convert.d.cmo spec/f32_convert.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/f64.d.cmo spec/f64.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/f64_convert.d.cmo spec/f64_convert.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/i32_convert.d.cmo spec/i32_convert.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/i64_convert.d.cmo spec/i64_convert.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/float.d.cmo spec/float.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/int.d.cmo spec/int.ml
 ocamlyacc host/parser.mly
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/parser.cmi host/parser.mli
 ocamlc.opt -c -bin-annot -I host -I spec -I given -I host/import -o host/lexer.cmi host/lexer.mli
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/arrange.d.cmo host/arrange.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/check.d.cmo spec/check.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/decode.d.cmo spec/decode.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/desugar.d.cmo spec/desugar.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/check.d.cmo spec/check.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/decode.d.cmo spec/decode.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/desugar.d.cmo spec/desugar.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/encode.d.cmo host/encode.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/parse.d.cmo host/parse.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/script.d.cmo host/script.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/sexpr.d.cmo host/sexpr.ml
-ocamlc.opt -c -g -bin-annot -I spec -I given -I host -I host/import -o spec/ast.d.cmo spec/ast.ml
+ocamlc.opt -c -g -bin-annot -I spec -I host -I given -I host/import -o spec/ast.d.cmo spec/ast.ml
 ocamllex.opt -q host/lexer.mll
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/lexer.d.cmo host/lexer.ml
 ocamlc.opt -c -g -bin-annot -I host -I spec -I given -I host/import -o host/parser.d.cmo host/parser.ml


### PR DESCRIPTION
The binary encoding of a Function Body should start with the size of the AST, followed by declaring the locals. Instead we were declaring the locals first.

Also made a minor change to the README because `ocamlbuild` is no longer shipped with `ocaml` in Homebrew.

Finally, changed the `runtests.py` script to put quotes around all command arguments. This lets you run the tests from a path that has a space in it.