### PR TITLE
Stack test cleanup

### DIFF
--- a/ml-proto/test/block.wast
+++ b/ml-proto/test/block.wast
@@ -198,11 +198,6 @@
 )
 ;)
 
-;; TODO(stack): move this elsewhere
-(module (func $type-break-num-vs-void
-  (block (drop (i32.const 66)) (br 0))
-))
-
 (assert_invalid
   (module (func $type-break-last-void-vs-num (result i32)
     (block i32 (br 0))

--- a/ml-proto/test/block.wast
+++ b/ml-proto/test/block.wast
@@ -75,8 +75,8 @@
     (block i32
       (br 0 (i32.const 18))
       (br 0 (i32.const 19))
-      (br_if 0 (i32.const 20) (i32.const 0))
-      (br_if 0 (i32.const 20) (i32.const 1))
+      (drop (br_if 0 (i32.const 20) (i32.const 0)))
+      (drop (br_if 0 (i32.const 20) (i32.const 1)))
       (br 0 (i32.const 21))
       (br_table 0 (i32.const 22) (i32.const 4))
       (br_table 0 0 0 (i32.const 23) (i32.const 1))
@@ -200,7 +200,7 @@
 
 ;; TODO(stack): move this elsewhere
 (module (func $type-break-num-vs-void
-  (block (i32.const 66) (br 0))
+  (block (drop (i32.const 66)) (br 0))
 ))
 
 (assert_invalid

--- a/ml-proto/test/br.wast
+++ b/ml-proto/test/br.wast
@@ -56,7 +56,7 @@
     (block i32 (br_if 0 (br 0 (i32.const 8)) (i32.const 1)) (i32.const 7))
   )
   (func (export "as-br_if-value-cond") (result i32)
-    (block i32 (br_if 0 (i32.const 6) (br 0 (i32.const 9))) (i32.const 7))
+    (block i32 (drop (br_if 0 (i32.const 6) (br 0 (i32.const 9)))) (i32.const 7))
   )
 
   (func (export "as-br_table-index")
@@ -247,7 +247,7 @@
       (i32.const 1)
       (block i32
         (drop (i32.const 2))
-        (br_if 0 (i32.const 4) (br 0 (i32.const 8)))
+        (drop (br_if 0 (i32.const 4) (br 0 (i32.const 8))))
         (i32.const 16)
       )
     )
@@ -373,7 +373,7 @@
 
 ;; TODO(stack): move this elsewhere
 (module (func $type-arg-num-vs-void
-  (block (i32.const 0) (br 0))
+  (block (drop (i32.const 0)) (br 0))
 ))
 
 (; TODO(stack): soft failure

--- a/ml-proto/test/br_if.wast
+++ b/ml-proto/test/br_if.wast
@@ -14,10 +14,10 @@
     (block (call $dummy) (call $dummy) (br_if 0 (get_local 0)))
   )
   (func (export "as-block-first-value") (param i32) (result i32)
-    (block i32 (br_if 0 (i32.const 10) (get_local 0)) (return (i32.const 11)))
+    (block i32 (drop (br_if 0 (i32.const 10) (get_local 0))) (return (i32.const 11)))
   )
   (func (export "as-block-mid-value") (param i32) (result i32)
-    (block i32 (call $dummy) (br_if 0 (i32.const 20) (get_local 0)) (return (i32.const 21)))
+    (block i32 (call $dummy) (drop (br_if 0 (i32.const 20) (get_local 0))) (return (i32.const 21)))
   )
   (func (export "as-block-last-value") (param i32) (result i32)
     (block i32

--- a/ml-proto/test/br_table.wast
+++ b/ml-proto/test/br_table.wast
@@ -1382,11 +1382,6 @@
   "type mismatch"
 )
 
-;; TODO(stack): move this elsewhere
-(module (func $type-arg-num-vs-void
-  (drop (block (br_table 0 (i32.const 0) (i32.const 1))))
-))
-
 (; TODO(stack): soft failure
 (assert_invalid
   (module (func $type-arg-poly-vs-empty

--- a/ml-proto/test/br_table.wast
+++ b/ml-proto/test/br_table.wast
@@ -881,7 +881,7 @@
   )
   (func (export "as-br_if-value-cond") (result i32)
     (block i32
-      (br_if 0 (i32.const 6) (br_table 0 0 (i32.const 9) (i32.const 0)))
+      (drop (br_if 0 (i32.const 6) (br_table 0 0 (i32.const 9) (i32.const 0))))
       (i32.const 7)
     )
   )
@@ -1158,7 +1158,7 @@
         (i32.const 1)
         (block i32
           (drop (i32.const 2))
-          (br_if 0 (i32.const 4) (br_table 0 1 0 (i32.const 8) (get_local 0)))
+          (drop (br_if 0 (i32.const 4) (br_table 0 1 0 (i32.const 8) (get_local 0))))
           (i32.const 16)
         )
       )
@@ -1384,7 +1384,7 @@
 
 ;; TODO(stack): move this elsewhere
 (module (func $type-arg-num-vs-void
-  (block (br_table 0 (i32.const 0) (i32.const 1)))
+  (drop (block (br_table 0 (i32.const 0) (i32.const 1))))
 ))
 
 (; TODO(stack): soft failure

--- a/ml-proto/test/call.wast
+++ b/ml-proto/test/call.wast
@@ -191,14 +191,6 @@
   "type mismatch"
 )
 
-;; TODO(stack): move these elsewhere
-(module
-  (func (param i32 i32))
-  (func $arity-nop-first (call 0 (nop) (i32.const 1) (i32.const 2)))
-  (func $arity-nop-mid (call 0 (i32.const 1) (nop) (i32.const 2)))
-  (func $arity-nop-last (call 0 (i32.const 1) (i32.const 2) (nop)))
-)
-
 (assert_invalid
   (module
     (func $type-first-void-vs-num (call 1 (nop) (i32.const 1)))

--- a/ml-proto/test/call_indirect.wast
+++ b/ml-proto/test/call_indirect.wast
@@ -285,21 +285,6 @@
   "type mismatch"
 )
 
-;; TODO(stack): move these elsewhere
-(module
-  (type (func (param i32 i32)))
-  (table 0 anyfunc)
-  (func $arity-nop-first
-    (call_indirect 0 (nop) (i32.const 1) (i32.const 2) (i32.const 0))
-  )
-  (func $arity-nop-mid
-    (call_indirect 0 (i32.const 1) (nop) (i32.const 2) (i32.const 0))
-  )
-  (func $arity-nop-last
-    (call_indirect 0 (i32.const 1) (i32.const 2) (nop) (i32.const 0))
-  )
-)
-
 (assert_invalid
   (module
     (type (func (param i32)))

--- a/ml-proto/test/func.wast
+++ b/ml-proto/test/func.wast
@@ -475,11 +475,6 @@
 )
 ;)
 
-;; TODO(stack): move this elsewhere
-(module (func $type-break-last-num-vs-void
-  (i32.const 0) (br 0)
-))
-
 (assert_invalid
   (module (func $type-break-last-void-vs-num (result i32)
     (br 0)

--- a/ml-proto/test/loop.wast
+++ b/ml-proto/test/loop.wast
@@ -64,7 +64,7 @@
 
   (func (export "break-bare") (result i32)
     (block (loop (br 1) (br 0) (unreachable)))
-    (block (loop (br_if 1 (i32.const 1)) (unreachable)))
+    (block (loop (drop (br_if 1 (i32.const 1))) (unreachable)))
     (block (loop (br_table 1 (i32.const 0)) (unreachable)))
     (block (loop (br_table 1 1 1 (i32.const 1)) (unreachable)))
     (i32.const 19)
@@ -77,8 +77,8 @@
       (loop i32
         (br 1 (i32.const 18))
         (br 1 (i32.const 19))
-        (br_if 1 (i32.const 20) (i32.const 0))
-        (br_if 1 (i32.const 20) (i32.const 1))
+        (drop (br_if 1 (i32.const 20) (i32.const 0)))
+        (drop (br_if 1 (i32.const 20) (i32.const 1)))
         (br 1 (i32.const 21))
         (br_table 1 (i32.const 22) (i32.const 0))
         (br_table 1 1 1 (i32.const 23) (i32.const 1))
@@ -125,7 +125,7 @@
     (set_local 1 (i64.const 1))
     (block
       (loop
-        (br_if 1 (i64.eqz (get_local 0)))
+        (drop (br_if 1 (i64.eqz (get_local 0))))
         (set_local 1 (i64.mul (get_local 0) (get_local 1)))
         (set_local 0 (i64.sub (get_local 0) (i64.const 1)))
         (br 0)
@@ -140,7 +140,7 @@
     (set_local 2 (i64.const 2))
     (block
       (loop
-        (br_if 1 (i64.gt_u (get_local 2) (get_local 0)))
+        (drop (br_if 1 (i64.gt_u (get_local 2) (get_local 0))))
         (set_local 1 (i64.mul (get_local 1) (get_local 2)))
         (set_local 2 (i64.add (get_local 2) (i64.const 1)))
         (br 0)
@@ -153,12 +153,12 @@
     (local f32 f32)
     (block
       (loop
-        (br_if 1 (f32.eq (get_local 0) (f32.const 0)))
+        (drop (br_if 1 (f32.eq (get_local 0) (f32.const 0))))
         (set_local 2 (get_local 1))
         (block
           (loop
-            (br_if 1 (f32.eq (get_local 2) (f32.const 0)))
-            (br_if 3 (f32.lt (get_local 2) (f32.const 0)))
+            (drop (br_if 1 (f32.eq (get_local 2) (f32.const 0))))
+            (drop (br_if 3 (f32.lt (get_local 2) (f32.const 0))))
             (set_local 3 (f32.add (get_local 3) (get_local 2)))
             (set_local 2 (f32.sub (get_local 2) (f32.const 2)))
             (br 0)
@@ -280,10 +280,3 @@
   "type mismatch"
 )
 
-;; TODO(stack): move these elsewhere
-(module (func $type-cont-num-vs-void
-  (loop (i32.const 0) (br 0))
-))
-(module (func $type-cont-nested-num-vs-void
-  (block (loop (i32.const 1) (loop (i32.const 1) (br 2)) (br 1)))
-))

--- a/ml-proto/test/loop.wast
+++ b/ml-proto/test/loop.wast
@@ -64,7 +64,7 @@
 
   (func (export "break-bare") (result i32)
     (block (loop (br 1) (br 0) (unreachable)))
-    (block (loop (drop (br_if 1 (i32.const 1))) (unreachable)))
+    (block (loop (br_if 1 (i32.const 1)) (unreachable)))
     (block (loop (br_table 1 (i32.const 0)) (unreachable)))
     (block (loop (br_table 1 1 1 (i32.const 1)) (unreachable)))
     (i32.const 19)
@@ -125,7 +125,7 @@
     (set_local 1 (i64.const 1))
     (block
       (loop
-        (drop (br_if 1 (i64.eqz (get_local 0))))
+        (br_if 1 (i64.eqz (get_local 0)))
         (set_local 1 (i64.mul (get_local 0) (get_local 1)))
         (set_local 0 (i64.sub (get_local 0) (i64.const 1)))
         (br 0)
@@ -140,7 +140,7 @@
     (set_local 2 (i64.const 2))
     (block
       (loop
-        (drop (br_if 1 (i64.gt_u (get_local 2) (get_local 0))))
+        (br_if 1 (i64.gt_u (get_local 2) (get_local 0)))
         (set_local 1 (i64.mul (get_local 1) (get_local 2)))
         (set_local 2 (i64.add (get_local 2) (i64.const 1)))
         (br 0)
@@ -153,12 +153,12 @@
     (local f32 f32)
     (block
       (loop
-        (drop (br_if 1 (f32.eq (get_local 0) (f32.const 0))))
+        (br_if 1 (f32.eq (get_local 0) (f32.const 0)))
         (set_local 2 (get_local 1))
         (block
           (loop
-            (drop (br_if 1 (f32.eq (get_local 2) (f32.const 0))))
-            (drop (br_if 3 (f32.lt (get_local 2) (f32.const 0))))
+            (br_if 1 (f32.eq (get_local 2) (f32.const 0)))
+            (br_if 3 (f32.lt (get_local 2) (f32.const 0)))
             (set_local 3 (f32.add (get_local 3) (get_local 2)))
             (set_local 2 (f32.sub (get_local 2) (f32.const 2)))
             (br 0)

--- a/ml-proto/test/return.wast
+++ b/ml-proto/test/return.wast
@@ -59,7 +59,7 @@
     (block i32 (br_if 0 (return (i32.const 8)) (i32.const 1)) (i32.const 7))
   )
   (func (export "as-br_if-value-cond") (result i32)
-    (block i32 (br_if 0 (i32.const 6) (return (i32.const 9))) (i32.const 7))
+    (block i32 (drop (br_if 0 (i32.const 6) (return (i32.const 9)))) (i32.const 7))
   )
 
   (func (export "as-br_table-index") (result i64)

--- a/ml-proto/test/stack.wast
+++ b/ml-proto/test/stack.wast
@@ -131,3 +131,8 @@
 (assert_return (invoke "fac-stack" (i64.const 25)) (i64.const 7034535277573963776))
 (assert_return (invoke "fac-mixed" (i64.const 25)) (i64.const 7034535277573963776))
 
+;; from br_table.wast
+(module (func $type-arg-num-vs-void
+  (block (br_table 0 (i32.const 0) (i32.const 1)))
+))
+

--- a/ml-proto/test/stack.wast
+++ b/ml-proto/test/stack.wast
@@ -131,3 +131,38 @@
 (assert_return (invoke "fac-stack" (i64.const 25)) (i64.const 7034535277573963776))
 (assert_return (invoke "fac-mixed" (i64.const 25)) (i64.const 7034535277573963776))
 
+;; from call.wast
+(module
+  (func (param i32 i32))
+  (func $arity-nop-first (call 0 (nop) (i32.const 1) (i32.const 2)))
+  (func $arity-nop-mid (call 0 (i32.const 1) (nop) (i32.const 2)))
+  (func $arity-nop-last (call 0 (i32.const 1) (i32.const 2) (nop)))
+)
+
+;; from call_indirect.wast
+(module
+  (type (func (param i32 i32)))
+  (table 0 anyfunc)
+  (func $arity-nop-first
+    (call_indirect 0 (nop) (i32.const 1) (i32.const 2) (i32.const 0))
+  )
+  (func $arity-nop-mid
+    (call_indirect 0 (i32.const 1) (nop) (i32.const 2) (i32.const 0))
+  )
+  (func $arity-nop-last
+    (call_indirect 0 (i32.const 1) (i32.const 2) (nop) (i32.const 0))
+  )
+)
+
+;; from func.wast
+(module (func $type-break-last-num-vs-void
+  (i32.const 0) (br 0)
+))
+
+;; from loop.wast
+(module (func $type-cont-num-vs-void
+  (loop (i32.const 0) (br 0))
+))
+(module (func $type-cont-nested-num-vs-void
+  (block (loop (i32.const 1) (loop (i32.const 1) (br 2)) (br 1)))
+))

--- a/ml-proto/test/stack.wast
+++ b/ml-proto/test/stack.wast
@@ -131,38 +131,3 @@
 (assert_return (invoke "fac-stack" (i64.const 25)) (i64.const 7034535277573963776))
 (assert_return (invoke "fac-mixed" (i64.const 25)) (i64.const 7034535277573963776))
 
-;; from call.wast
-(module
-  (func (param i32 i32))
-  (func $arity-nop-first (call 0 (nop) (i32.const 1) (i32.const 2)))
-  (func $arity-nop-mid (call 0 (i32.const 1) (nop) (i32.const 2)))
-  (func $arity-nop-last (call 0 (i32.const 1) (i32.const 2) (nop)))
-)
-
-;; from call_indirect.wast
-(module
-  (type (func (param i32 i32)))
-  (table 0 anyfunc)
-  (func $arity-nop-first
-    (call_indirect 0 (nop) (i32.const 1) (i32.const 2) (i32.const 0))
-  )
-  (func $arity-nop-mid
-    (call_indirect 0 (i32.const 1) (nop) (i32.const 2) (i32.const 0))
-  )
-  (func $arity-nop-last
-    (call_indirect 0 (i32.const 1) (i32.const 2) (nop) (i32.const 0))
-  )
-)
-
-;; from func.wast
-(module (func $type-break-last-num-vs-void
-  (i32.const 0) (br 0)
-))
-
-;; from loop.wast
-(module (func $type-cont-num-vs-void
-  (loop (i32.const 0) (br 0))
-))
-(module (func $type-cont-nested-num-vs-void
-  (block (loop (i32.const 1) (loop (i32.const 1) (br 2)) (br 1)))
-))

--- a/ml-proto/test/unreachable.wast
+++ b/ml-proto/test/unreachable.wast
@@ -63,7 +63,7 @@
     (block i32 (br_if 0 (unreachable) (i32.const 1)) (i32.const 7))
   )
   (func (export "as-br_if-value-cond") (result i32)
-    (block i32 (br_if 0 (i32.const 6) (unreachable)) (i32.const 7))
+    (block i32 (drop (br_if 0 (i32.const 6) (unreachable))) (i32.const 7))
   )
 
   (func (export "as-br_table-index")


### PR DESCRIPTION
As discussed in #343, this adds `drop` to `br_if`s where necessary, and moves some stacky tests into `stack.wast`. With these changes, the "non-stacky" test files don't have stacky stuff, and binaryen can pass them (with just these disabled: stack, nop, typecheck).