### PR TITLE
Parameterise runtests script

### DIFF
--- a/interpreter/runtests.py
+++ b/interpreter/runtests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
 import os.path
 import unittest
@@ -7,20 +8,37 @@ import subprocess
 import glob
 import sys
 
-# Set to run tests through JS as well
-jsCommand = ""
 
-interpreterPath = os.path.abspath("./wasm")
-inputDir = "test/"
-expectDir = inputDir + "expected-output/"
-outputDir = inputDir + "output/"
+inputDir = "test"
+expectDir = "expected-output"
+outputDir = "output"
+
+
+def usage():
+  print("Usage: runtests.py [--wasm <wasm-path>] [--js <js-path>] [file ...]", file=sys.stderr)
+  exit(1)
+
+def param(args, name, default):
+  if name not in args:
+	return default
+  pos = args.index(name)
+  args.pop(pos)
+  if pos == len(args):
+    usage()
+  return args.pop(pos)
+
+wasmCommand = os.path.abspath(param(sys.argv, '--wasm', "./wasm"))
+jsCommand = param(sys.argv, '--js', None)
+jsCommand = os.path.abspath(jsCommand) if jsCommand != None else None
+
 
 def auxFile(path):
-    try:
-      os.remove(path)
-    except OSError:
-      pass
-    return path
+  try:
+    os.remove(path)
+  except OSError:
+    pass
+  return path
+
 
 class RunTests(unittest.TestCase):
   def _runCommand(self, command, logPath = None, expectedExitCode = 0):
@@ -43,14 +61,15 @@ class RunTests(unittest.TestCase):
     except IOError:
       pass
 
-  def _runTestFile(self, shortName, inputPath, interpreterPath):
-    outputPath = inputPath.replace(inputDir, outputDir)
-    expectPath = inputPath.replace(inputDir, expectDir)
+  def _runTestFile(self, inputPath):
+    dir, file = os.path.split(inputPath)
+    outputPath = os.path.join(dir, os.path.join(outputDir, file))
+    expectPath = os.path.join(dir, os.path.join(expectDir, file))
 
     # Run original file
-    expectedExitCode = 1 if ".fail." in inputPath else 0
+    expectedExitCode = 1 if ".fail." in file else 0
     logPath = auxFile(outputPath + ".log")
-    self._runCommand(("%s '%s'") % (interpreterPath, inputPath), logPath, expectedExitCode)
+    self._runCommand(("%s '%s'") % (wasmCommand, inputPath), logPath, expectedExitCode)
     self._compareFile(expectPath + ".log", logPath)
 
     if expectedExitCode != 0:
@@ -59,20 +78,20 @@ class RunTests(unittest.TestCase):
     # Convert to binary and validate again
     wasmPath = auxFile(outputPath + ".bin.wast")
     logPath = auxFile(wasmPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (interpreterPath, inputPath, wasmPath))
-    self._runCommand(("%s -d '%s'") % (interpreterPath, wasmPath), logPath)
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, wasmPath))
+    self._runCommand(("%s -d '%s'") % (wasmCommand, wasmPath), logPath)
 
     # Convert back to text and validate again
     wastPath = auxFile(wasmPath + ".wast")
     logPath = auxFile(wastPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (interpreterPath, wasmPath, wastPath))
-    self._runCommand(("%s -d '%s' ") % (interpreterPath, wastPath), logPath)
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wasmPath, wastPath))
+    self._runCommand(("%s -d '%s' ") % (wasmCommand, wastPath), logPath)
 
     # Convert back to binary once more and compare
     wasm2Path = auxFile(wastPath + ".bin.wast")
     logPath = auxFile(wasm2Path + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (interpreterPath, wastPath, wasm2Path))
-    self._runCommand(("%s -d '%s'") % (interpreterPath, wasm2Path), logPath)
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wastPath, wasm2Path))
+    self._runCommand(("%s -d '%s'") % (wasmCommand, wasm2Path), logPath)
     # TODO: The binary should stay the same, but OCaml's float-string conversions are inaccurate.
     # Once we upgrade to OCaml 4.03, use sprintf "%s" for printing floats.
     # self._compareFile(wasmPath, wasm2Path)
@@ -80,30 +99,27 @@ class RunTests(unittest.TestCase):
     # Convert to JavaScript
     jsPath = auxFile(outputPath.replace(".wast", ".js"))
     logPath = auxFile(jsPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (interpreterPath, inputPath, jsPath))
-    if jsCommand != "":
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, jsPath))
+    if jsCommand != None:
       self._runCommand(("%s '%s'") % (jsCommand, jsPath))
 
-def generate_test_case(rec):
-  return lambda self : self._runTestFile(*rec)
-
-
-def generate_test_cases(cls, interpreterPath, files):
-  for fileName in files:
-    attrName = fileName
-    rec = (attrName, fileName, interpreterPath)
-    testCase = generate_test_case(rec)
-    setattr(cls, attrName, testCase)
 
 if __name__ == "__main__":
