### PR TITLE
Add more descriptive messages for assertInstantiateError and assertInstantiateSuccess tests

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -714,7 +714,22 @@ test(() => {
     assert_equals(instantiate, instantiateDesc.value);
     assert_equals(instantiate.length, 1);
     assert_equals(instantiate.name, "instantiate");
+
+    // Keep track of all the messages for assertInstantiateError and assertCompileSuccess
+    // to make sure they're all unique.
+    const testNames = new Set();
+    function ensureUniqueTest(message) {
+        if (testNames.has(message)) {
+            if (quit instanceof Function) {
+                print("Test names must all be unique, but '" + message + "' already exists.");
+                quit(1);
+            }
+        }
+        testNames.add(message);
+    }
+
     function assertInstantiateError(args, err, message) {
+        ensureUniqueTest(message);
         promise_test(() => {
             return instantiate(...args)
                 .then(m => {
@@ -751,6 +766,7 @@ test(() => {
     assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "instantiate on complexImportingModuleBinary, {'c': {'d': scratch_memory}} throws TypeError");
 
     function assertInstantiateSuccess(module, imports, message) {
+        ensureUniqueTest(message);
         promise_test(()=> {
             return instantiate(module, imports)
                 .then(result => {

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -750,7 +750,7 @@ test(() => {
     assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {}] => TypeError)");
     assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {'c': {'d': scratch_memory}}] => TypeError)");
 
-    function assertInstantiateSuccess(module, imports) {
+    function assertInstantiateSuccess(module, imports, message) {
         promise_test(()=> {
             return instantiate(module, imports)
                 .then(result => {
@@ -768,19 +768,19 @@ test(() => {
                         assert_equals(desc.enumerable, true);
                         assert_equals(desc.configurable, true);
                     }
-                })}, 'unexpected failure in assertInstantiateSuccess');
+                })}, message);
     }
-    assertInstantiateSuccess(emptyModule);
-    assertInstantiateSuccess(emptyModuleBinary);
-    assertInstantiateSuccess(emptyModuleBinary.buffer);
-    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}});
-    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}});
-    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}});
+    assertInstantiateSuccess(emptyModule, undefined, "assertInstantiateSuccess(emptyModule, undefined)");
+    assertInstantiateSuccess(emptyModuleBinary, undefined, "assertInstantiateSuccess(emptyModuleBinary, undefined)");
+    assertInstantiateSuccess(emptyModuleBinary.buffer, undefined, "assertInstantiateSuccess(emptyModuleBinary.buffer, undefined)");
+    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModule, {"":{f:()=>{}}})');
+    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}})');
+    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}})');
     assertInstantiateSuccess(complexImportingModuleBinary, {
         a:{b:()=>{}},
         c:{d:scratch_memory},
         e:{f:scratch_table},
-        g:{'⚡':1}});
+        g:{'⚡':1}}, "assertInstantiateSuccess(complexImportingModuleBinary, {...})");
 }, "'WebAssembly.instantiate' function");
 
 })();

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -728,27 +728,27 @@ test(() => {
     }
     var scratch_memory = new WebAssembly.Memory({initial:1});
     var scratch_table = new WebAssembly.Table({element:"anyfunc", initial:1, maximum:1});
-    assertInstantiateError([], TypeError, "assertInstantiateError([] => TypeError)");
-    assertInstantiateError([undefined], TypeError, "assertInstantiateError([undefined] => TypeError)");
-    assertInstantiateError([1], TypeError, "assertInstantiateError([1] => TypeError)");
-    assertInstantiateError([{}], TypeError, "assertInstantiateError([{}] => TypeError)");
-    assertInstantiateError([new Uint8Array()], CompileError, "assertInstantiateError([Uint8Array()] => CompileError)");
-    assertInstantiateError([new ArrayBuffer()], CompileError, "assertInstantiateError([ArrayBuffer()] => CompileError)");
-    assertInstantiateError([new Uint8Array("hi!")], CompileError, "assertInstantiateError([Uint8Array('hi!')] => CompileError)");
-    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "assertInstantiateError([ArrayBuffer('hi!')] => CompileError)");
-    assertInstantiateError([importingModule], TypeError, "assertInstantiateError([importingModule] => TypeError)");
-    assertInstantiateError([importingModule, null], TypeError, "assertInstantiateError([importingModule, null] => TypeError)");
-    assertInstantiateError([importingModuleBinary, null], TypeError, "assertInstantiateError([importingModuleBinary, null] => TypeError)");
-    assertInstantiateError([emptyModule, null], TypeError, "assertInstantiateError([emptyModule] => TypeError)");
-    assertInstantiateError([importingModuleBinary, null], TypeError, "assertInstantiateError([importingModuleBinary, null] => TypeError)");
-    assertInstantiateError([importingModuleBinary, undefined], TypeError, "assertInstantiateError([importingModuleBinary, undefined] => TypeError)");
-    assertInstantiateError([importingModuleBinary, {}], TypeError, "assertInstantiateError([importingModuleBinary, {}] => TypeError)");
-    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "assertInstantiateError([importingModuleBinary, {'':{g:()=>{}}}] => LinkError)");
-    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}] => TypeError)");
-    assertInstantiateError([complexImportingModuleBinary, null], TypeError, "assertInstantiateError([complexImportingModuleBinary, null] => TypeError)");
-    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError, "assertInstantiateError([complexImportingModuleBinary, undefined] => TypeError)");
-    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {}] => TypeError)");
-    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {'c': {'d': scratch_memory}}] => TypeError)");
+    assertInstantiateError([], TypeError, "instantiate with no args throws TypeError)");
+    assertInstantiateError([undefined], TypeError, "instantiate on undefined throws TypeError)");
+    assertInstantiateError([1], TypeError, "instantiate on a number throws TypeError)");
+    assertInstantiateError([{}], TypeError, "instantiate on empty object throws TypeError)");
+    assertInstantiateError([new Uint8Array()], CompileError, "instantiate on empty Uint8Array throws CompileError)");
+    assertInstantiateError([new ArrayBuffer()], CompileError, "instantiate on empty ArrayBuffer throws CompileError)");
+    assertInstantiateError([new Uint8Array("hi!")], CompileError, "instantiate on Uint8Array('hi!') throws CompileError)");
+    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "instantiate on ArrayBuffer('hi!') throws CompileError)");
+    assertInstantiateError([importingModule], TypeError, "instantiate on importingModule throws TypeError");
+    assertInstantiateError([importingModule, null], TypeError, "instantiate on importingModule, null throws TypeError");
+    assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");
+    assertInstantiateError([emptyModule, null], TypeError, "instantiate on emptyModule throws TypeError");
+    assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");
+    assertInstantiateError([importingModuleBinary, undefined], TypeError, "instantiate on importingModuleBinary, undefined throws TypeError");
+    assertInstantiateError([importingModuleBinary, {}], TypeError, "instantiate on importingModuleBinary, {} throws TypeError");
+    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "instantiate on importingModuleBinary, {'':{g:()=>{}}} throws LinkError");
+    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "instantiate on importingModuleBinary, {t:{f:()=>{}}} throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, null], TypeError, "instantiate on complexImportingModuleBinary, null throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError, "instantiate on complexImportingModuleBinary, undefined throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "instantiate on complexImportingModuleBinary, empty object throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "instantiate on complexImportingModuleBinary, {'c': {'d': scratch_memory}} throws TypeError");
 
     function assertInstantiateSuccess(module, imports, message) {
         promise_test(()=> {
@@ -770,17 +770,17 @@ test(() => {
                     }
                 })}, message);
     }
