### PR TITLE
Test builder: introduce CLI options for specific sub-tasks

### DIFF
--- a/test/build.py
+++ b/test/build.py
@@ -58,7 +58,7 @@ def convert_wast_to_js(out_js_dir):
 
     for wast_file in glob.glob(os.path.join(WAST_TESTS_DIR, '*.wast')):
         # Don't try to compile tests that are supposed to fail.
-        if 'fail.wast' in wast_file:
+        if '.fail.' in wast_file:
             continue
 
         js_filename = os.path.basename(wast_file) + '.js'

--- a/test/build.py
+++ b/test/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import sys
 import os
 import glob
@@ -9,13 +10,10 @@ import shutil
 CWD = os.getcwd()
 WASM_EXEC = os.path.join(CWD, '..', 'interpreter', 'wasm')
 
-WAST_DIR = os.path.join(CWD, 'core')
-JS_DIR = os.path.join(CWD, 'js-api')
-HTML_DIR = os.path.join(CWD, 'html')
-
-OUT_DIR = os.path.join(CWD, 'out')
-OUT_JS_DIR = os.path.join(OUT_DIR, 'js')
-OUT_HTML_DIR = os.path.join(OUT_DIR, 'html')
+WAST_TESTS_DIR = os.path.join(CWD, 'core')
+JS_TESTS_DIR = os.path.join(CWD, 'js-api')
+HTML_TESTS_DIR = os.path.join(CWD, 'html')
+HARNESS_DIR = os.path.join(CWD, 'harness')
 
 # Helpers.
 def run(*cmd):
@@ -25,9 +23,13 @@ def run(*cmd):
                           universal_newlines=True)
 
 # Preconditions.
-def ensure_dir(path):
-    if not os.path.exists(path) or not os.path.isdir(path):
-        os.mkdir(path)
+def ensure_remove_dir(path):
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+def ensure_empty_dir(path):
+    ensure_remove_dir(path)
+    os.mkdir(path)
 
 def ensure_wasm_executable(path_to_wasm):
     """
@@ -39,66 +41,52 @@ def ensure_wasm_executable(path_to_wasm):
         sys.exit(1)
 
 
-def ensure_clean_initial_state():
-    ensure_wasm_executable(WASM_EXEC)
-
-    if os.path.exists(OUT_DIR):
-        shutil.rmtree(OUT_DIR)
-
-    ensure_dir(OUT_DIR)
-    ensure_dir(OUT_JS_DIR)
-    ensure_dir(OUT_HTML_DIR)
-
 # JS harness.
-def replace_js_harness(js_file):
-    test_func_name = os.path.basename(js_file).replace('.', '_').replace('-', '_')
-
-    content = ["(function {}() {{".format(test_func_name)]
-    with open(js_file, 'r') as f:
-        content += f.readlines()
-    content.append('})();')
-
-    with open(js_file, 'w') as f:
-        f.write('\n'.join(content))
-
-def convert_wast_to_js():
+def convert_wast_to_js(out_js_dir):
     """Compile all the wast files to JS and store the results in the JS dir."""
-    for wast_file in glob.glob(os.path.join(WAST_DIR, '*.wast')):
+    for wast_file in glob.glob(os.path.join(WAST_TESTS_DIR, '*.wast')):
         # Don't try to compile tests that are supposed to fail.
         if 'fail.wast' in wast_file:
             continue
 
         print('Compiling {} to JS...'.format(wast_file))
         js_filename = os.path.basename(wast_file) + '.js'
-        js_file = os.path.join(OUT_JS_DIR, js_filename)
+        js_file = os.path.join(out_js_dir, js_filename)
         result = run(WASM_EXEC, wast_file, '-h', '-o', js_file)
         if result.returncode != 0:
             print('Error when compiling {} to JS: {}', wast_file, result.stdout)
 
-        replace_js_harness(js_file)
-
-def build_js():
+def build_js(out_js_dir):
     print('Building JS...')
-    convert_wast_to_js()
+    convert_wast_to_js(out_js_dir)
 
     print('Copying JS tests to the JS out dir...')
-    for js_file in glob.glob(os.path.join(JS_DIR, '*.js')):
-        shutil.copy(js_file, OUT_JS_DIR)
+    for js_file in glob.glob(os.path.join(JS_TESTS_DIR, '*.js')):
+        shutil.copy(js_file, out_js_dir)
 
+    harness_dir = os.path.join(out_js_dir, 'harness')
+    ensure_empty_dir(harness_dir)
+
+    print('Copying JS test harness to the JS out dir...')
+    for js_file in glob.glob(os.path.join(HARNESS_DIR, '*')):
+        shutil.copy(js_file, harness_dir)
+
+    print('Done building JS.')
+
+# HTML harness.
 HTML_HEADER = """<!doctype html>
 <html>
     <head>
         <meta charset="UTF-8">
         <title>WebAssembly Web Platform Test</title>
