### PR TITLE
Fix a few binary version tests

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -9,11 +9,11 @@
 (assert_malformed (module "asm\00") "magic header not detected")
 (assert_malformed (module "msa\00") "magic header not detected")
 (assert_malformed (module "msa\00\01\00\00\00") "magic header not detected")
-(assert_malformed (module "msa\00\00\00\00\0d") "magic header not detected")
+(assert_malformed (module "msa\00\00\00\00\01") "magic header not detected")
 
 (assert_malformed (module "\00asm") "unexpected end")
 (assert_malformed (module "\00asm\01") "unexpected end")
 (assert_malformed (module "\00asm\01\00\00") "unexpected end")
 (assert_malformed (module "\00asm\0d\00\00\00") "unknown binary version")
 (assert_malformed (module "\00asm\0e\00\00\00") "unknown binary version")
-(assert_malformed (module "\00asm\00\00\00\0d") "unknown binary version")
+(assert_malformed (module "\00asm\00\00\00\01") "unknown binary version")


### PR DESCRIPTION
I missed updating a few cases to version 1 in binary.wast that are meant
to test endianness.