### PR TITLE
Reduce the requested amount of pages in the biggest grow test case

### DIFF
--- a/interpreter/test/resizing.wast
+++ b/interpreter/test/resizing.wast
@@ -42,7 +42,7 @@
 (assert_return (invoke "grow" (i32.const 1)) (i32.const 0))
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 1))
 (assert_return (invoke "grow" (i32.const 2)) (i32.const 1))
-(assert_return (invoke "grow" (i32.const 10000)) (i32.const 3))
+(assert_return (invoke "grow" (i32.const 800)) (i32.const 3))
 
 (module
   (memory 0 10)


### PR DESCRIPTION
Really a dumb request: we have these tests checked in in automation in SM, and among all the test machines they run on VMs which have less than 512 MB of memory. One of the resizing tests requests 10K pages of memory which is 625 MB of memory, so this consistently triggers out-of-memory (grow returning -1) in our infra. While we could tweak the test infra to handle this as an expected failures, it sounds like it defeats the purpose of the test itself, and we could just lower the amount of pages requested maybe? 800 pages is 50 MB, which is still a high number and works in our infra. I think the test was requesting a lot of memory in general; not sure it was testing for values above an certain implicit threshold.