-  if not os.path.exists(interpreterPath):
-    raise Exception("Interpreter not found. Looked for %s" % path)
+  if not os.path.exists(wasmCommand):
+    print("Wasm interpreter not found: %s" % wasmCommand, file=sys.stderr)
+    exit(1)
+  if jsCommand != None and not os.path.exists(jsCommand):
+    print("JS interpreter not found: %s" % jsCommand, file=sys.stderr)
+    exit(1)
 
   try:
     os.makedirs(outputDir)
   except OSError:
     pass
 
-  testFiles = glob.glob(inputDir + "*.wast")
-  generate_test_cases(RunTests, interpreterPath, testFiles)
+  inputFiles = glob.glob(os.path.join(inputDir, '*.wast')) if len(sys.argv) <= 1 else sys.argv[1:]
+  sys.argv = sys.argv[:1]
+
+  for fileName in inputFiles:
+    setattr(RunTests, fileName, lambda self, file=fileName: self._runTestFile(file))
   unittest.main()

--- a/interpreter/runtests.py
+++ b/interpreter/runtests.py
@@ -15,7 +15,7 @@ outputDir = "output"
 
 
 def usage():
-  print("Usage: runtests.py [--wasm <wasm-path>] [--js <js-path>] [file ...]", file=sys.stderr)
+  print("Usage: runtests.py [--wasm <wasm-command>] [--js <js-command>] [file ...]", file=sys.stderr)
   exit(1)
 
 def param(args, name, default):
@@ -27,9 +27,8 @@ def param(args, name, default):
     usage()
   return args.pop(pos)
 
-wasmCommand = os.path.abspath(param(sys.argv, '--wasm', "./wasm"))
+wasmCommand = param(sys.argv, '--wasm', "./wasm")
 jsCommand = param(sys.argv, '--js', None)
-jsCommand = os.path.abspath(jsCommand) if jsCommand != None else None
 
 
 def auxFile(path):
@@ -105,13 +104,6 @@ class RunTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-  if not os.path.exists(wasmCommand):
-    print("Wasm interpreter not found: %s" % wasmCommand, file=sys.stderr)
-    exit(1)
-  if jsCommand != None and not os.path.exists(jsCommand):
-    print("JS interpreter not found: %s" % jsCommand, file=sys.stderr)
-    exit(1)
-
   try:
     os.makedirs(outputDir)
   except OSError:

--- a/interpreter/runtests.py
+++ b/interpreter/runtests.py
@@ -11,11 +11,11 @@ import sys
 
 inputDir = "test"
 expectDir = "expected-output"
-outputDir = "output"
+outputDir = os.path.join(inputDir, "output")
 
 
 def usage():
-  print("Usage: runtests.py [--wasm <wasm-command>] [--js <js-command>] [file ...]", file=sys.stderr)
+  print("Usage: runtests.py [--wasm <wasm-command>] [--js <js-command>] [--out <out-dir>] [file ...]", file=sys.stderr)
   exit(1)
 
 def param(args, name, default):
@@ -29,45 +29,39 @@ def param(args, name, default):
 
 wasmCommand = param(sys.argv, '--wasm', "./wasm")
 jsCommand = param(sys.argv, '--js', None)
+outputDir = param(sys.argv, '--out', outputDir)
 
-
-def auxFile(path):
-  try:
-    os.remove(path)
-  except OSError:
-    pass
-  return path
+inputFiles = glob.glob(os.path.join(inputDir, '*.wast')) if len(sys.argv) <= 1 else sys.argv[1:]
+sys.argv = sys.argv[:1]
 
 
 class RunTests(unittest.TestCase):
-  def _runCommand(self, command, logPath = None, expectedExitCode = 0):
-    out = None if logPath is None else file(logPath, 'w+')
-
-    try:
+  def _runCommand(self, command, logPath, expectedExitCode = 0):
+    with open(logPath, 'w+') as out:
       exitCode = subprocess.call(command, shell=True, stdout=out, stderr=subprocess.STDOUT)
       self.assertEqual(expectedExitCode, exitCode, "failed with exit code %i (expected %i) for %s" % (exitCode, expectedExitCode, command))
-    finally:
-      if logPath is not None:
-        out.close()
 
-  def _compareFile(self, expectedFile, actualFile):
-    try:
-      with open(expectedFile) as expected:
+  def _auxFile(self, path):
+    if os.path.exists(path):
+      os.remove(path)
+    return path
+
+  def _compareFile(self, expectFile, actualFile):
+    if os.path.exists(expectFile):
+      with open(expectFile) as expect:
         with open(actualFile) as actual:
-          expectedText = expected.read()
+          expectText = expect.read()
           actualText = actual.read()
-          self.assertEqual(expectedText, actualText)
-    except IOError:
-      pass
+          self.assertEqual(expectText, actualText)
 
   def _runTestFile(self, inputPath):
