### PR TITLE
Fix broken link to semantics

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -119,7 +119,7 @@ See `wasm -h` for (the few) additional options.
 
 ## S-Expression Syntax
 
-The implementation consumes a WebAssembly AST given in S-expression syntax. Here is an overview of the grammar of types, expressions, functions, and modules, mirroring what's described in the [design doc](https://github.com/WebAssembly/design/blob/master/AstSemantics.md):
+The implementation consumes a WebAssembly AST given in S-expression syntax. Here is an overview of the grammar of types, expressions, functions, and modules, mirroring what's described in the [design doc](https://github.com/WebAssembly/design/blob/master/Semantics.md):
 
 ```
 value: <int> | <float>


### PR DESCRIPTION
Updating the link to reflect recent rename in the design repository.