### PR TITLE
Represent alignment in log2 in AST

### DIFF
--- a/interpreter/spec/decode.ml
+++ b/interpreter/spec/decode.ml
@@ -193,7 +193,7 @@ let memop s =
   let align = vu32 s in
   require (I32.le_u align 32l) s (pos s - 1) "invalid memop flags";
   let offset = vu32 s in
-  1 lsl Int32.to_int align, offset
+  Int32.to_int align, offset
 
 let rec instr s =
   let pos = pos s in

--- a/interpreter/spec/encode.ml
+++ b/interpreter/spec/encode.ml
@@ -134,9 +134,7 @@ let encode m =
     let op n = u8 n
     let end_ () = op 0x0b
 
-    let memop {align; offset; _} =
-      vu32 (I32.ctz (Int32.of_int align));
-      vu32 offset
+    let memop {align; offset; _} = vu32 (Int32.of_int align); vu32 offset
 
     let var x = vu32 x.it
 

--- a/interpreter/spec/valid.ml
+++ b/interpreter/spec/valid.ml
@@ -131,8 +131,6 @@ let type_cvtop at = function
 
 let check_memop (c : context) (memop : 'a memop) get_sz at =
   ignore (memory c (0l @@ at));
-  require (Lib.Int.is_power_of_two memop.align) at
-    "alignment must be a power of two";
   let size =
     match get_sz memop.sz with
     | None -> size memop.ty
@@ -141,7 +139,8 @@ let check_memop (c : context) (memop : 'a memop) get_sz at =
         "memory size too big";
       Memory.mem_size sz
   in
-  require (memop.align <= size) at "alignment must not be larger than natural"
+  require (1 lsl memop.align <= size) at
+    "alignment must not be larger than natural"
 
 let check_arity n at =
   require (n <= 1) at "invalid result arity, larger than 1 is not (yet) allowed"

--- a/interpreter/test/load-align-0.fail.wast
+++ b/interpreter/test/load-align-0.fail.wast
@@ -1,0 +1,1 @@
+(module (memory 0) (func (drop (i64.load align=0 (i32.const 0)))))

--- a/interpreter/test/load-align-odd.fail.wast
+++ b/interpreter/test/load-align-odd.fail.wast
@@ -1,0 +1,1 @@
+(module (memory 0) (func (drop (i64.load align=5 (i32.const 0)))))

--- a/interpreter/test/memory.wast
+++ b/interpreter/test/memory.wast
@@ -106,27 +106,6 @@
 (module (memory 0) (func (drop (f32.load align=4 (i32.const 0)))))
 
 (assert_invalid
-  (module (memory 0) (func (drop (i64.load align=0 (i32.const 0)))))
-  "alignment must be a power of two"
-)
-(assert_invalid
-  (module (memory 0) (func (drop (i64.load align=3 (i32.const 0)))))
-  "alignment must be a power of two"
-)
-(assert_invalid
-  (module (memory 0) (func (drop (i64.load align=5 (i32.const 0)))))
-  "alignment must be a power of two"
-)
-(assert_invalid
-  (module (memory 0) (func (drop (i64.load align=6 (i32.const 0)))))
-  "alignment must be a power of two"
-)
-(assert_invalid
-  (module (memory 0) (func (drop (i64.load align=7 (i32.const 0)))))
-  "alignment must be a power of two"
-)
-
-(assert_invalid
   (module (memory 0) (func (drop (i64.load align=16 (i32.const 0)))))
   "alignment must not be larger than natural"
 )

--- a/interpreter/test/store-align-0.fail.wast
+++ b/interpreter/test/store-align-0.fail.wast
@@ -1,0 +1,1 @@
+(module (memory 0) (func (i64.store align=0 (i32.const 0) (i64.const 0))))

--- a/interpreter/test/store-align-odd.fail.wast
+++ b/interpreter/test/store-align-odd.fail.wast
@@ -1,0 +1,1 @@
+(module (memory 0) (func (i64.store align=6 (i32.const 0) (i64.const 0))))

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -190,7 +190,7 @@ let extension = function
 let memop name {ty; align; offset; _} =
   value_type ty ^ "." ^ name ^
   (if offset = 0l then "" else " offset=" ^ nat32 offset) ^
-  (if align = size ty then "" else " align=" ^ nat align)
+  (if 1 lsl align = size ty then "" else " align=" ^ nat (1 lsl align))
 
 let loadop op =
   match op.sz with

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -168,36 +168,36 @@ rule token = parse
 
   | (nxx as t)".load"
     { LOAD (fun a o ->
-        numop t (i32_load (opt a 4)) (i64_load (opt a 8))
-                (f32_load (opt a 4)) (f64_load (opt a 8)) o) }
+        numop t (i32_load (opt a 2)) (i64_load (opt a 3))
+                (f32_load (opt a 2)) (f64_load (opt a 3)) o) }
   | (nxx as t)".store"
     { STORE (fun a o ->
-        numop t (i32_store (opt a 4)) (i64_store (opt a 8))
-                (f32_store (opt a 4)) (f64_store (opt a 8)) o) }
+        numop t (i32_store (opt a 2)) (i64_store (opt a 3))
+                (f32_store (opt a 2)) (f64_store (opt a 3)) o) }
   | (ixx as t)".load"(mem_size as sz)"_"(sign as s)
     { if t = "i32" && sz = "32" then error lexbuf "unknown operator";
       LOAD (fun a o ->
         intop t
           (memsz sz
-            (ext s i32_load8_s i32_load8_u (opt a 1))
-            (ext s i32_load16_s i32_load16_u (opt a 2))
+            (ext s i32_load8_s i32_load8_u (opt a 0))
+            (ext s i32_load16_s i32_load16_u (opt a 1))
             (fun _ -> unreachable) o)
           (memsz sz
-            (ext s i64_load8_s i64_load8_u (opt a 1))
-            (ext s i64_load16_s i64_load16_u (opt a 2))
-            (ext s i64_load32_s i64_load32_u (opt a 4)) o)) }
+            (ext s i64_load8_s i64_load8_u (opt a 0))
+            (ext s i64_load16_s i64_load16_u (opt a 1))
+            (ext s i64_load32_s i64_load32_u (opt a 2)) o)) }
   | (ixx as t)".store"(mem_size as sz)
     { if t = "i32" && sz = "32" then error lexbuf "unknown operator";
       STORE (fun a o ->
         intop t
           (memsz sz
-            (i32_store8 (opt a 1))
-            (i32_store16 (opt a 2))
+            (i32_store8 (opt a 0))
+            (i32_store16 (opt a 1))
             (fun _ -> unreachable) o)
           (memsz sz
-            (i64_store8 (opt a 1))
-            (i64_store16 (opt a 2))
-            (i64_store32 (opt a 4)) o)) }
+            (i64_store8 (opt a 0))
+            (i64_store16 (opt a 1))
+            (i64_store32 (opt a 2)) o)) }
 
   | "offset="(nat as s) { OFFSET_EQ_NAT s }
   | "align="(nat as s) { ALIGN_EQ_NAT s }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -292,7 +292,11 @@ offset_opt :
 ;
 align_opt :
   | /* empty */ { None }
-  | ALIGN_EQ_NAT { Some (nat $1 (at ())) }
+  | ALIGN_EQ_NAT
+    { let n = nat $1 (at ()) in
+      if not (Lib.Int.is_power_of_two n) then
+        error (at ()) "alignment must be a power of two";
+      Some (Lib.Int.log2 n) }
 ;
 
 instr :

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -131,9 +131,14 @@ end
 
 module Int =
 struct
-  let is_power_of_two x =
-    if x < 0 then failwith "is_power_of_two";
-    x <> 0 && (x land (x - 1)) = 0
+  let log2 n =
+    if n <= 0 then failwith "log2";
+    let rec loop acc n = if n = 1 then acc else loop (acc + 1) (n lsr 1) in
+    loop 0 n
+
+  let is_power_of_two n =
+    if n < 0 then failwith "is_power_of_two";
+    n <> 0 && n land (n - 1) = 0
 end
 
 module String =

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -58,6 +58,7 @@ end
 
 module Int :
 sig
+  val log2 : int -> int
   val is_power_of_two : int -> bool
 end
 


### PR DESCRIPTION
To match the binary format. Ill-formed alignment is now a syntax error instead of a validation error, because it cannot be represented to binary.