### PR TITLE
Make JS harness optional and compatible with async

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -96,6 +96,8 @@ wasm -d script.wast -o script.js
 The first creates a new test scripts where all embedded modules are converted to binary, the second one where all are converted to textual.
 
 The last invocation produces an equivalent, self-contained JavaScript test file.
+The flag `-h` can be used to omit the test harness from the converted file;
+it then is the client's responsibility to provide versions of the necessary functions.
 By default, the generated script will require `assert_soft_invalid` (see below) to detect validation failures. Use the `-us` flag ("unchecked soft") to deactivate these assertions to run on implementations that do not validate dead code.
 
 #### Command Line Expressions

--- a/interpreter/host/flags.ml
+++ b/interpreter/host/flags.ml
@@ -5,3 +5,4 @@ let unchecked_soft = ref false
 let print_sig = ref false
 let dry = ref false
 let width = ref 80
+let harness = ref true

--- a/interpreter/host/js.ml
+++ b/interpreter/host/js.ml
@@ -6,7 +6,7 @@ open Source
 
 (* Harness *)
 
-let prefix =
+let harness =
   "'use strict';\n" ^
   "\n" ^
   "let soft_validate = " ^ string_of_bool (not !Flags.unchecked_soft) ^ ";\n" ^
@@ -352,4 +352,5 @@ let of_command mods cmd =
   | Meta _ -> assert false
 
 let of_script scr =
-  prefix ^ String.concat "" (List.map (of_command (ref Map.empty)) scr)
+  (if !Flags.harness then harness else "") ^
+  String.concat "" (List.map (of_command (ref Map.empty)) scr)

--- a/interpreter/host/main.ml
+++ b/interpreter/host/main.ml
@@ -1,5 +1,5 @@
 let name = "wasm"
-let version = "0.6"
+let version = "0.7"
 
 let configure () =
   Import.register "spectest" Spectest.lookup;
@@ -31,6 +31,7 @@ let argspec = Arg.align
   "-s", Arg.Set Flags.print_sig, " show module signatures";
   "-u", Arg.Set Flags.unchecked, " unchecked, do not perform validation";
   "-us", Arg.Set Flags.unchecked_soft, " do not perform soft validation checks";
+  "-h", Arg.Clear Flags.harness, " exclude harness for JS convesion";
   "-d", Arg.Set Flags.dry, " dry, do not run program";
   "-t", Arg.Set Flags.trace, " trace execution";
   "-v", Arg.Unit banner, " show version"


### PR DESCRIPTION
This allows for use of the JS-converted files with alternative test harnesses.