### PR TITLE
Intro with design goals

### DIFF
--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -48,8 +48,6 @@ The design goals of WebAssembly are the following:
 
   * **Portable**: makes no architectural assumptions that are not broadly supported across modern hardware.
 
-  * **Versatile**: can be targetted equally by both state-of-the-art optimizing compilers and single-pass baseline compilers.
-
 WebAssembly code is also intended to be easy to display and debug, especially in environments like web browsers, but such features are beyond the scope of this specification.
 
 

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -34,7 +34,7 @@ The design goals of WebAssembly are the following:
 
   * **Open**: programs can interoperate with their environment in a simple and universal manner.
 
-* Efficient, checkable, and portable *representation*:
+* Efficient and portable *representation*:
 
   * **Compact**: a binary format that is fast to transmit by being smaller than typical text or native code formats.
 

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -3,7 +3,7 @@ Introduction
 
 WebAssembly (abbreviated Wasm [#wasm]_) is a *safe, portable, low-level code format*
 designed for efficient execution and compact representation.
-Its main goal is to enable high performance applications on the Web, but it does not bake in any Web-specific assumptions or features, so can be employed in other environments as well.
+Its main goal is to enable high performance applications on the Web, but it does not make any Web-specific assumptions or provide Web-specific features, so can be employed in other environments as well.
 
 WebAssembly is an open standard developed by a `W3C Community Group <https://www.w3.org/community/webassembly/>`_ that includes representatives of all major browser vendors.
 

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -22,7 +22,7 @@ The design goals of WebAssembly are the following:
 
   * **Fast**: executes with near native code performance, taking advantage of capabilities common to all contemporary hardware.
 
-  * **Safe**: code is validated and executes in a memory-safe, sandboxed environment preventing data corruption or security breaches.
+  * **Safe**: code is validated and executes in a memory-safe [#memorysafe]_, sandboxed environment preventing data corruption or security breaches.
 
   * **Well-defined**: fully and precisely defines valid programs and their behavior in a way that is easy to reason about informally and formally.
 
@@ -52,3 +52,5 @@ WebAssembly code is also intended to be easy to inspect and debug, especially in
 
 
 .. [#wasm] A contraction of "WebAssembly", not an acronym, hence not using all-caps.
+
+.. [#memorysafe] No program can break WebAssembly's memory model. Of course, it cannot guarantee that an unsafe language compiling to WebAssembly does not corrupt its own memory layout, e.g. inside WebAssembly's linear memory.

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -24,23 +24,23 @@ The design goals of WebAssembly are the following:
 
   * **Safe**: code is validated and executes in a memory-safe, sandboxed environment preventing data corruption or security breaches.
 
-  * **Deterministic**: fully and precisely defines valid programs and their behavior in a way that is easy to reason about informally and formally.
+  * **Well-defined**: fully and precisely defines valid programs and their behavior in a way that is easy to reason about informally and formally.
 
-  * **Hardware-independent**: can run on all modern hardware and CPUs, desktop or mobile devices and embedded systems alike.
+  * **Hardware-independent**: can be compiled on all modern architectures, desktop or mobile devices and embedded systems alike.
 
-  * **Language-independent**: does not privilege nor penalize any particular programming or object model.
+  * **Language-independent**: does not privilege any particular language, programming model, or object model.
 
   * **Platform-independent**: can be embedded in browsers, run as a stand-alone VM, or integrated in other environments.
 
   * **Open**: programs can interoperate with their environment in a simple and universal manner.
 
-* Efficient, safe, and portable *representation*:
+* Efficient, checkable, and portable *representation*:
 
   * **Compact**: a binary format that is fast to transmit by being smaller than typical text or native code formats.
 
   * **Modular**: programs can be split up in smaller parts that can be transmitted, cached, and consumed separately.
 
-  * **Efficient**: can be decoded, validated, and compiled to native code in a fast single pass, equally with either just-in-time (JIT) or ahead-of-time (AOT) compilation.
+  * **Efficient**: can be decoded, validated, and compiled in a fast single pass, equally with either just-in-time (JIT) or ahead-of-time (AOT) compilation.
 
   * **Streamable**: allows decoding, validation, and compilation to begin as soon as possible, before all data has been seen.
 
@@ -48,7 +48,7 @@ The design goals of WebAssembly are the following:
 
   * **Portable**: makes no architectural assumptions that are not broadly supported across modern hardware.
 
-WebAssembly code is also intended to be easy to display and debug, especially in environments like web browsers, but such features are beyond the scope of this specification.
+WebAssembly code is also intended to be easy to inspect and debug, especially in environments like web browsers, but such features are beyond the scope of this specification.
 
 
 .. [#wasm] A contraction of "WebAssembly", not an acronym, hence not using all-caps.

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -1,6 +1,56 @@
 Introduction
 ============
 
-.. todo::
+WebAssembly (abbreviated Wasm [#wasm]_) is a *safe, portable, low-level code format*
+designed for efficient execution and compact representation.
+Its main goal is to enable high performance applications on the Web, but it does not bake in any Web-specific assumptions or features, so can be employed in other environments as well.
 
-   All there is to say
+WebAssembly is an open standard developed by a `W3C Community Group <https://www.w3.org/community/webassembly/>`_ that includes representatives of all major browser vendors.
+
+This document describes version |release| of the standard.
+It is intended that it will be superseded by new incremental releases with additional features in the future.
+
+
+Design Goals
+------------
+
+.. index:: design goals, portability
+
+The design goals of WebAssembly are the following:
+
+* Fast, safe, and portable *semantics*:
+
+  * **Fast**: executes with near native code performance, taking advantage of capabilities common to all contemporary hardware.
+
+  * **Safe**: code is validated and executes in a memory-safe, sandboxed environment preventing data corruption or security breaches.
+
+  * **Deterministic**: fully and precisely defines valid programs and their behavior in a way that is easy to reason about informally and formally.
+
+  * **Hardware-independent**: can run on all modern hardware and CPUs, desktop or mobile devices and embedded systems alike.
+
+  * **Language-independent**: does not privilege nor penalize any particular programming or object model.
+
+  * **Platform-independent**: can be embedded in browsers, run as a stand-alone VM, or integrated in other environments.
+
+  * **Open**: programs can interoperate with their environment in a simple and universal manner.
+
+* Efficient, safe, and portable *representation*:
+
+  * **Compact**: a binary format that is fast to transmit by being smaller than typical text or native code formats.
+
+  * **Modular**: programs can be split up in smaller parts that can be transmitted, cached, and consumed separately.
+
+  * **Efficient**: can be decoded, validated, and compiled to native code in a fast single pass, equally with either just-in-time (JIT) or ahead-of-time (AOT) compilation.
+
+  * **Streamable**: allows decoding, validation, and compilation to begin as soon as possible, before all data has been seen.
+
+  * **Parallelizable**: allows decoding, validation, and compilation to be split into many independent parallel tasks.
+
+  * **Portable**: makes no architectural assumptions that are not broadly supported across modern hardware.
+
+  * **Versatile**: can be targetted equally by both state-of-the-art optimizing compilers and single-pass baseline compilers
+
+WebAssembly code is also intended to be easy to display and debug, especially in environments like web browsers, but such features are beyond the scope of this specification.
+
+
+.. [#wasm] A contraction of "WebAssembly", not an acronym, hence not using all-caps.

--- a/document/introduction/index.rst
+++ b/document/introduction/index.rst
@@ -48,7 +48,7 @@ The design goals of WebAssembly are the following:
 
   * **Portable**: makes no architectural assumptions that are not broadly supported across modern hardware.
 
-  * **Versatile**: can be targetted equally by both state-of-the-art optimizing compilers and single-pass baseline compilers
+  * **Versatile**: can be targetted equally by both state-of-the-art optimizing compilers and single-pass baseline compilers.
 
 WebAssembly code is also intended to be easy to display and debug, especially in environments like web browsers, but such features are beyond the scope of this specification.
 


### PR DESCRIPTION
Adds intro that mainly summarises the design goals. Leaves out meta topics like design process and future features which don't belong into the spec itself.