### PR TITLE
Zero-extend Int32 values to Int64 when encoding as varuint

### DIFF
--- a/ml-proto/host/arrange.ml
+++ b/ml-proto/host/arrange.ml
@@ -190,7 +190,8 @@ let extension = function
 
 let memop name {ty; align; offset; _} =
   value_type ty ^ "." ^ name ^
-  (if offset = 0l then "" else " offset=" ^ int32 offset) ^
+  (if offset = 0l then "" else " offset=" ^
+   I64.to_string (I64_convert.extend_u_i32 offset)) ^
   (if align = size ty then "" else " align=" ^ int align)
 
 let loadop op =

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -56,7 +56,11 @@ let encode m =
       if -64L <= i && i < 64L then u8 b
       else (u8 (b lor 0x80); vs64 (Int64.shift_right i 7))
 
-    let vu32 i = vu64 (Int64.of_int32 i)
+    let zext_i32 i =
+      (Int64.logand (Int64.shift_right_logical Int64.minus_one 32)
+                    (Int64.of_int32 i))
+
+    let vu32 i = vu64 (zext_i32 i)
     let vs32 i = vs64 (Int64.of_int32 i)
     let f32 x = u32 (F32.to_bits x)
     let f64 x = u64 (F64.to_bits x)

--- a/ml-proto/host/encode.ml
+++ b/ml-proto/host/encode.ml
@@ -56,11 +56,7 @@ let encode m =
       if -64L <= i && i < 64L then u8 b
       else (u8 (b lor 0x80); vs64 (Int64.shift_right i 7))
 
-    let zext_i32 i =
-      (Int64.logand (Int64.shift_right_logical Int64.minus_one 32)
-                    (Int64.of_int32 i))
-
-    let vu32 i = vu64 (zext_i32 i)
+    let vu32 i = vu64 (I64_convert.extend_u_i32 i)
     let vs32 i = vs64 (Int64.of_int32 i)
     let f32 x = u32 (F32.to_bits x)
     let f64 x = u64 (F64.to_bits x)


### PR DESCRIPTION
Currently Int32 values get converted to Int64 when encoding as varint,
but this is a sign extension, resulting in encoding errors when the
Int32's value is > max_int.
Instead, zero-extend by masking off the sign bits when encoding as
varuint.