### PR TITLE
More LinkError that should be TypeError in async instanciate

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -742,13 +742,13 @@ test(() => {
     assertInstantiateError([emptyModule, null], TypeError);
     assertInstantiateError([importingModuleBinary, null], TypeError);
     assertInstantiateError([importingModuleBinary, undefined], TypeError);
-    assertInstantiateError([importingModuleBinary, {}], LinkError);
+    assertInstantiateError([importingModuleBinary, {}], TypeError);
     assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError);
-    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], LinkError);
+    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError);
     assertInstantiateError([complexImportingModuleBinary, null], TypeError);
     assertInstantiateError([complexImportingModuleBinary, undefined], TypeError);
-    assertInstantiateError([complexImportingModuleBinary, {}], LinkError);
-    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], LinkError);
+    assertInstantiateError([complexImportingModuleBinary, {}], TypeError);
+    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError);
 
     function assertInstantiateSuccess(module, imports) {
         promise_test(()=> {


### PR DESCRIPTION
Sorry, I didn't catch them because we had issues with our `promise_test` JS polyfill, and `jsapi.js` doesn't succeed as a WPT (for some unrelated reason).

@rossberg-chromium, can you please take a look? Thanks!