### PR TITLE
Tests for checking segments against actual table/memory sizes

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -90,6 +90,9 @@ $(ZIP):		$(WINMAKE)
 test:		$(NAME)
 		../test/core/run.py --wasm `pwd`/wasm
 
+test/%:		$(NAME)
+		../test/core/run.py --wasm `pwd`/wasm $(@:test/%=../test/core/%.wast)
+
 clean:
 		$(OCB) -clean
 

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -156,6 +156,12 @@
 
 (assert_trap (invoke $Ot "call" (i32.const 20)) "undefined")
 
+(module $Pt
+  (table (import "Mt" "tab") 0 anyfunc)
+  (elem (i32.const 9) $f)
+  (func $f)
+)
+
 (assert_unlinkable
   (module
     (table (import "Mt" "tab") 10 anyfunc)
@@ -235,6 +241,11 @@
 (assert_return (invoke $Om "load" (i32.const 12)) (i32.const 0xa7))
 
 (module $Pm
+  (memory (import "Mm" "mem") 0)
+  (data (i32.const 1000) "abc")
+)
+
+(module $Qm
   (memory (import "Mm" "mem") 1 8)
 
   (func (export "grow") (param $a i32) (result i32)
@@ -242,14 +253,14 @@
   )
 )
 
-(assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 1))
-(assert_return (invoke $Pm "grow" (i32.const 2)) (i32.const 1))
-(assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 3))
-(assert_return (invoke $Pm "grow" (i32.const 1)) (i32.const 3))
-(assert_return (invoke $Pm "grow" (i32.const 1)) (i32.const 4))
-(assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 5))
-(assert_return (invoke $Pm "grow" (i32.const 1)) (i32.const -1))
-(assert_return (invoke $Pm "grow" (i32.const 0)) (i32.const 5))
+(assert_return (invoke $Qm "grow" (i32.const 0)) (i32.const 1))
+(assert_return (invoke $Qm "grow" (i32.const 2)) (i32.const 1))
+(assert_return (invoke $Qm "grow" (i32.const 0)) (i32.const 3))
+(assert_return (invoke $Qm "grow" (i32.const 1)) (i32.const 3))
+(assert_return (invoke $Qm "grow" (i32.const 1)) (i32.const 4))
+(assert_return (invoke $Qm "grow" (i32.const 0)) (i32.const 5))
+(assert_return (invoke $Qm "grow" (i32.const 1)) (i32.const -1))
+(assert_return (invoke $Qm "grow" (i32.const 0)) (i32.const 5))
 
 (assert_unlinkable
   (module


### PR DESCRIPTION
For imports, segment bounds checks ought to be performed wrt to the actual object sizes, not the declared ones.

Also, add convenience target to Makefile to enable running individual tests like
```
make test/memory
```