### PR TITLE
Test traps from start function; check JS Error classes

### DIFF
--- a/ml-proto/README.md
+++ b/ml-proto/README.md
@@ -275,6 +275,7 @@ assertion:
   ( assert_malformed <module> <failure> )    ;; assert module cannot be decoded with given failure string
   ( assert_invalid <module> <failure> )      ;; assert module is invalid with given failure string
   ( assert_unlinkable <module> <failure> )   ;; assert module fails to link
+  ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
 
 meta:
   ( script <name>? <script> )                ;; name a subscript

--- a/ml-proto/host/arrange.ml
+++ b/ml-proto/host/arrange.ml
@@ -413,6 +413,8 @@ let assertion mode ass =
     Node ("assert_invalid", [definition mode None def; Atom (string re)])
   | AssertUnlinkable (def, re) ->
     Node ("assert_unlinkable", [definition mode None def; Atom (string re)])
+  | AssertUninstantiable (def, re) ->
+    Node ("assert_trap", [definition mode None def; Atom (string re)])
   | AssertReturn (act, lits) ->
     Node ("assert_return", action act :: List.map literal lits)
   | AssertReturnNaN act ->

--- a/ml-proto/host/parser.mly
+++ b/ml-proto/host/parser.mly
@@ -693,6 +693,8 @@ assertion :
     { AssertInvalid (snd $3, $4) @@ at () }
   | LPAR ASSERT_UNLINKABLE module_ TEXT RPAR
     { AssertUnlinkable (snd $3, $4) @@ at () }
+  | LPAR ASSERT_TRAP module_ TEXT RPAR
+    { AssertUninstantiable (snd $3, $4) @@ at () }
   | LPAR ASSERT_RETURN action const_list RPAR { AssertReturn ($3, $4) @@ at () }
   | LPAR ASSERT_RETURN_NAN action RPAR { AssertReturnNaN $3 @@ at () }
   | LPAR ASSERT_TRAP action TEXT RPAR { AssertTrap ($3, $4) @@ at () }

--- a/ml-proto/host/run.ml
+++ b/ml-proto/host/run.ml
@@ -305,6 +305,24 @@ let run_assertion ass =
       Assert.error ass.at "expected linking error"
     )
 
+  | AssertUninstantiable (def, re) ->
+    trace "Asserting trap...";
+    let m = run_definition def in
+    if not !Flags.unchecked then Check.check_module m;
+    (match
+      let imports = Import.link m in
+      ignore (Eval.init m imports)
+    with
+    | exception Eval.Trap (_, msg) ->
+      if not (Str.string_match (Str.regexp re) msg 0) then begin
+        print_endline ("Result: \"" ^ msg ^ "\"");
+        print_endline ("Expect: \"" ^ re ^ "\"");
+        Assert.error ass.at "wrong instantiation trap"
+      end
+    | _ ->
+      Assert.error ass.at "expected instaniation trap"
+    )
+
   | AssertReturn (act, es) ->
     trace ("Asserting return...");
     let got_vs = run_action act in

--- a/ml-proto/host/script.ml
+++ b/ml-proto/host/script.ml
@@ -15,6 +15,7 @@ and assertion' =
   | AssertMalformed of definition * string
   | AssertInvalid of definition * string
   | AssertUnlinkable of definition * string
+  | AssertUninstantiable of definition * string
   | AssertReturn of action * Ast.literal list
   | AssertReturnNaN of action
   | AssertTrap of action * string

--- a/ml-proto/test/start.wast
+++ b/ml-proto/test/start.wast
@@ -86,3 +86,8 @@
   (func $main (call $print_i32 (i32.const 2)))
   (start $main)
 )
+
+(assert_trap
+  (module (func $main (unreachable)) (start $main))
+  "unreachable"
+)


### PR DESCRIPTION
Noticed that there was no test for traps from module instantiation. Added a new form of `assert_trap` taking a module definition.

Also refined JS translation to check that the correct exceptions are thrown.