### PR TITLE
Soft fail loop tests

### DIFF
--- a/interpreter/.gitignore
+++ b/interpreter/.gitignore
@@ -2,7 +2,7 @@
 *.byte
 *.opt
 *.zip
-wasmlib.mlpack
+wasm.mlpack
 _build
 wasm
 unopt

--- a/interpreter/test/loop.wast
+++ b/interpreter/test/loop.wast
@@ -252,16 +252,3 @@
   "type mismatch"
 )
 
-(assert_invalid
-  (module (func $type-cont-last-void-vs-empty (result i32)
-    (loop (br 0 (nop)))
-  ))
-  "type mismatch"
-)
-(assert_invalid
-  (module (func $type-cont-last-num-vs-empty (result i32)
-    (loop (br 0 (i32.const 0)))
-  ))
-  "type mismatch"
-)
-

--- a/interpreter/test/soft-fail.wast
+++ b/interpreter/test/soft-fail.wast
@@ -562,3 +562,16 @@
   ))
   "type mismatch"
 )
+
+(assert_soft_invalid
+  (module (func $type-cont-last-void-vs-empty (result i32)
+    (loop (br 0 (nop)))
+  ))
+  "type mismatch"
+)
+(assert_soft_invalid
+  (module (func $type-cont-last-num-vs-empty (result i32)
+    (loop (br 0 (i32.const 0)))
+  ))
+  "type mismatch"
+)


### PR DESCRIPTION
Two commits:
- first one to update `.gitignore`, following a name change somewhere (?).
- second one: I've checked with @sunfishcode, and it seems those two tests from `loop.wast` are part of the unreachable test cases, which should only softly fail. The rationale, in both cases, is that a `br` to a loop top label is always void, and the function's end is unreachable, since we have infinite loops; so per spec, the validation error is a soft fail. Does it make sense? (SM doesn't issue validation errors for these two test cases, according to this reasoning)