### PR TITLE
Malformed tests for mutable encoding

### DIFF
--- a/interpreter/test/globals.wast
+++ b/interpreter/test/globals.wast
@@ -95,3 +95,15 @@
   (module (global i32 (get_global 1)) (global i32 (i32.const 0)))
   "unknown global"
 )
+
+(module
+  (import "spectest" "global" (global i32))
+)
+(assert_malformed (module "\00asm\0d\00\00\00\02\94\80\80\80\00\01\08\73\70\65\63\74\65\73\74\06\67\6c\6f\62\61\6c\03\7f\02") "invalid mutability")
+
+(module
+  (global i32 (i32.const 0))
+)
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\ff\41\00\0b") "invalid mutability")
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\d4\41\00\0b") "invalid mutability")
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\02\41\00\0b") "invalid mutability")


### PR DESCRIPTION
Add tests for invalid global mutable encoding value