### PR TITLE
Add br_table test that targets typed loop and void block

### DIFF
--- a/test/core/br_table.wast
+++ b/test/core/br_table.wast
@@ -1203,6 +1203,20 @@
       )
     )
   )
+
+  (func (export "nested-br_table-loop-block") (param i32) (result i32)
+    (loop i32
+      (block
+        (br_table 0 1 1
+          (get_local 0)
+        )
+        (return
+          (i32.const 0)
+        )
+      )
+      (i32.const 1)
+    )
+  )
 )
 
 (assert_return (invoke "type-i32"))
@@ -1381,6 +1395,8 @@
 (assert_return (invoke "nested-br_table-value-index" (i32.const 3)) (i32.const 9))
 (assert_return (invoke "nested-br_table-value-index" (i32.const -1000000)) (i32.const 9))
 (assert_return (invoke "nested-br_table-value-index" (i32.const 9423975)) (i32.const 9))
+
+(assert_return (invoke "nested-br_table-loop-block" (i32.const 0)) (i32.const 1))
 
 (assert_invalid
   (module (func $type-arg-void-vs-num (result i32)

--- a/test/core/br_table.wast
+++ b/test/core/br_table.wast
@@ -1205,16 +1205,19 @@
   )
 
   (func (export "nested-br_table-loop-block") (param i32) (result i32)
+    (set_local 0
+      (loop i32
+        (block
+          (br_table 1 0 0 (get_local 0))
+        )
+        (i32.const 0)
+      )
+    )
     (loop i32
       (block
-        (br_table 0 1 1
-          (get_local 0)
-        )
-        (return
-          (i32.const 0)
-        )
+        (br_table 0 1 1 (get_local 0))
       )
-      (i32.const 1)
+      (i32.const 3)
     )
   )
 )
@@ -1396,7 +1399,7 @@
 (assert_return (invoke "nested-br_table-value-index" (i32.const -1000000)) (i32.const 9))
 (assert_return (invoke "nested-br_table-value-index" (i32.const 9423975)) (i32.const 9))
 
-(assert_return (invoke "nested-br_table-loop-block" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "nested-br_table-loop-block" (i32.const 1)) (i32.const 3))
 
 (assert_invalid
   (module (func $type-arg-void-vs-num (result i32)


### PR DESCRIPTION
This adds a spec test for an unhandled `br_table` cause, found in wabt (https://github.com/WebAssembly/wabt/issues/389) and V8 (https://bugs.chromium.org/p/v8/issues/detail?id=6204)