-    assertInstantiateSuccess(emptyModule, undefined, "assertInstantiateSuccess(emptyModule, undefined)");
-    assertInstantiateSuccess(emptyModuleBinary, undefined, "assertInstantiateSuccess(emptyModuleBinary, undefined)");
-    assertInstantiateSuccess(emptyModuleBinary.buffer, undefined, "assertInstantiateSuccess(emptyModuleBinary.buffer, undefined)");
-    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModule, {"":{f:()=>{}}})');
-    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}})');
-    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}}, 'assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}})');
+    assertInstantiateSuccess(emptyModule, undefined, "instantiate on emptyModule, undefined succeeds");
+    assertInstantiateSuccess(emptyModuleBinary, undefined, "instantiate on emptyModuleBinary, undefined succeeds");
+    assertInstantiateSuccess(emptyModuleBinary.buffer, undefined, "instantiate on emptyModuleBinary.buffer, undefined succeeds");
+    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}}, 'instantiate on importingModule, {"":{f:()=>{}}} succeeds');
+    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}}, 'instantiate on importingModuleBinary, {"":{f:()=>{}}} succeeds');
+    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}}, 'instantiate on importingModuleBinary.buffer, {"":{f:()=>{}}} succeeds');
     assertInstantiateSuccess(complexImportingModuleBinary, {
         a:{b:()=>{}},
         c:{d:scratch_memory},
         e:{f:scratch_table},
-        g:{'⚡':1}}, "assertInstantiateSuccess(complexImportingModuleBinary, {...})");
+        g:{'⚡':1}}, "instantiate on complexImportingModuleBinary, {...} succeeds");
 }, "'WebAssembly.instantiate' function");
 
 })();

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -714,7 +714,7 @@ test(() => {
     assert_equals(instantiate, instantiateDesc.value);
     assert_equals(instantiate.length, 1);
     assert_equals(instantiate.name, "instantiate");
-    function assertInstantiateError(args, err) {
+    function assertInstantiateError(args, err, message) {
         promise_test(() => {
             return instantiate(...args)
                 .then(m => {
@@ -724,31 +724,31 @@ test(() => {
                     assert_equals(error instanceof err, true);
                     assert_equals(Boolean(error.stack.match("jsapi.js")), true);
                 })
-        }, 'unexpected success in assertInstantiateError');
+        }, message);
     }
     var scratch_memory = new WebAssembly.Memory({initial:1});
     var scratch_table = new WebAssembly.Table({element:"anyfunc", initial:1, maximum:1});
-    assertInstantiateError([], TypeError);
-    assertInstantiateError([undefined], TypeError);
-    assertInstantiateError([1], TypeError);
-    assertInstantiateError([{}], TypeError);
-    assertInstantiateError([new Uint8Array()], CompileError);
-    assertInstantiateError([new ArrayBuffer()], CompileError);
-    assertInstantiateError([new Uint8Array("hi!")], CompileError);
-    assertInstantiateError([new ArrayBuffer("hi!")], CompileError);
-    assertInstantiateError([importingModule], TypeError);
-    assertInstantiateError([importingModule, null], TypeError);
-    assertInstantiateError([importingModuleBinary, null], TypeError);
-    assertInstantiateError([emptyModule, null], TypeError);
-    assertInstantiateError([importingModuleBinary, null], TypeError);
-    assertInstantiateError([importingModuleBinary, undefined], TypeError);
-    assertInstantiateError([importingModuleBinary, {}], TypeError);
-    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError);
-    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError);
-    assertInstantiateError([complexImportingModuleBinary, null], TypeError);
-    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError);
-    assertInstantiateError([complexImportingModuleBinary, {}], TypeError);
-    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError);
+    assertInstantiateError([], TypeError, "assertInstantiateError([] => TypeError)");
+    assertInstantiateError([undefined], TypeError, "assertInstantiateError([undefined] => TypeError)");
+    assertInstantiateError([1], TypeError, "assertInstantiateError([1] => TypeError)");
+    assertInstantiateError([{}], TypeError, "assertInstantiateError([{}] => TypeError)");
+    assertInstantiateError([new Uint8Array()], CompileError, "assertInstantiateError([Uint8Array()] => CompileError)");
+    assertInstantiateError([new ArrayBuffer()], CompileError, "assertInstantiateError([ArrayBuffer()] => CompileError)");
+    assertInstantiateError([new Uint8Array("hi!")], CompileError, "assertInstantiateError([Uint8Array('hi!')] => CompileError)");
+    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "assertInstantiateError([ArrayBuffer('hi!')] => CompileError)");
+    assertInstantiateError([importingModule], TypeError, "assertInstantiateError([importingModule] => TypeError)");
+    assertInstantiateError([importingModule, null], TypeError, "assertInstantiateError([importingModule, null] => TypeError)");
+    assertInstantiateError([importingModuleBinary, null], TypeError, "assertInstantiateError([importingModuleBinary, null] => TypeError)");
+    assertInstantiateError([emptyModule, null], TypeError, "assertInstantiateError([emptyModule] => TypeError)");
+    assertInstantiateError([importingModuleBinary, null], TypeError, "assertInstantiateError([importingModuleBinary, null] => TypeError)");
+    assertInstantiateError([importingModuleBinary, undefined], TypeError, "assertInstantiateError([importingModuleBinary, undefined] => TypeError)");
+    assertInstantiateError([importingModuleBinary, {}], TypeError, "assertInstantiateError([importingModuleBinary, {}] => TypeError)");
+    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "assertInstantiateError([importingModuleBinary, {'':{g:()=>{}}}] => LinkError)");
+    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}] => TypeError)");
+    assertInstantiateError([complexImportingModuleBinary, null], TypeError, "assertInstantiateError([complexImportingModuleBinary, null] => TypeError)");
+    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError, "assertInstantiateError([complexImportingModuleBinary, undefined] => TypeError)");
+    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {}] => TypeError)");
+    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "assertInstantiateError([complexImportingModuleBinary, {'c': {'d': scratch_memory}}] => TypeError)");
 
     function assertInstantiateSuccess(module, imports) {
         promise_test(()=> {

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -720,7 +720,7 @@ test(() => {
     const testNames = new Set();
     function ensureUniqueTest(message) {
         if (testNames.has(message)) {
-            if (quit instanceof Function) {
+            if (typeof quit === 'function') {
                 print("Test names must all be unique, but '" + message + "' already exists.");
                 quit(1);
             }

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -751,18 +751,17 @@ test(() => {
     assertInstantiateError([new ArrayBuffer()], CompileError, "instantiate on empty ArrayBuffer throws CompileError");
     assertInstantiateError([new Uint8Array("hi!")], CompileError, "instantiate on Uint8Array('hi!') throws CompileError");
     assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "instantiate on ArrayBuffer('hi!') throws CompileError");
-    assertInstantiateError([importingModule], TypeError, "instantiate on importingModule throws TypeError");
+    assertInstantiateError([importingModule], TypeError, "instantiate a module importing functions without passing an imports object throws TypeError");
     assertInstantiateError([importingModule, null], TypeError, "instantiate on importingModule, null throws TypeError");
     assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");
     assertInstantiateError([emptyModule, null], TypeError, "instantiate on emptyModule throws TypeError");
-    assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");
     assertInstantiateError([importingModuleBinary, undefined], TypeError, "instantiate on importingModuleBinary, undefined throws TypeError");
-    assertInstantiateError([importingModuleBinary, {}], TypeError, "instantiate on importingModuleBinary, {} throws TypeError");
-    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "instantiate on importingModuleBinary, {'':{g:()=>{}}} throws LinkError");
-    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "instantiate on importingModuleBinary, {t:{f:()=>{}}} throws TypeError");
+    assertInstantiateError([importingModuleBinary, {}], TypeError, "providing an empty imports object to a module that expects imports throws TypeError [1]");
+    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "instantiate on an module importing a function named f, not provided in the imports object, throws LinkError");
+    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "instantiate on an module importing a function from a module named '', not provided in the imports object, throws LinkError");
     assertInstantiateError([complexImportingModuleBinary, null], TypeError, "instantiate on complexImportingModuleBinary, null throws TypeError");
     assertInstantiateError([complexImportingModuleBinary, undefined], TypeError, "instantiate on complexImportingModuleBinary, undefined throws TypeError");
-    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "instantiate on complexImportingModuleBinary, empty object throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "providing an empty imports object to a module that expects imports throws TypeError [2]");
     assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "instantiate on complexImportingModuleBinary, {'c': {'d': scratch_memory}} throws TypeError");
 
     function assertInstantiateSuccess(module, imports, message) {
@@ -796,7 +795,7 @@ test(() => {
         a:{b:()=>{}},
         c:{d:scratch_memory},
         e:{f:scratch_table},
-        g:{'⚡':1}}, "instantiate on complexImportingModuleBinary, {...} succeeds");
+        g:{'⚡':1}}, "instantiate complexImportingModuleBinary with all expected imports succeeds");
 }, "'WebAssembly.instantiate' function");
 
 })();

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -747,22 +747,45 @@ test(() => {
     assertInstantiateError([undefined], TypeError, "instantiate on undefined throws TypeError");
     assertInstantiateError([1], TypeError, "instantiate on a number throws TypeError");
     assertInstantiateError([{}], TypeError, "instantiate on empty object throws TypeError");
-    assertInstantiateError([new Uint8Array()], CompileError, "instantiate on empty Uint8Array throws CompileError");
-    assertInstantiateError([new ArrayBuffer()], CompileError, "instantiate on empty ArrayBuffer throws CompileError");
-    assertInstantiateError([new Uint8Array("hi!")], CompileError, "instantiate on Uint8Array('hi!') throws CompileError");
-    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "instantiate on ArrayBuffer('hi!') throws CompileError");
-    assertInstantiateError([importingModule], TypeError, "instantiate a module importing functions without passing an imports object throws TypeError");
-    assertInstantiateError([importingModule, null], TypeError, "instantiate on importingModule, null throws TypeError");
-    assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");
-    assertInstantiateError([emptyModule, null], TypeError, "instantiate on emptyModule throws TypeError");
-    assertInstantiateError([importingModuleBinary, undefined], TypeError, "instantiate on importingModuleBinary, undefined throws TypeError");
-    assertInstantiateError([importingModuleBinary, {}], TypeError, "providing an empty imports object to a module that expects imports throws TypeError [1]");
-    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError, "instantiate on an module importing a function named f, not provided in the imports object, throws LinkError");
-    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError, "instantiate on an module importing a function from a module named '', not provided in the imports object, throws LinkError");
-    assertInstantiateError([complexImportingModuleBinary, null], TypeError, "instantiate on complexImportingModuleBinary, null throws TypeError");
-    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError, "instantiate on complexImportingModuleBinary, undefined throws TypeError");
-    assertInstantiateError([complexImportingModuleBinary, {}], TypeError, "providing an empty imports object to a module that expects imports throws TypeError [2]");
-    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError, "instantiate on complexImportingModuleBinary, {'c': {'d': scratch_memory}} throws TypeError");
+    assertInstantiateError([new Uint8Array()], CompileError,
+                           "instantiate on empty Uint8Array throws CompileError");
+    assertInstantiateError([new ArrayBuffer()], CompileError,
+                           "instantiate on empty ArrayBuffer throws CompileError");
+    assertInstantiateError([new Uint8Array("hi!")], CompileError,
+                           "instantiate on Uint8Array('hi!') throws CompileError");
+    assertInstantiateError([new ArrayBuffer("hi!")], CompileError,
+                           "instantiate on ArrayBuffer('hi!') throws CompileError");
+    assertInstantiateError([importingModule], TypeError,
+                           "instantiate a module importing functions without passing an " +
+                           "imports object throws TypeError");
+    assertInstantiateError([importingModule, null], TypeError,
+                           "instantiate on importingModule, null throws TypeError");
+    assertInstantiateError([importingModuleBinary, null], TypeError,
+                           "instantiate on importingModuleBinary, null throws TypeError");
+    assertInstantiateError([emptyModule, null], TypeError,
+                           "instantiate on emptyModule throws TypeError");
+    assertInstantiateError([importingModuleBinary, undefined], TypeError,
+                           "instantiate on importingModuleBinary, undefined throws TypeError");
+    assertInstantiateError([importingModuleBinary, {}], TypeError,
+                           "providing an empty imports object to a module that expects imports " +
+                           "throws TypeError [1]");
+    assertInstantiateError([importingModuleBinary, {"":{g:()=>{}}}], LinkError,
+                           "instantiate on an module importing a function named f, not provided " +
+                           "in the imports object, throws LinkError");
+    assertInstantiateError([importingModuleBinary, {t:{f:()=>{}}}], TypeError,
+                           "instantiate on an module importing a function from a module named " +
+                           "'', not provided in the imports object, throws LinkError");
+    assertInstantiateError([complexImportingModuleBinary, null], TypeError,
+                           "instantiate on complexImportingModuleBinary, null throws TypeError");
+    assertInstantiateError([complexImportingModuleBinary, undefined], TypeError,
+                           "instantiate on complexImportingModuleBinary, undefined throws " +
+                           "TypeError");
+    assertInstantiateError([complexImportingModuleBinary, {}], TypeError,
+                           "providing an empty imports object to a module that expects imports " +
+                           "throws TypeError [2]");
+    assertInstantiateError([complexImportingModuleBinary, {"c": {"d": scratch_memory}}], TypeError,
+                           "instantiate on complexImportingModuleBinary, " +
+                           "{'c': {'d': scratch_memory}} throws TypeError");
 
     function assertInstantiateSuccess(module, imports, message) {
         ensureUniqueTest(message);
@@ -785,12 +808,19 @@ test(() => {
                     }
                 })}, message);
     }
