### PR TITLE
Remove use of "stack" property on Error

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -722,7 +722,6 @@ test(() => {
                 })
                 .catch(error => {
                     assert_equals(error instanceof err, true);
-                    assert_equals(Boolean(error.stack.match("jsapi.js")), true);
                 })
         }, 'unexpected success in assertInstantiateError');
     }


### PR DESCRIPTION
Since stack is not standard, it fits oddly in a test suite for a standard.