### PR TITLE
Fix type checker's peek function

### DIFF
--- a/interpreter/spec/valid.ml
+++ b/interpreter/spec/valid.ml
@@ -81,7 +81,7 @@ let push (ell1, ts1) (ell2, ts2) =
   ts2 @ ts1
 
 let peek i (ell, ts) =
-  try List.nth ts i with Failure _ -> None
+  try List.nth (List.rev ts) i with Failure _ -> None
 
 
 (* Type Synthesis *)

--- a/test/core/select.wast
+++ b/test/core/select.wast
@@ -13,9 +13,19 @@
 
   ;; Check that both sides of the select are evaluated
   (func (export "select_trap_l") (param $cond i32) (result i32)
-   (select (unreachable) (i32.const 0) (get_local $cond)))
+    (select (unreachable) (i32.const 0) (get_local $cond))
+  )
   (func (export "select_trap_r") (param $cond i32) (result i32)
-   (select (i32.const 0) (unreachable) (get_local $cond)))
+    (select (i32.const 0) (unreachable) (get_local $cond))
+  )
+
+  (func (export "select_unreached")
+    (unreachable) (select)
+    (unreachable) (i32.const 0) (select)
+    (unreachable) (i32.const 0) (i32.const 0) (select)
+    (unreachable) (f32.const 0) (i32.const 0) (select)
+    (unreachable)
+  )
 )
 
 (assert_return (invoke "select_i32" (i32.const 1) (i32.const 2) (i32.const 1)) (i32.const 1))


### PR DESCRIPTION
It was indexing the operand stack from the wrong end, breaking typing of `drop` and `select`. Fixes #423.