-    assertInstantiateSuccess(emptyModule, undefined, "instantiate on emptyModule, undefined succeeds");
-    assertInstantiateSuccess(emptyModuleBinary, undefined, "instantiate on emptyModuleBinary, undefined succeeds");
-    assertInstantiateSuccess(emptyModuleBinary.buffer, undefined, "instantiate on emptyModuleBinary.buffer, undefined succeeds");
-    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}}, 'instantiate on importingModule, {"":{f:()=>{}}} succeeds');
-    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}}, 'instantiate on importingModuleBinary, {"":{f:()=>{}}} succeeds');
-    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}}, 'instantiate on importingModuleBinary.buffer, {"":{f:()=>{}}} succeeds');
+    assertInstantiateSuccess(emptyModule, undefined,
+                             "instantiate on emptyModule, undefined succeeds");
+    assertInstantiateSuccess(emptyModuleBinary, undefined,
+                             "instantiate on emptyModuleBinary, undefined succeeds");
+    assertInstantiateSuccess(emptyModuleBinary.buffer, undefined,
+                             "instantiate on emptyModuleBinary.buffer, undefined succeeds");
+    assertInstantiateSuccess(importingModule, {"":{f:()=>{}}},
+                             'instantiate on importingModule, {"":{f:()=>{}}} succeeds');
+    assertInstantiateSuccess(importingModuleBinary, {"":{f:()=>{}}},
+                             'instantiate on importingModuleBinary, {"":{f:()=>{}}} succeeds');
+    assertInstantiateSuccess(importingModuleBinary.buffer, {"":{f:()=>{}}},
+                             'instantiate on importingModuleBinary.buffer, {"":{f:()=>{}}} ' +
+                             'succeeds');
     assertInstantiateSuccess(complexImportingModuleBinary, {
         a:{b:()=>{}},
         c:{d:scratch_memory},

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -728,14 +728,14 @@ test(() => {
     }
     var scratch_memory = new WebAssembly.Memory({initial:1});
     var scratch_table = new WebAssembly.Table({element:"anyfunc", initial:1, maximum:1});
-    assertInstantiateError([], TypeError, "instantiate with no args throws TypeError)");
-    assertInstantiateError([undefined], TypeError, "instantiate on undefined throws TypeError)");
-    assertInstantiateError([1], TypeError, "instantiate on a number throws TypeError)");
-    assertInstantiateError([{}], TypeError, "instantiate on empty object throws TypeError)");
-    assertInstantiateError([new Uint8Array()], CompileError, "instantiate on empty Uint8Array throws CompileError)");
-    assertInstantiateError([new ArrayBuffer()], CompileError, "instantiate on empty ArrayBuffer throws CompileError)");
-    assertInstantiateError([new Uint8Array("hi!")], CompileError, "instantiate on Uint8Array('hi!') throws CompileError)");
-    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "instantiate on ArrayBuffer('hi!') throws CompileError)");
+    assertInstantiateError([], TypeError, "instantiate with no args throws TypeError");
+    assertInstantiateError([undefined], TypeError, "instantiate on undefined throws TypeError");
+    assertInstantiateError([1], TypeError, "instantiate on a number throws TypeError");
+    assertInstantiateError([{}], TypeError, "instantiate on empty object throws TypeError");
+    assertInstantiateError([new Uint8Array()], CompileError, "instantiate on empty Uint8Array throws CompileError");
+    assertInstantiateError([new ArrayBuffer()], CompileError, "instantiate on empty ArrayBuffer throws CompileError");
+    assertInstantiateError([new Uint8Array("hi!")], CompileError, "instantiate on Uint8Array('hi!') throws CompileError");
+    assertInstantiateError([new ArrayBuffer("hi!")], CompileError, "instantiate on ArrayBuffer('hi!') throws CompileError");
     assertInstantiateError([importingModule], TypeError, "instantiate on importingModule throws TypeError");
     assertInstantiateError([importingModule, null], TypeError, "instantiate on importingModule, null throws TypeError");
     assertInstantiateError([importingModuleBinary, null], TypeError, "instantiate on importingModuleBinary, null throws TypeError");


### PR DESCRIPTION
This PR gives each of these tests a unique message (although they are a bit verbose, so I'm open to changing them), to make it easier to see exactly what is failing.

@bnjbvr, @rossberg-chromium - could you take a look?