### PR TITLE
Add link to gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ specification language.
 It also holds the WebAssembly testsuite, which tests numerous aspects of
 conformance to the spec.
 
-View the HTML rendered spec at [webassembly.github.io/spec](webassembly.github.io/spec/).
+View the spec at [webassembly.github.io/spec](webassembly.github.io/spec/).
 
 At this time, the contents of this repository are under development and known
 to be "incomplet and inkorrect".

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ specification language.
 It also holds the WebAssembly testsuite, which tests numerous aspects of
 conformance to the spec.
 
+View the HTML rendered spec at [webassembly.github.io/spec](webassembly.github.io/spec/).
+
 At this time, the contents of this repository are under development and known
 to be "incomplet and inkorrect".
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ specification language.
 It also holds the WebAssembly testsuite, which tests numerous aspects of
 conformance to the spec.
 
-View the spec at [webassembly.github.io/spec](https://webassembly.github.io/spec/).
+View the work-in-progress spec at [webassembly.github.io/spec](https://webassembly.github.io/spec/).
 
 At this time, the contents of this repository are under development and known
 to be "incomplet and inkorrect".

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ specification language.
 It also holds the WebAssembly testsuite, which tests numerous aspects of
 conformance to the spec.
 
-View the spec at [webassembly.github.io/spec](webassembly.github.io/spec/).
+View the spec at [webassembly.github.io/spec](https://webassembly.github.io/spec/).
 
 At this time, the contents of this repository are under development and known
 to be "incomplet and inkorrect".


### PR DESCRIPTION
I built the html locally before I knew the gh-pages existed.  Would good to link it somewhere? 

P.S. The URL on the repository just points to `webassembly.github.io`, instead of with `/spec`.  Might be a typo.