### PR TITLE
Fix import-after-global.fail test

### DIFF
--- a/test/core/import-after-global.fail.wast
+++ b/test/core/import-after-global.fail.wast
@@ -1,1 +1,1 @@
-(module (global i64) (import "" "" (table 0 anyfunc)))
+(module (global i64 (i64.const 0)) (import "" "" (table 0 anyfunc)))


### PR DESCRIPTION
The test was missing a global variable initializer expression, and so would fail regardless of whether the import-after-global syntax error is detected correctly.