-        <link rel=author href=mailto:bbouvier@mozilla.com title=bnjbvr>
     </head>
     <body>
 
-        <script src={PREFIX}harness/testharness.js></script>
-        <script src={PREFIX}harness/testharnessreport.js></script>
-        <script src={PREFIX}harness/index.js></script>
-        <script src={PREFIX}harness/wasm-constants.js></script>
-        <script src={PREFIX}harness/wasm-module-builder.js></script>
+        <script src={PREFIX}/testharness.js></script>
+        <script src={PREFIX}/testharnessreport.js></script>
+        <script src={PREFIX}/index.js></script>
+        <script src={PREFIX}/wasm-constants.js></script>
+        <script src={PREFIX}/wasm-module-builder.js></script>
 
         <div id=log></div>
 """
@@ -108,44 +96,121 @@ HTML_BOTTOM = """
 </html>
 """
 
-def build_html_from_js(src_dir):
-    files = []
-    for js_file in glob.glob(os.path.join(src_dir, '*.js')):
-        if src_dir != OUT_JS_DIR:
-            shutil.copy(js_file, OUT_JS_DIR)
-
+def build_html_from_js(js_html_dir, html_dir):
+    for js_file in glob.glob(os.path.join(js_html_dir, '*.js')):
         js_filename = os.path.basename(js_file)
-        files.append(js_filename)
         html_filename = js_filename + '.html'
-        html_file = os.path.join(OUT_HTML_DIR, html_filename)
+        html_file = os.path.join(html_dir, html_filename)
         with open(html_file, 'w+') as f:
-            content = HTML_HEADER.replace('{PREFIX}', '../../')
-            content += "        <script src=../js/{SCRIPT}></script>".replace('{SCRIPT}', js_filename)
+            content = HTML_HEADER.replace('{PREFIX}', './js/harness')
+            content += "        <script src=./js/{SCRIPT}></script>".replace('{SCRIPT}', js_filename)
             content += HTML_BOTTOM
             f.write(content)
-    return files
 
-def build_html():
+def build_html_js(out_dir, js_dir):
+    if js_dir is None:
+        ensure_empty_dir(out_dir)
+        build_js(out_dir)
+    else:
+        print('Copying JS files into the HTML dir...')
+        ensure_remove_dir(out_dir)
+        shutil.copytree(js_dir, out_dir)
+        print('Done copying JS files into the HTML dir.')
+
+    for js_file in glob.glob(os.path.join(HTML_TESTS_DIR, '*.js')):
+        shutil.copy(js_file, out_dir)
+
+def build_html(html_dir, js_dir):
     print("Building HTML tests...")
 
-    print('Building WPT tests from pure JS tests...')
-    js_files = build_html_from_js(OUT_JS_DIR)
+    js_html_dir = os.path.join(html_dir, 'js')
 
-    print('Building WPT tests from HTML JS tests...')
-    js_files += build_html_from_js(HTML_DIR)
+    build_html_js(js_html_dir, js_dir)
 
+    print('Building WPT tests from JS tests...')
+    build_html_from_js(js_html_dir, html_dir)
+
+    print("Done building HTML tests.")
+
+
+# Front page harness.
+def wrap_single_test(js_file):
+    test_func_name = os.path.basename(js_file).replace('.', '_').replace('-', '_')
+
+    content = ["(function {}() {{".format(test_func_name)]
+    with open(js_file, 'r') as f:
+        content += f.readlines()
+    content.append('reinitializeRegistry();')
+    content.append('})();')
+
+    with open(js_file, 'w') as f:
+        f.write('\n'.join(content))
+
+def build_front_page(out_dir, js_dir):
     print('Building front page containing all the HTML tests...')
-    front_page = os.path.join(OUT_DIR, 'index.html')
+
+    js_out_dir = os.path.join(out_dir, 'js')
+
+    build_html_js(js_out_dir, js_dir)
+    for js_file in glob.glob(os.path.join(js_out_dir, '*.js')):
+        wrap_single_test(js_file)
+
+    front_page = os.path.join(out_dir, 'index.html')
     with open(front_page, 'w+') as f:
-        content = HTML_HEADER.replace('{PREFIX}', '../')
-        for filename in js_files:
+        content = HTML_HEADER.replace('{PREFIX}', './js/harness')
+        for js_file in glob.glob(os.path.join(js_out_dir, '*.js')):
+            filename = os.path.basename(js_file)
             content += "        <script src=./js/{SCRIPT}></script>\n".replace('{SCRIPT}', filename)
-            content += "        <script>reinitializeRegistry();</script>\n"
         content += HTML_BOTTOM
         f.write(content)
 
+    print('Done building front page!')
+
+# Main program.
+def process_args():
+    parser = argparse.ArgumentParser(description="Helper tool to build the\
+            multi-stage cross-browser test suite for WebAssembly.")
+
+    parser.add_argument('--front',
+                        dest="front_dir",
+                        help="Relative path to the output directory for the front page.",
+                        type=str)
+
+    parser.add_argument('--js',
+                        dest="js_dir",
+                        help="Relative path to the output directory for the pure JS tests.",
+                        type=str)
+
+    parser.add_argument('--html',
+                        dest="html_dir",
+                        help="Relative path to the output directory for the HTML tests.",
+                        type=str)
+
+    return parser.parse_args()
+
 if __name__ == '__main__':
-    ensure_clean_initial_state()
-    build_js()
-    build_html()
+    args = process_args()
+
+    js_dir = args.js_dir
+    html_dir = args.html_dir
+    front_dir = args.front_dir
+
+    ensure_wasm_executable(WASM_EXEC)
+
+    if front_dir is None and js_dir is None and html_dir is None:
+        print('At least one mode must be selected.')
+        exit(1)
+
+    if js_dir is not None:
+        ensure_empty_dir(js_dir)
+        build_js(js_dir)
+
+    if html_dir is not None:
+        ensure_empty_dir(html_dir)
+        build_html(html_dir, js_dir)
+
+    if front_dir is not None:
+        ensure_empty_dir(front_dir)
+        build_front_page(front_dir, js_dir)
+
     print('Done!')

--- a/test/build.py
+++ b/test/build.py
@@ -8,13 +8,13 @@ import subprocess
 import shutil
 import multiprocessing as mp
 
-CWD = os.getcwd()
-WASM_EXEC = os.path.join(CWD, '..', 'interpreter', 'wasm')
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+WASM_EXEC = os.path.join(SCRIPT_DIR, '..', 'interpreter', 'wasm')
 
-WAST_TESTS_DIR = os.path.join(CWD, 'core')
-JS_TESTS_DIR = os.path.join(CWD, 'js-api')
-HTML_TESTS_DIR = os.path.join(CWD, 'html')
-HARNESS_DIR = os.path.join(CWD, 'harness')
+WAST_TESTS_DIR = os.path.join(SCRIPT_DIR, 'core')
+JS_TESTS_DIR = os.path.join(SCRIPT_DIR, 'js-api')
+HTML_TESTS_DIR = os.path.join(SCRIPT_DIR, 'html')
+HARNESS_DIR = os.path.join(SCRIPT_DIR, 'harness')
 
 # Helpers.
 def run(*cmd):

--- a/test/harness/index.js
+++ b/test/harness/index.js
@@ -133,21 +133,25 @@ function module(bytes, valid = true) {
     return module;
 }
 
+function uniqueTest(func, desc) {
+    test(func, testNum() + desc);
+}
+
 function assert_invalid(bytes) {
-    test(() => {
+    uniqueTest(() => {
         try {
             module(bytes, /* valid */ false);
             throw new Error('did not fail');
         } catch(e) {
             assert_true(e instanceof WebAssembly.CompileError, "expected invalid failure:");
         }
-    }, testNum() + "A wast module that should be invalid or malformed.");
+    }, "A wast module that should be invalid or malformed.");
 }
 
 const assert_malformed = assert_invalid;
 
 function assert_soft_invalid(bytes) {
-    test(() => {
+    uniqueTest(() => {
         try {
             module(bytes, /* valid */ soft_validate);
             if (soft_validate)
@@ -156,7 +160,7 @@ function assert_soft_invalid(bytes) {
             if (soft_validate)
                 assert_true(e instanceof WebAssembly.CompileError, "expected soft invalid failure:");
         }
-    }, testNum() + "A wast module that *could* be invalid under certain engines.");
+    }, "A wast module that *could* be invalid under certain engines.");
 }
 
 function instance(bytes, imports = registry, valid = true) {
@@ -177,10 +181,10 @@ function instance(bytes, imports = registry, valid = true) {
     }
 
     if (valid) {
-        test(() => {
-            let instanciated = err === null;
-            assert_true(instanciated, err);
-        }, testNum() + "module successfully instanciated");
+        uniqueTest(() => {
+            let instantiated = err === null;
+            assert_true(instantiated, err);
+        }, "module successfully instantiated");
     }
 
     return err !== null ? ErrorResult(err) : ValueResult(i);
@@ -235,10 +239,10 @@ function run(action) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         if (result.isError())
             throw result.value;
-    }, testNum() + "A wast test that runs without any special assertion.");
+    }, "A wast test that runs without any special assertion.");
 }
 
 function assert_unlinkable(bytes) {
@@ -246,13 +250,13 @@ function assert_unlinkable(bytes) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(result.isError(), 'expected error result');
         if (result.isError()) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.LinkError, `expected link error, observed ${e}:`);
         }
-    }, testNum() + "A wast module that is unlinkable.");
+    }, "A wast module that is unlinkable.");
 }
 
 function assert_uninstantiable(bytes) {
@@ -260,13 +264,13 @@ function assert_uninstantiable(bytes) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(result.isError(), 'expected error result');
         if (result.isError()) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.RuntimeError, `expected runtime error, observed ${e}:`);
         }
-    }, testNum() + "A wast module that is uninstantiable.");
+    }, "A wast module that is uninstantiable.");
 }
 
 function assert_trap(action) {
@@ -274,13 +278,13 @@ function assert_trap(action) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(result.isError(), 'expected error result');
         if (result.isError()) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.RuntimeError, `expected runtime error, observed ${e}:`);
         }
-    }, testNum() + "A wast module that must trap at runtime.");
+    }, "A wast module that must trap at runtime.");
 }
 
 let StackOverflow;
@@ -291,13 +295,13 @@ function assert_exhaustion(action) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(result.isError(), 'expected error result');
         if (result.isError()) {
             let e = result.value;
             assert_true(e instanceof StackOverflow, `expected stack overflow error, observed ${e}:`);
         }
-    }, testNum() + "A wast module that must exhaust the stack space.");
+    }, "A wast module that must exhaust the stack space.");
 }
 
 function assert_return(action, expected) {
@@ -311,12 +315,12 @@ function assert_return(action, expected) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(!result.isError(), `expected success result, got: ${result.value}.`);
         if (!result.isError()) {
             assert_equals(result.value, expected);
         };
-    }, testNum() + "A wast module that must return a particular value.");
+    }, "A wast module that must return a particular value.");
 };
 
 function assert_return_nan(action) {
@@ -324,10 +328,10 @@ function assert_return_nan(action) {
 
     _assert(result instanceof Result);
 
-    test(() => {
+    uniqueTest(() => {
         assert_true(!result.isError(), 'expected success result');
         if (!result.isError()) {
             assert_true(Number.isNaN(result.value), `expected NaN, observed ${result.value}.`);
         };
-    }, testNum() + "A wast module that must return NaN.");
+    }, "A wast module that must return NaN.");
 }

--- a/test/harness/index.js
+++ b/test/harness/index.js
@@ -16,7 +16,14 @@
 
 'use strict';
 
-// WPT's assert_throw uses a list of predefined, hardcoded know errors. Since
+let testNum = (function() {
+    let count = 1;
+    return function() {
+        return `#${count++} `;
+    }
+})();
+
+// WPT's assert_throw uses a list of predefined, hardcoded known errors. Since
 // it is not aware of the WebAssembly error types (yet), implement our own
 // version.
 function assertThrows(func, err) {
@@ -27,7 +34,7 @@ function assertThrows(func, err) {
         assert_true(e instanceof err, `expected ${err.name}, observed ${e.constructor.name}`);
         caught = true;
     }
-    assert_true(caught, "assertThrows must catch any error.")
+    assert_true(caught, testNum() + "assertThrows must catch any error.")
 }
 
 /******************************************************************************
@@ -134,7 +141,7 @@ function assert_invalid(bytes) {
         } catch(e) {
             assert_true(e instanceof WebAssembly.CompileError, "expected invalid failure:");
         }
-    }, "A wast module that should be invalid or malformed.");
+    }, testNum() + "A wast module that should be invalid or malformed.");
 }
 
 const assert_malformed = assert_invalid;
@@ -149,7 +156,7 @@ function assert_soft_invalid(bytes) {
             if (soft_validate)
                 assert_true(e instanceof WebAssembly.CompileError, "expected soft invalid failure:");
         }
-    }, "A wast module that *could* be invalid under certain engines.");
+    }, testNum() + "A wast module that *could* be invalid under certain engines.");
 }
 
 function instance(bytes, imports = registry, valid = true) {
@@ -173,7 +180,7 @@ function instance(bytes, imports = registry, valid = true) {
         test(() => {
             let instanciated = err === null;
             assert_true(instanciated, err);
-        }, "module successfully instanciated");
+        }, testNum() + "module successfully instanciated");
     }
 
     return err !== null ? ErrorResult(err) : ValueResult(i);
@@ -231,7 +238,7 @@ function run(action) {
     test(() => {
         if (result.isError())
             throw result.value;
-    }, "A wast test that runs without any special assertion.");
+    }, testNum() + "A wast test that runs without any special assertion.");
 }
 
 function assert_unlinkable(bytes) {
@@ -245,7 +252,7 @@ function assert_unlinkable(bytes) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.LinkError, `expected link error, observed ${e}:`);
         }
-    }, "A wast module that is unlinkable.");
+    }, testNum() + "A wast module that is unlinkable.");
 }
 
 function assert_uninstantiable(bytes) {
@@ -259,7 +266,7 @@ function assert_uninstantiable(bytes) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.RuntimeError, `expected runtime error, observed ${e}:`);
         }
-    }, "A wast module that is uninstantiable.");
+    }, testNum() + "A wast module that is uninstantiable.");
 }
 
 function assert_trap(action) {
@@ -273,7 +280,7 @@ function assert_trap(action) {
             let e = result.value;
             assert_true(e instanceof WebAssembly.RuntimeError, `expected runtime error, observed ${e}:`);
         }
-    }, "A wast module that must trap at runtime.");
+    }, testNum() + "A wast module that must trap at runtime.");
 }
 
 let StackOverflow;
@@ -290,7 +297,7 @@ function assert_exhaustion(action) {
             let e = result.value;
             assert_true(e instanceof StackOverflow, `expected stack overflow error, observed ${e}:`);
         }
-    }, "A wast module that must exhaust the stack space.");
+    }, testNum() + "A wast module that must exhaust the stack space.");
 }
 
 function assert_return(action, expected) {
@@ -309,7 +316,7 @@ function assert_return(action, expected) {
         if (!result.isError()) {
             assert_equals(result.value, expected);
         };
-    }, "A wast module that must return a particular value.");
+    }, testNum() + "A wast module that must return a particular value.");
 };
 
 function assert_return_nan(action) {
@@ -322,5 +329,5 @@ function assert_return_nan(action) {
         if (!result.isError()) {
             assert_true(Number.isNaN(result.value), `expected NaN, observed ${result.value}.`);
         };
-    }, "A wast module that must return NaN.");
+    }, testNum() + "A wast module that must return NaN.");
 }


### PR DESCRIPTION
This should allow us building only interesting subsets of tests for different purposes:

- a browser vendor can build the JS and HTML tests only.
- for the website, we'll be able to build the front page (in a single HTML page) only.

I need to make sure this will interact well at least with Spidermonkey and the webassembly website gh-pages before asking for review. If other browser vendors could confirm this fits their workflow too, this would be great.