### PR TITLE
Check all segment bounds beforehand

### DIFF
--- a/interpreter/spec/eval.mli
+++ b/interpreter/spec/eval.mli
@@ -5,5 +5,5 @@ exception Link of Source.region * string
 exception Trap of Source.region * string
 exception Crash of Source.region * string
 
-val init : Ast.module_ -> extern list -> instance
+val init : Ast.module_ -> extern list -> instance (* raises Link, Trap *)
 val invoke : closure -> value list -> value list (* raises Trap *)

--- a/interpreter/spec/memory.ml
+++ b/interpreter/spec/memory.ml
@@ -48,8 +48,11 @@ let create {min; max} =
   assert (within_limits min max);
   {content = create' min; max}
 
+let bound mem =
+  Array1_64.dim mem.content
+
 let size mem =
-  Int64.(to_int32 (div (Array1_64.dim mem.content) page_size))
+  Int64.(to_int32 (div (bound mem) page_size))
 
 let limits mem =
   {min = size mem; max = mem.max}

--- a/interpreter/spec/memory.mli
+++ b/interpreter/spec/memory.mli
@@ -23,6 +23,7 @@ val mem_size : mem_size -> int
 
 val create : size limits -> memory (* raise SizeOverflow, OutOfMemory *)
 val size : memory -> size
+val bound : memory -> address
 val limits : memory -> size limits
 val grow : memory -> size -> unit
   (* raise SizeLimit, SizeOverflow, OutOfMemory *)

--- a/interpreter/test/linking.wast
+++ b/interpreter/test/linking.wast
@@ -158,14 +158,36 @@
 
 (assert_unlinkable
   (module
-    (func $host (import "spectest" "print"))
     (table (import "Mt" "tab") 10 anyfunc)
     (memory (import "Mt" "mem") 1)  ;; does not exist
-    (elem (i32.const 7) $own)
-    (elem (i32.const 9) $host)
-    (func $own (result i32) (i32.const 666))
+    (func $f (result i32) (i32.const 0))
+    (elem (i32.const 7) $f)
+    (elem (i32.const 9) $f)
   )
   "unknown import"
+)
+(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
+
+(assert_unlinkable
+  (module
+    (table (import "Mt" "tab") 10 anyfunc)
+    (func $f (result i32) (i32.const 0))
+    (elem (i32.const 7) $f)
+    (elem (i32.const 12) $f)  ;; out of bounds
+  )
+  "elements segment does not fit"
+)
+(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
+
+(assert_unlinkable
+  (module
+    (table (import "Mt" "tab") 10 anyfunc)
+    (func $f (result i32) (i32.const 0))
+    (elem (i32.const 7) $f)
+    (memory 1)
+    (data (i32.const 0x10000) "d") ;; out of bounds
+  )
+  "data segment does not fit"
 )
 (assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
 
@@ -237,5 +259,27 @@
     (data (i32.const 0) "abc")
   )
   "unknown import"
+)
+(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
+
+(assert_unlinkable
+  (module
+    (memory (import "Mm" "mem") 1)
+    (data (i32.const 0) "abc")
+    (data (i32.const 0x50000) "d") ;; out of bounds
+  )
+  "data segment does not fit"
+)
+(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
+
+(assert_unlinkable
+  (module
+    (memory (import "Mm" "mem") 1)
+    (data (i32.const 0) "abc")
+    (table 0 anyfunc)
+    (func)
+    (elem (i32.const 0) 0) ;; out of bounds
+  )
+  "elements segment does not fit"
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))

--- a/interpreter/test/memory.wast
+++ b/interpreter/test/memory.wast
@@ -53,6 +53,14 @@
   (module (memory 1 2) (data (i32.const 0) "a") (data (i32.const 98304) "b"))
   "data segment does not fit"
 )
+(assert_unlinkable
+  (module (memory 0 0) (data (i32.const 1) ""))
+  "data segment does not fit"
+)
+(assert_unlinkable
+  (module (memory 1) (data (i32.const 0x12000) ""))
+  "data segment does not fit"
+)
 ;; This seems to cause a time-out on Travis.
 (;assert_unlinkable
   (module (memory 0x10000) (data (i32.const 0xffffffff) "ab"))
@@ -64,7 +72,7 @@
 )
 
 (module (memory 0 0) (data (i32.const 0) ""))
-(module (memory 0 0) (data (i32.const 1) ""))
+(module (memory 1 1) (data (i32.const 0x10000) ""))
 (module (memory 1 2) (data (i32.const 0) "abc") (data (i32.const 0) "def"))
 (module (memory 1 2) (data (i32.const 3) "ab") (data (i32.const 0) "de"))
 (module


### PR DESCRIPTION
...and add tests that memories/tables remain unchanged in case of error. Addresses WebAssembly/design#897