### PR TITLE
Fix test of empty module name in instanciation

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -334,8 +334,9 @@ test(() => {
     assertThrows(() => new Instance(emptyModule, null), TypeError);
     assertThrows(() => new Instance(importingModule, null), TypeError);
     assertThrows(() => new Instance(importingModule, undefined), TypeError);
+    assertThrows(() => new Instance(importingModule, {}), TypeError);
     assertThrows(() => new Instance(importingModule, {"":{g:()=>{}}}), LinkError);
-    assertThrows(() => new Instance(importingModule, {t:{f:()=>{}}}), LinkError);
+    assertThrows(() => new Instance(importingModule, {t:{f:()=>{}}}), TypeError);
     assert_equals(new Instance(emptyModule) instanceof Instance, true);
     assert_equals(new Instance(emptyModule, {}) instanceof Instance, true);
 }, "'WebAssembly.Instance' constructor function");


### PR DESCRIPTION
According to https://github.com/WebAssembly/design/blob/master/JS.md#webassemblyinstance-constructor, if `Type(Get(importObject, i.module_name))` is not object, then we should throw a `TypeError`, not a `LinkError`. This should be the case here, since `importingModule` tries to import `("", "f")`, the passed imports object's key `""` is undefined.

@rossberg-chromium / @mtrofin, PTAL.