-    inputDir, inputFile = os.path.split(inputPath)
-    outputPath = os.path.join(inputDir, os.path.join(outputDir, inputFile))
-    expectPath = os.path.join(inputDir, os.path.join(expectDir, inputFile))
+    dir, inputFile = os.path.split(inputPath)
+    outputPath = os.path.join(outputDir, inputFile)
+    expectPath = os.path.join(dir, os.path.join(expectDir, inputFile))
 
     # Run original file
     expectedExitCode = 1 if ".fail." in inputFile else 0
-    logPath = auxFile(outputPath + ".log")
+    logPath = self._auxFile(outputPath + ".log")
     self._runCommand(("%s '%s'") % (wasmCommand, inputPath), logPath, expectedExitCode)
     self._compareFile(expectPath + ".log", logPath)
 
@@ -75,43 +69,37 @@ class RunTests(unittest.TestCase):
       return
 
     # Convert to binary and validate again
-    wasmPath = auxFile(outputPath + ".bin.wast")
-    logPath = auxFile(wasmPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, wasmPath))
+    wasmPath = self._auxFile(outputPath + ".bin.wast")
+    logPath = self._auxFile(wasmPath + ".log")
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, wasmPath), logPath)
     self._runCommand(("%s -d '%s'") % (wasmCommand, wasmPath), logPath)
 
     # Convert back to text and validate again
-    wastPath = auxFile(wasmPath + ".wast")
-    logPath = auxFile(wastPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wasmPath, wastPath))
+    wastPath = self._auxFile(wasmPath + ".wast")
+    logPath = self._auxFile(wastPath + ".log")
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wasmPath, wastPath), logPath)
     self._runCommand(("%s -d '%s' ") % (wasmCommand, wastPath), logPath)
 
     # Convert back to binary once more and compare
-    wasm2Path = auxFile(wastPath + ".bin.wast")
-    logPath = auxFile(wasm2Path + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wastPath, wasm2Path))
+    wasm2Path = self._auxFile(wastPath + ".bin.wast")
+    logPath = self._auxFile(wasm2Path + ".log")
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, wastPath, wasm2Path), logPath)
     self._runCommand(("%s -d '%s'") % (wasmCommand, wasm2Path), logPath)
     # TODO: The binary should stay the same, but OCaml's float-string conversions are inaccurate.
     # Once we upgrade to OCaml 4.03, use sprintf "%s" for printing floats.
     # self._compareFile(wasmPath, wasm2Path)
 
     # Convert to JavaScript
-    jsPath = auxFile(outputPath.replace(".wast", ".js"))
-    logPath = auxFile(jsPath + ".log")
-    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, jsPath))
+    jsPath = self._auxFile(outputPath.replace(".wast", ".js"))
+    logPath = self._auxFile(jsPath + ".log")
+    self._runCommand(("%s -d '%s' -o '%s'") % (wasmCommand, inputPath, jsPath), logPath)
     if jsCommand != None:
-      self._runCommand(("%s '%s'") % (jsCommand, jsPath))
+      self._runCommand(("%s '%s'") % (jsCommand, jsPath), logPath)
 
 
 if __name__ == "__main__":
-  try:
+  if not os.path.exists(outputDir):
     os.makedirs(outputDir)
-  except OSError:
-    pass
-
-  inputFiles = glob.glob(os.path.join(inputDir, '*.wast')) if len(sys.argv) <= 1 else sys.argv[1:]
-  sys.argv = sys.argv[:1]
-
   for fileName in inputFiles:
     setattr(RunTests, fileName, lambda self, file=fileName: self._runTestFile(file))
   unittest.main()

--- a/interpreter/runtests.py
+++ b/interpreter/runtests.py
@@ -61,12 +61,12 @@ class RunTests(unittest.TestCase):
       pass
 
   def _runTestFile(self, inputPath):
-    dir, file = os.path.split(inputPath)
-    outputPath = os.path.join(dir, os.path.join(outputDir, file))
-    expectPath = os.path.join(dir, os.path.join(expectDir, file))
+    inputDir, inputFile = os.path.split(inputPath)
+    outputPath = os.path.join(inputDir, os.path.join(outputDir, inputFile))
+    expectPath = os.path.join(inputDir, os.path.join(expectDir, inputFile))
 
     # Run original file
-    expectedExitCode = 1 if ".fail." in file else 0
+    expectedExitCode = 1 if ".fail." in inputFile else 0
     logPath = auxFile(outputPath + ".log")
     self._runCommand(("%s '%s'") % (wasmCommand, inputPath), logPath, expectedExitCode)
     self._compareFile(expectPath + ".log", logPath)


### PR DESCRIPTION
Usage is now
```
runtests.py [--wasm <wasm-command>] [--js <js-command>] [file ...]
```
which allows selecting tests or setting the JS command from the command line, e.g.
```
runtests.py --js 'd8 --expose-wasm' test/address.wast
```