### PR TITLE
[spec] Execution: conventions, runtime, instructions

### DIFF
--- a/document/binary/instructions.rst
+++ b/document/binary/instructions.rst
@@ -37,7 +37,7 @@ Control Instructions
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Binstr &::=&
+   \production{instruction} & \Binstr &::=&
      \hex{00} &\Rightarrow& \UNREACHABLE \\ &&|&
      \hex{01} &\Rightarrow& \NOP \\ &&|&
      \hex{02}~~\X{rt}{:}\Bblocktype~~(\X{in}{:}\Binstr)^\ast~~\hex{0B}
@@ -77,7 +77,7 @@ Parametric Instructions
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Binstr &::=& \dots \\ &&|&
+   \production{instruction} & \Binstr &::=& \dots \\ &&|&
      \hex{1A} &\Rightarrow& \DROP \\ &&|&
      \hex{1B} &\Rightarrow& \SELECT \\
    \end{array}
@@ -101,7 +101,7 @@ Variable Instructions
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Binstr &::=& \dots \\ &&|&
+   \production{instruction} & \Binstr &::=& \dots \\ &&|&
      \hex{20}~~x{:}\Blocalidx &\Rightarrow& \GETLOCAL~x \\ &&|&
      \hex{21}~~x{:}\Blocalidx &\Rightarrow& \SETLOCAL~x \\ &&|&
      \hex{22}~~x{:}\Blocalidx &\Rightarrow& \TEELOCAL~x \\ &&|&
@@ -131,9 +131,9 @@ Each variant of :ref:`memory instruction <syntax-instr-memory>` is encoded with 
 
 .. math::
    \begin{array}{llclll}
-   \production{memory arguments} & \Bmemarg &::=&
+   \production{memory argument} & \Bmemarg &::=&
      a{:}\Bu32~~o{:}\Bu32 &\Rightarrow& \{ \ALIGN~a,~\OFFSET~o \} \\
-   \production{instructions} & \Binstr &::=& \dots \\ &&|&
+   \production{instruction} & \Binstr &::=& \dots \\ &&|&
      \hex{28}~~m{:}\Bmemarg &\Rightarrow& \I32.\LOAD~m \\ &&|&
      \hex{29}~~m{:}\Bmemarg &\Rightarrow& \I64.\LOAD~m \\ &&|&
      \hex{2A}~~m{:}\Bmemarg &\Rightarrow& \F32.\LOAD~m \\ &&|&
@@ -181,7 +181,7 @@ The |CONST| instructions are followed by the respective literal.
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Binstr &::=& \dots \\&&|&
+   \production{instruction} & \Binstr &::=& \dots \\&&|&
      \hex{41}~~n{:}\Bi32 &\Rightarrow& \I32.\CONST~n \\ &&|&
      \hex{42}~~n{:}\Bi64 &\Rightarrow& \I64.\CONST~n \\ &&|&
      \hex{43}~~z{:}\Bf32 &\Rightarrow& \F32.\CONST~z \\ &&|&
@@ -195,7 +195,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Binstr &::=& \dots && \phantom{thisshouldbeenough} \\&&|&
+   \production{instruction} & \Binstr &::=& \dots && \phantom{thisshouldbeenough} \\&&|&
      \hex{45} &\Rightarrow& \I32.\EQZ \\ &&|&
      \hex{46} &\Rightarrow& \I32.\EQ \\ &&|&
      \hex{47} &\Rightarrow& \I32.\NE \\ &&|&
@@ -211,7 +211,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{50} &\Rightarrow& \I64.\EQZ \\ &&|&
      \hex{51} &\Rightarrow& \I64.\EQ \\ &&|&
      \hex{52} &\Rightarrow& \I64.\NE \\ &&|&
@@ -227,7 +227,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{5B} &\Rightarrow& \F32.\EQ \\ &&|&
      \hex{5C} &\Rightarrow& \F32.\NE \\ &&|&
      \hex{5D} &\Rightarrow& \F32.\LT \\ &&|&
@@ -238,7 +238,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{61} &\Rightarrow& \F64.\EQ \\ &&|&
      \hex{62} &\Rightarrow& \F64.\NE \\ &&|&
      \hex{63} &\Rightarrow& \F64.\LT \\ &&|&
@@ -252,7 +252,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{67} &\Rightarrow& \I32.\CLZ \\ &&|&
      \hex{68} &\Rightarrow& \I32.\CTZ \\ &&|&
      \hex{69} &\Rightarrow& \I32.\POPCNT \\ &&|&
@@ -275,7 +275,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{79} &\Rightarrow& \I64.\CLZ \\ &&|&
      \hex{7A} &\Rightarrow& \I64.\CTZ \\ &&|&
      \hex{7B} &\Rightarrow& \I64.\POPCNT \\ &&|&
@@ -298,7 +298,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{8B} &\Rightarrow& \F32.\ABS \\ &&|&
      \hex{8C} &\Rightarrow& \F32.\NEG \\ &&|&
      \hex{8D} &\Rightarrow& \F32.\CEIL \\ &&|&
@@ -317,7 +317,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{99} &\Rightarrow& \F64.\ABS \\ &&|&
      \hex{9A} &\Rightarrow& \F64.\NEG \\ &&|&
      \hex{9B} &\Rightarrow& \F64.\CEIL \\ &&|&
@@ -338,7 +338,7 @@ All other numeric instructions are plain opcodes without any immediates.
 
 .. math::
    \begin{array}{llclll}
-   \phantom{\production{instructions}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{A7} &\Rightarrow& \I32.\WRAP\K{/}\I64 \\ &&|&
      \hex{A8} &\Rightarrow& \I32.\TRUNC\K{\_s/}\F32 \\ &&|&
      \hex{A9} &\Rightarrow& \I32.\TRUNC\K{\_u/}\F32 \\ &&|&
@@ -380,6 +380,6 @@ Expressions
 
 .. math::
    \begin{array}{llclll}
-   \production{instructions} & \Bexpr &::=&
+   \production{expression} & \Bexpr &::=&
      (\X{in}{:}\Binstr)^\ast~~\hex{0B} &\Rightarrow& \X{in}^\ast~\END \\
    \end{array}

--- a/document/binary/modules.rst
+++ b/document/binary/modules.rst
@@ -40,13 +40,13 @@ All :ref:`indices <syntax-index>` are encoded with their respective |U32| value.
 
 .. math::
    \begin{array}{llclll}
-   \production{type indices} & \Btypeidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{function indices} & \Bfuncidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{table indices} & \Btableidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{memory indices} & \Bmemidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{global indices} & \Bglobalidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{local indices} & \Blocalidx &::=& x{:}\Bu32 &\Rightarrow& x \\
-   \production{label indices} & \Blabelidx &::=& l{:}\Bu32 &\Rightarrow& l \\
+   \production{type index} & \Btypeidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{function index} & \Bfuncidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{table index} & \Btableidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{memory index} & \Bmemidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{global index} & \Bglobalidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{local index} & \Blocalidx &::=& x{:}\Bu32 &\Rightarrow& x \\
+   \production{label index} & \Blabelidx &::=& l{:}\Bu32 &\Rightarrow& l \\
    \end{array}
 
 
@@ -69,7 +69,7 @@ The following parameterized grammar rule defines the generic structure of a sect
 
 .. math::
    \begin{array}{llclll@{\qquad}l}
-   \production{sections} & \Bsection_N(\B{B}) &::=&
+   \production{section} & \Bsection_N(\B{B}) &::=&
      N{:}\Bbyte~~\X{size}{:}\Bu32~~\X{cont}{:}\B{B}
        &\Rightarrow& \X{cont} & (\X{size} = ||\B{B}||) \\ &&|&
      \epsilon &\Rightarrow& \epsilon
@@ -98,7 +98,7 @@ Their contents consist of a :ref:`name <syntax-name>` further identifying the cu
 
 .. math::
    \begin{array}{llclll}
-   \production{custom sections} & \Bcustomsec &::=&
+   \production{custom section} & \Bcustomsec &::=&
      \Bsection_0(\Bcustom) \\
    \production{custom data} & \Bcustom &::=&
      \Bname~~\Bbyte^\ast \\
@@ -123,7 +123,7 @@ It decodes into a vector of :ref:`function types <syntax-functype>` that represe
 
 .. math::
    \begin{array}{llclll}
-   \production{type sections} & \Btypesec &::=&
+   \production{type section} & \Btypesec &::=&
      \X{ft}^\ast{:\,}\Bsection_1(\Bfunctype^\ast) &\Rightarrow& \X{ft}^\ast \\
    \end{array}
 
@@ -143,12 +143,12 @@ It decodes into a vector of :ref:`imports <syntax-import>` that represent the |I
 
 .. math::
    \begin{array}{llclll}
-   \production{import sections} & \Bimportsec &::=&
+   \production{import section} & \Bimportsec &::=&
      \X{im}^\ast{:}\Bsection_2(\Bimport^\ast) &\Rightarrow& \X{im}^\ast \\
-   \production{imports} & \Bimport &::=&
+   \production{import} & \Bimport &::=&
      \X{mod}{:}\Bname~~\X{nm}{:}\Bname~~d{:}\Bimportdesc
        &\Rightarrow& \{ \MODULE~\X{mod}, \NAME~\X{nm}, \DESC~d \} \\
-   \production{import descriptions} & \Bimportdesc &::=&
+   \production{import description} & \Bimportdesc &::=&
      \hex{00}~~x{:}\Btypeidx &\Rightarrow& \FUNC~x \\ &&|&
      \hex{01}~~\X{tt}{:}\Btabletype &\Rightarrow& \TABLE~\X{tt} \\ &&|&
      \hex{02}~~\X{mt}{:}\Bmemtype &\Rightarrow& \MEM~\X{mt} \\ &&|&
@@ -172,7 +172,7 @@ The |LOCALS| and |BODY| fields of the respective functions are encoded separatel
 
 .. math::
    \begin{array}{llclll}
-   \production{function sections} & \Bfuncsec &::=&
+   \production{function section} & \Bfuncsec &::=&
      x^\ast{:}\Bsection_3(\Btypeidx^\ast) &\Rightarrow& x^\ast \\
    \end{array}
 
@@ -192,9 +192,9 @@ It decodes into a vector of :ref:`tables <syntax-table>` that represent the |TAB
 
 .. math::
    \begin{array}{llclll}
-   \production{table sections} & \Btablesec &::=&
+   \production{table section} & \Btablesec &::=&
      \X{tab}^\ast{:}\Bsection_4(\Btable^\ast) &\Rightarrow& \X{tab}^\ast \\
-   \production{tables} & \Btable &::=&
+   \production{table} & \Btable &::=&
      \X{tt}{:}\Btabletype &\Rightarrow& \{ \TYPE~\X{tt} \} \\
    \end{array}
 
@@ -214,9 +214,9 @@ It decodes into a vector of :ref:`memories <syntax-mem>` that represent the |MEM
 
 .. math::
    \begin{array}{llclll}
-   \production{memory sections} & \Bmemsec &::=&
+   \production{memory section} & \Bmemsec &::=&
      \X{mem}^\ast{:}\Bsection_5(\Bmem^\ast) &\Rightarrow& \X{mem}^\ast \\
-   \production{memories} & \Bmem &::=&
+   \production{memory} & \Bmem &::=&
      \X{mt}{:}\Bmemtype &\Rightarrow& \{ \TYPE~\X{mt} \} \\
    \end{array}
 
@@ -236,9 +236,9 @@ It decodes into a vector of :ref:`globals <syntax-global>` that represent the |G
 
 .. math::
    \begin{array}{llclll}
-   \production{global sections} & \Bglobalsec &::=&
+   \production{global section} & \Bglobalsec &::=&
      \X{glob}^\ast{:}\Bsection_6(\Bglobal^\ast) &\Rightarrow& \X{glob}^\ast \\
-   \production{globals} & \Bglobal &::=&
+   \production{global} & \Bglobal &::=&
      \X{gt}{:}\Bglobaltype~~e{:}\Bexpr
        &\Rightarrow& \{ \TYPE~\X{gt}, \INIT~e \} \\
    \end{array}
@@ -259,12 +259,12 @@ It decodes into a vector of :ref:`exports <syntax-export>` that represent the |E
 
 .. math::
    \begin{array}{llclll}
-   \production{export sections} & \Bexportsec &::=&
+   \production{export section} & \Bexportsec &::=&
      \X{ex}^\ast{:}\Bsection_7(\Bexport^\ast) &\Rightarrow& \X{ex}^\ast \\
-   \production{exports} & \Bexport &::=&
+   \production{export} & \Bexport &::=&
      \X{nm}{:}\Bname~~d{:}\Bexportdesc
        &\Rightarrow& \{ \NAME~\X{nm}, \DESC~d \} \\
-   \production{export descriptions} & \Bexportdesc &::=&
+   \production{export description} & \Bexportdesc &::=&
      \hex{00}~~x{:}\Bfuncidx &\Rightarrow& \FUNC~x \\ &&|&
      \hex{01}~~x{:}\Btableidx &\Rightarrow& \TABLE~x \\ &&|&
      \hex{02}~~x{:}\Bmemidx &\Rightarrow& \MEM~x \\ &&|&
@@ -288,9 +288,9 @@ It decodes into an optional :ref:`start function <syntax-start>` that represents
 
 .. math::
    \begin{array}{llclll}
-   \production{start sections} & \Bstartsec &::=&
+   \production{start section} & \Bstartsec &::=&
      \X{st}^?{:}\Bsection_8(\Bstart) &\Rightarrow& \X{st}^? \\
-   \production{start functions} & \Bstart &::=&
+   \production{start function} & \Bstart &::=&
      x{:}\Bfuncidx &\Rightarrow& \{ \FUNC~x \} \\
    \end{array}
 
@@ -312,9 +312,9 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
 
 .. math::
    \begin{array}{llclll}
-   \production{element sections} & \Belemsec &::=&
+   \production{element section} & \Belemsec &::=&
      \X{seg}^\ast{:}\Bsection_9(\Belem^\ast) &\Rightarrow& \X{seg} \\
-   \production{element segments} & \Belem &::=&
+   \production{element segment} & \Belem &::=&
      x{:}\Btableidx~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \{ \TABLE~x, \OFFSET~e, \INIT~y^\ast \} \\
    \end{array}
@@ -352,13 +352,13 @@ denoting *count* locals of the same value type.
 
 .. math::
    \begin{array}{llclll@{\qquad}l}
-   \production{code sections} & \Bcodesec &::=&
+   \production{code section} & \Bcodesec &::=&
      \X{code}^\ast{:}\Bsection_{10}(\Bcode^\ast)
        &\Rightarrow& \X{code}^\ast \\
    \production{code} & \Bcode &::=&
      \X{size}{:}\Bu32~~\X{code}{:}\Bfunc
        &\Rightarrow& \X{code} & (\X{size} = ||\Bfunc||) \\
-   \production{functions} & \Bfunc &::=&
+   \production{function} & \Bfunc &::=&
      (t^\ast)^\ast{:}\Bvec(\Blocals)~~e{:}\Bexpr
        &\Rightarrow& \F{concat}((t^\ast)^\ast), e^\ast
          & (|\F{concat}((t^\ast)^\ast)| < 2^{32}) \\
@@ -368,13 +368,13 @@ denoting *count* locals of the same value type.
 
 .. math (commented out)
    \begin{array}{llclll}
-   \production{code sections} & \Bcodesec_{\typeidx^n} &::=&
+   \production{code section} & \Bcodesec_{\typeidx^n} &::=&
      \f^\ast{:}\Bsection_{10}(\Bcode_{\typeidx}^n)
        &\Rightarrow& \f^\ast \\
    \production{code} & \Bcode_{\typeidx} &::=&
      \X{size}{:}\Bu32~~f{:}\Bfunc_{\typeidx}
        &\Rightarrow& f \qquad\qquad (\X{size} = |\Bfunc|) \\
-   \production{functions} & \Bfunc_{\typeidx} &::=&
+   \production{function} & \Bfunc_{\typeidx} &::=&
      (t^\ast)^\ast{:}\Bvec(\Blocals)~~e{:}\Bexpr &\Rightarrow&
        \{ \TYPE~\typeidx, \LOCALS~\F{concat}((t^\ast)^\ast), \BODY~e^\ast \} \\
    \production{locals} & \Blocals &::=&
@@ -407,9 +407,9 @@ It decodes into a vector of :ref:`data segments <syntax-data>` that represent th
 
 .. math::
    \begin{array}{llclll}
-   \production{data sections} & \Bdatasec &::=&
+   \production{data section} & \Bdatasec &::=&
      \X{seg}^\ast{:}\Bsection_{11}(\Bdata^\ast) &\Rightarrow& \X{seg} \\
-   \production{data segments} & \Bdata &::=&
+   \production{data segment} & \Bdata &::=&
      x{:}\Bmemidx~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
        &\Rightarrow& \{ \MEM~x, \OFFSET~e, \INIT~b^\ast \} \\
    \end{array}
@@ -440,7 +440,7 @@ The lengths of vectors produced by the (possibly empty) :ref:`function <binary-f
      \hex{00}~\hex{61}~\hex{73}~\hex{6D} \\
    \production{version} & \Bversion &::=&
      \hex{01}~\hex{00}~\hex{00}~\hex{00} \\
-   \production{modules} & \Bmodule &::=&
+   \production{module} & \Bmodule &::=&
      \Bmagic \\ &&&
      \Bversion \\ &&&
      \Bcustomsec^\ast \\ &&&
@@ -466,7 +466,7 @@ The lengths of vectors produced by the (possibly empty) :ref:`function <binary-f
      \Bcustomsec^\ast \\ &&&
      \data^\ast{:\,}\Bdatasec \\ &&&
      \Bcustomsec^\ast
-     &\Rightarrow& \{~
+     \quad\Rightarrow\quad \{~
        \begin{array}[t]{@{}l@{}}
        \TYPES~\functype^\ast, \\
        \FUNCS~\func^n, \\
@@ -479,10 +479,11 @@ The lengths of vectors produced by the (possibly empty) :ref:`function <binary-f
        \IMPORTS~\import^\ast, \\
        \EXPORTS~\export^\ast ~\} \\
       \end{array} \\
+   &&& (\begin{array}[t]{@{}l@{}}
+        \mbox{where for each $t_i^\ast, e_i$ in $\X{code}^n$,} \\
+        \func^n[i] = \{ \TYPE~\typeidx^n[i], \LOCALS~t_i^\ast, \BODY~e_i \} ) \\
+        \end{array}
    \end{array}
-
-where for each :math:`(t_i^\ast, e_i)` in :math:`\X{code}^n`,
-:math:`\func^n[i] = \{ \TYPE~\typeidx^n[i], \LOCALS~t_i^\ast, \BODY~e_i \}`.
 
 .. note::
    The version of the WebAssembly binary format may increase in the future

--- a/document/binary/types.rst
+++ b/document/binary/types.rst
@@ -18,7 +18,7 @@ Value Types
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{value types} & \Bvaltype &::=&
+   \production{value type} & \Bvaltype &::=&
      \hex{7F} &\Rightarrow& \I32 \\ &&|&
      \hex{7E} &\Rightarrow& \I64 \\ &&|&
      \hex{7D} &\Rightarrow& \F32 \\ &&|&
@@ -43,7 +43,7 @@ The only :ref:`result types <syntax-resulttype>` occurring in the binary format 
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{result types} & \Bblocktype &::=&
+   \production{result type} & \Bblocktype &::=&
      \hex{40} &\Rightarrow& [] \\ &&|&
      t{:}\Bvaltype &\Rightarrow& [t] \\
    \end{array}
@@ -64,7 +64,7 @@ Function Types
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{function types} & \Bfunctype &::=&
+   \production{function type} & \Bfunctype &::=&
      \hex{60}~~t_1^\ast{:\,}\Bvec(\Bvaltype)~~t_2^\ast{:\,}\Bvec(\Bvaltype)
        &\Rightarrow& [t_1^\ast] \to [t_2^\ast] \\
    \end{array}
@@ -100,7 +100,7 @@ Memory Types
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{memory types} & \Bmemtype &::=&
+   \production{memory type} & \Bmemtype &::=&
      \X{lim}{:}\Blimits &\Rightarrow& \X{lim} \\
    \end{array}
 
@@ -120,9 +120,9 @@ Table Types
 
 .. math::
    \begin{array}{llclll}
-   \production{table types} & \Btabletype &::=&
+   \production{table type} & \Btabletype &::=&
      \X{et}{:}\Belemtype~~\X{lim}{:}\Blimits &\Rightarrow& \X{lim}~\X{et} \\
-   \production{element types} & \Belemtype &::=&
+   \production{element type} & \Belemtype &::=&
      \hex{70} &\Rightarrow& \ANYFUNC \\
    \end{array}
 
@@ -141,9 +141,9 @@ Global Types
 
 .. math::
    \begin{array}{llclll}
-   \production{global types} & \Bglobaltype &::=&
+   \production{global type} & \Bglobaltype &::=&
      t{:}\Bvaltype~~m{:}\Bmut &\Rightarrow& m~t \\
    \production{mutability} & \Bmut &::=&
-     \hex{00} &\Rightarrow& \CONST \\ &&|&
-     \hex{01} &\Rightarrow& \MUT \\
+     \hex{00} &\Rightarrow& \MCONST \\ &&|&
+     \hex{01} &\Rightarrow& \MVAR \\
    \end{array}

--- a/document/binary/values.rst
+++ b/document/binary/values.rst
@@ -19,7 +19,7 @@ Bytes
 
 .. math::
    \begin{array}{llcll@{\qquad}l}
-   \production{bytes} & \Bbyte &::=&
+   \production{byte} & \Bbyte &::=&
      \hex{00} &\Rightarrow& \hex{00} \\ &&|&&
      \dots \\ &&|&
      \hex{FF} &\Rightarrow& \hex{FF} \\
@@ -49,9 +49,9 @@ As an additional constraint, the total number of bytes encoding a value of type 
 
 .. math::
    \begin{array}{llclll@{\qquad}l}
-   \production{unsigned integers} & \BuX{N} &::=&
+   \production{unsigned integer} & \BuX{N} &::=&
      n{:}\Bbyte &\Rightarrow& n & (n < 2^7 \wedge n < 2^N) \\ &&|&
-     n{:}\Bbyte~~m{:}\BuX{N-7} &\Rightarrow&
+     n{:}\Bbyte~~m{:}\BuX{(N\B{-7})} &\Rightarrow&
        2^7\cdot m + (n-2^7) & (n \geq 2^7 \wedge N > 7) \\
    \end{array}
 
@@ -60,10 +60,10 @@ As an additional constraint, the total number of bytes encoding a value of type 
 
 .. math::
    \begin{array}{llclll@{\qquad}l}
-   \production{signed integers} & \BsX{N} &::=&
+   \production{signed integer} & \BsX{N} &::=&
      n{:}\Bbyte &\Rightarrow& n & (n < 2^6 \wedge n < 2^{N-1}) \\ &&|&
      n{:}\Bbyte &\Rightarrow& n-2^7 & (2^6 \leq n < 2^7 \wedge n \geq 2^7-2^{N-1}) \\ &&|&
-     n{:}\Bbyte~~m{:}\BsX{N-7} &\Rightarrow&
+     n{:}\Bbyte~~m{:}\BsX{(N\B{-7})} &\Rightarrow&
        2^7\cdot m + (n-2^7) & (n \geq 2^7 \wedge N > 7) \\
    \end{array}
 
@@ -71,7 +71,7 @@ As an additional constraint, the total number of bytes encoding a value of type 
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{uninterpreted integers} & \BiX{N} &::=&
+   \production{uninterpreted integer} & \BiX{N} &::=&
      n{:}\BsX{N} &\Rightarrow& n
    \end{array}
 
@@ -99,7 +99,7 @@ Floating-Point
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{floating-point numbers} & \BfX{N} &::=&
+   \production{floating-point number} & \BfX{N} &::=&
      b^\ast{:\,}\Bbyte^{N/8} &\Rightarrow& \F{reverse}(b^\ast) \\
    \end{array}
 
@@ -118,7 +118,7 @@ Vectors
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
-   \production{vectors} & \Bvec(\B{B}) &::=&
+   \production{vector} & \Bvec(\B{B}) &::=&
      n{:}\Bu32~~(x{:}\B{B})^n &\Rightarrow& x^n \\
    \end{array}
 
@@ -135,13 +135,13 @@ Names
 
 .. math::
    \begin{array}{llclll@{\qquad}l}
-   \production{names} & \Bname &::=&
+   \production{name} & \Bname &::=&
      n{:}\Bu32~~(\X{uc}{:}\Bcodepoint)^\ast &\Rightarrow& \X{uc}^\ast
        & (|\Bcodepoint^\ast| = n) \\
-   \production{code points} & \Bcodepoint &::=&
+   \production{code point} & \Bcodepoint &::=&
      \X{uv}{:}\Bcodeval_N &\Rightarrow& \X{uv}
        & (\X{uv} \geq N \wedge (\X{uv} < \unicode{D800} \vee \unicode{E000} \leq \X{uv} < \unicode{110000})) \\
-   \production{code values} & \Bcodeval_N &::=&
+   \production{code value} & \Bcodeval_N &::=&
      b_1{:}\Bbyte &\Rightarrow&
        b_1
        & (b_1 < \hex{80} \wedge N = \unicode{00}) \\ &&|&

--- a/document/binary/values.rst
+++ b/document/binary/values.rst
@@ -67,12 +67,12 @@ As an additional constraint, the total number of bytes encoding a value of type 
        2^7\cdot m + (n-2^7) & (n \geq 2^7 \wedge N > 7) \\
    \end{array}
 
-:ref:`Uninterpreted integers <syntax-int>` are always encoded as signed integers.
+:ref:`Uninterpreted integers <syntax-int>` are encoded as signed integers.
 
 .. math::
    \begin{array}{llclll@{\qquad\qquad}l}
    \production{uninterpreted integer} & \BiX{N} &::=&
-     n{:}\BsX{N} &\Rightarrow& n
+     n{:}\BsX{N} &\Rightarrow& i & (n = \signed_{\iX{N}}(i))
    \end{array}
 
 .. note::

--- a/document/execution/conventions.rst
+++ b/document/execution/conventions.rst
@@ -1,0 +1,131 @@
+.. index:: ! execution, stack, store
+
+Conventions
+-----------
+
+WebAssembly code is *executed* when :ref:`instantiating <instantiation>` a module or :ref:`invoking <exec-invocation>` a function on the resulting module instance.
+
+Execution behavior is defined in terms of an *abstract machine* that models the *program state*.
+It includes a *stack*, which records operand values and control constructs, and an abstract *store* containing global state.
+
+For each instruction, there is a rule that specifies the effect of its execution on the program state.
+Furthermore, there are rules describing the instantiation of a module.
+As with :ref:`validation <validation>`, all rules are given in two *equivalent* forms:
+
+1. In *prose*, describing the execution in intuitive form.
+2. In *formal notation*, describing the rule in mathematical form.
+
+.. note::
+   As with validation, the prose and formal rules are equivalent,
+   so that understanding of the formal notation is *not* required to read this specification.
+   The formalism offers a more concise description in notation that is used widely in programming languages semantics and is readily amenable to mathematical proof.
+
+:ref:`Store <syntax-store>`, :ref:`stack <syntax-stack>`, and other *runtime structure*, such as :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary :ref:`syntax <syntax-runtime>`.
+
+
+.. _exec-notation-textual:
+
+Textual Notation
+~~~~~~~~~~~~~~~~
+
+Execution is specified by stylised, step-wise rules for each :ref:`instruction <syntax-instr>` of the :ref:`abstract syntax <syntax>`.
+The following conventions are adopted in stating these rules.
+
+* The execution rules implicitly assume a given :ref:`store <store>` :math:`S`.
+
+* The execution rules also assume the presence of an implicit :ref:`stack <stack>`
+  that is modified by *pushing* or *popping*
+  :ref:`values <syntax-value>`, :ref:`labels <syntax-label>`, and :ref:`frames <syntax-frame>`.
+
+* Certain rules require the stack to contain at least one frame,
+  which is referred to as the *current* frame.
+
+* Both the store and the current frame are mutated by *replacing* some of its components.
+  Such replacement is assumed to apply globally.
+
+* The execution of an instruction may *trap*,
+  in which case the entire computation is aborted and no further modifications to the store are performed by it.
+
+* The execution of an instruction may also end in a *jump* to a designated target,
+  which defines the next instruction to execute.
+
+* Execution can *enter* and *exit* :ref:`instruction sequences <syntax-instr-seq>` in a block-like fashion.
+
+* :ref:`Instruction sequences <syntax-instr-seq>` are implicitly executed in order, unless a trap or jump occurs.
+
+* In various places the rules contain *assertions* expressing crucial invariants about the program state, with indications why these are known to hold.
+
+
+.. _exec-notation:
+.. index:: ! reduction rules, ! configuration
+
+Formal Notation
+~~~~~~~~~~~~~~~
+
+.. note::
+   This section gives a brief explanation of the notation for specifying execution formally.
+   For the interested reader, a more thorough introduction can be found in respective text books. [#tapl]_
+
+The formal execution rules use a standard approach for specifying operational semantics, rendering them into *reduction rules*.
+Every rule has the following general form:
+
+.. math::
+   \X{configuration} \quad\stepto\quad \X{configuration}
+
+A *configuration* is a syntactic description of a specific program state.
+Each rule specifies one *step* of execution.
+As long as there is at most one reduction rule applicable to a given configuration, reduction -- and thereby execution -- is *deterministic*.
+WebAssembly has only very few exceptions to this, which are noted explicitly in this specification.
+
+For WebAssembly, a configuration is a tuple :math:`(S; F; \instr^\ast)` consisting of the current :ref:`store <store>` :math:`S`, the :ref:`call frame <frame>` :math:`F` of the current function, and the sequence of :ref:`instructions <syntax-instr>` that is to be executed.
+
+To avoid unnecessary clutter, the store :math:`S` and the frame :math:`F` are omitted from reduction rules that do not touch them.
+
+There is no separate representation of the :ref:`stack <stack>`.
+Instead, it is conveniently represented as part of the configuration's instruction sequence.
+In particular, :ref:`values <syntax-val>` are defined to coincide with |CONST| instructions,
+and a sequence of |CONST| instructions can be interpreted as an operand "stack".
+
+.. note::
+   For example, the :ref:`reduction rule <exec-binop>` for the :math:`\I32.\ADD` instruction could be given as follows:
+
+   .. math::
+      (\I32.\CONST~n_1)~(\I32.\CONST~n_2)~\I32.\ADD \quad\stepto\quad (\I32.\CONST~(n_1 + n_2) \mod 2^{32})
+
+   Per this rule, two |CONST| instructions and the |ADD| instruction itself are removed from the instruction stream and replaced with one new |CONST| instruction.
+   This can be interpreted as popping two value off the stack and pushing the result.
+
+   When no result is produced, an instruction reduces to the empty sequence:
+
+   .. math::
+      \NOP \quad\stepto\quad \epsilon
+
+:ref:`Labels <label>` and :ref:`frames <frame>` are similarly :ref:`defined to be part <syntax-instr-admin>` of an instruction sequence.
+
+The order of reduction is determined by the definition of an approporiate :ref:`evaluation context <syntax-ctxt-eval>`.
+
+Reduction *terminates* when no more reduction rules are applicable.
+:ref:`Soundness <soundness>` of the WebAssembly :ref:`type system <type-system>` guarantees that this is only the case when the original instruction sequence has either been reduced to a sequence of |CONST| instructions, which can be interpreted as the :ref:`values <syntax-val>` of the resulting operand stack,
+or if a trap occurred.
+
+.. note::
+   For example, the following instruction sequence,
+
+   .. math::
+      (\F64.\CONST~x_1)~(\F64.\CONST~x_2)~\F64.\NEG~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL
+
+   terminates after three steps:
+
+   .. math::
+      \begin{array}{ll}
+      & (\F64.\CONST~x_1)~(\F64.\CONST~x_2)~\F64.\NEG~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL \\
+      \stepto & (\F64.\CONST~x_1)~(\F64.\CONST~x_4)~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL \\
+      \stepto & (\F64.\CONST~x_1)~(\F64.\CONST~x_5)~\F64.\MUL \\
+      \stepto & (\F64.\CONST~x_6) \\
+      \end{array}
+
+   where :math:`x_4 = -x_2` and :math:`x_5 = -x_2 + x_3` and :math:`x_6 = x_1 \cdot (-x_2 + x_3)`.
+
+
+.. [#tapl]
+   For example: Benjamin Pierce. `Types and Programming Languages <https://www.cis.upenn.edu/~bcpierce/tapl/>`_. The MIT Press 2002

--- a/document/execution/conventions.rst
+++ b/document/execution/conventions.rst
@@ -3,7 +3,7 @@
 Conventions
 -----------
 
-WebAssembly code is *executed* when :ref:`instantiating <instantiation>` a module or :ref:`invoking <exec-invocation>` a function on the resulting module instance.
+WebAssembly code is *executed* when :ref:`instantiating <instantiation>` a module or :ref:`invoking <exec-invocation>` an :ref:`exported <syntax-export>` function on the resulting module :ref:`instance <syntax-moduleinst>`.
 
 Execution behavior is defined in terms of an *abstract machine* that models the *program state*.
 It includes a *stack*, which records operand values and control constructs, and an abstract *store* containing global state.
@@ -20,7 +20,7 @@ As with :ref:`validation <validation>`, all rules are given in two *equivalent* 
    so that understanding of the formal notation is *not* required to read this specification.
    The formalism offers a more concise description in notation that is used widely in programming languages semantics and is readily amenable to mathematical proof.
 
-:ref:`Store <syntax-store>`, :ref:`stack <syntax-stack>`, and other *runtime structure*, such as :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary :ref:`syntax <syntax-runtime>`.
+:ref:`Store <store>`, :ref:`stack <stack>`, and other *runtime structure*, such as :ref:`module instances <syntax-moduleinst>`, are made precise in terms of additional auxiliary :ref:`syntax <syntax-runtime>`.
 
 
 .. _exec-notation-textual:
@@ -44,7 +44,7 @@ The following conventions are adopted in stating these rules.
   Such replacement is assumed to apply globally.
 
 * The execution of an instruction may *trap*,
-  in which case the entire computation is aborted and no further modifications to the store are performed by it.
+  in which case the entire computation is aborted and no further modifications to the store are performed by it. (Other computations can still be initiated afterwards.)
 
 * The execution of an instruction may also end in a *jump* to a designated target,
   which defines the next instruction to execute.
@@ -72,7 +72,7 @@ Every rule has the following general form:
 .. math::
    \X{configuration} \quad\stepto\quad \X{configuration}
 
-A *configuration* is a syntactic description of a specific program state.
+A *configuration* is a syntactic description of a program state.
 Each rule specifies one *step* of execution.
 As long as there is at most one reduction rule applicable to a given configuration, reduction -- and thereby execution -- is *deterministic*.
 WebAssembly has only very few exceptions to this, which are noted explicitly in this specification.

--- a/document/execution/conventions.rst
+++ b/document/execution/conventions.rst
@@ -25,8 +25,8 @@ As with :ref:`validation <validation>`, all rules are given in two *equivalent* 
 
 .. _exec-notation-textual:
 
-Textual Notation
-~~~~~~~~~~~~~~~~
+Prose Notation
+~~~~~~~~~~~~~~
 
 Execution is specified by stylised, step-wise rules for each :ref:`instruction <syntax-instr>` of the :ref:`abstract syntax <syntax>`.
 The following conventions are adopted in stating these rules.

--- a/document/execution/index.rst
+++ b/document/execution/index.rst
@@ -5,5 +5,7 @@ Execution
    :maxdepth: 2
 
    conventions
-   invocation
+   runtime
+   numerics
    instructions
+   modules

--- a/document/execution/instructions.rst
+++ b/document/execution/instructions.rst
@@ -22,7 +22,7 @@ Numeric Instructions
 1. Push the value :math:`t.\CONST~c` to the stack.
 
 .. note::
-   No formal reduction rule is needed for this instruction, since |CONST| instructions coincide with :ref:`values <syntax-val>`.
+   No formal reduction rule is required for this instruction, since |CONST| instructions coincide with :ref:`values <syntax-val>`.
 
 
 .. _exec-unop:
@@ -172,7 +172,7 @@ Parametric Instructions
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   \val~\DROP &\stepto& \epsilon
+   \val~~\DROP &\stepto& \epsilon
    \end{array}
 
 
@@ -183,7 +183,7 @@ Parametric Instructions
 
 1. Assert: due to :ref:`validation <valid-select>`, a value :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-2. Pop the value :math:`\I32.\CONST~n` from the stack.
+2. Pop the value :math:`\I32.\CONST~c` from the stack.
 
 3. Assert: due to :ref:`validation <valid-select>`, two more values (of the same :ref:`value type <syntax-valtype>`) are on the top of the stack.
 
@@ -191,7 +191,7 @@ Parametric Instructions
 
 5. Pop the value :math:`\val_1` from the stack.
 
-6. If :math:`n` is not :math:`0`, then:
+6. If :math:`c` is not :math:`0`, then:
 
    a. Push the value :math:`\val_1` back to the stack.
 
@@ -201,10 +201,10 @@ Parametric Instructions
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   \val_1~\val_2~(\I32\K{.}\CONST~n)~\SELECT &\stepto& \val_1
-     & (\mbox{if}~n \neq 0) \\
-   \val_1~\val_2~(\I32\K{.}\CONST~n)~\SELECT &\stepto& \val_2
-     & (\mbox{if}~n = 0) \\
+   \val_1~\val_2~(\I32\K{.}\CONST~c)~\SELECT &\stepto& \val_1
+     & (\mbox{if}~c \neq 0) \\
+   \val_1~\val_2~(\I32\K{.}\CONST~c)~\SELECT &\stepto& \val_2
+     & (\mbox{if}~c = 0) \\
    \end{array}
 
 
@@ -372,7 +372,7 @@ Memory Instructions
 
 9. If :math:`N` is not part of the instruction, then:
 
-   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :ref:`value type <syntax-valtype>` of :math:`t`.
+   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :math:`|t|` of :ref:`value type <syntax-valtype>` :math:`t`.
 
 10. If :math:`\X{ea} + N` is larger than the length of :math:`\X{mem}.\DATA`, then:
 
@@ -450,7 +450,7 @@ Memory Instructions
 
 9. If :math:`N` is not part of the instruction, then:
 
-   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :ref:`value type <syntax-valtype>` of :math:`t`.
+   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :math:`|t|` of :ref:`value type <syntax-valtype>` :math:`t`.
 
 10. If :math:`\X{ea} + N` is larger than the length of :math:`\X{mem}.\DATA`, then:
 
@@ -872,9 +872,9 @@ Control Instructions
 
 14. Let :math:`\X{f}` be the :ref:`function instance <syntax-funcinst>` :math:`S.\FUNCS[a]`.
 
-15. Assert: due to :ref:`validation <valid-func>`, :math:`\X{func}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]` exists.
+15. Assert: due to :ref:`validation <valid-func>`, :math:`\X{f}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]` exists.
 
-16. Let :math:`\X{ft}_{\F{actual}}` be the :ref:`function type <syntax-functype>` :math:`\X{func}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]`.
+16. Let :math:`\X{ft}_{\F{actual}}` be the :ref:`function type <syntax-functype>` :math:`\X{f}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]`.
 
 15. If :math:`\X{ft}_{\F{actual}}` and :math:`\X{ft}_{\F{expect}}` differ, then:
 
@@ -890,7 +890,8 @@ Control Instructions
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
      (\mbox{if} & S.\TABLES[F.\MODULE.\TABLES[0]].\ELEM[i] = a \\
-     \wedge & F.\MODULE.\TYPES[x] = f.\MODULE.\TYPES[S.\FUNCS[a].\CODE.\TYPE])
+    \wedge S.\FUNCS[a] = f \\
+     \wedge & F.\MODULE.\TYPES[x] = f.\MODULE.\TYPES[f.\CODE.\TYPE])
      \end{array} \\
    \begin{array}{lcl@{\qquad}l}
    S; F; (\I32.\CONST~i)~(\CALLINDIRECT~x) &\stepto& S; F; \TRAP
@@ -917,7 +918,7 @@ Entering :math:`\instr^\ast` with label :math:`L`
 
 .. note::
    No formal reduction rule is needed for entering an instruction sequence,
-   because the label :math:`L` is embedded in the :ref:`administrative instruction <syntax-instr-admin>` that is reduced to directly.
+   because the label :math:`L` is embedded in the :ref:`administrative instruction <syntax-instr-admin>` that structured control instructions reduce to directly.
 
 
 .. _exec-instr-seq-exit:
@@ -948,7 +949,7 @@ When the end of a labelled instruction sequence is reached without a jump or tra
 
 .. note::
    This semantics also applies to the instruction sequence contained in a |LOOP| instruction.
-   Therefor, execution of a loop falls off the end if no backwards branch is performed explicitly.
+   Therefor, execution of a loop falls off the end, unless a backwards branch is performed explicitly.
 
 
 .. index:: ! invocation, function, function instance, label, frame
@@ -969,7 +970,7 @@ Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
 
 4. Let :math:`[t_1^n] \to [t_2^m]` be the :ref:`function type <syntax-functype>` :math:`f.\MODULE.\TYPES[f.\CODE.\TYPE]`.
 
-5. Let :math:`t^n` be the list of :ref:`value types <syntax-valtype>` :math:`f.\CODE.\LOCALS`.
+5. Let :math:`t^\ast` be the list of :ref:`value types <syntax-valtype>` :math:`f.\CODE.\LOCALS`.
 
 6. Let :math:`\instr^\ast~\END` be the :ref:`expression <syntax-expr>` :math:`f.\CODE.\BODY`.
 
@@ -981,19 +982,20 @@ Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
 
 10. Let :math:`F` be the :ref:`frame <syntax-frame>` :math:`\{ \MODULE~f.\MODULE, \LOCALS~\val^n~\val_0^\ast \}`.
 
-11. Push :math:`F` to the stack.
+11. Push the activation of :math:`F` with arity :math:`m` to the stack.
 
 12. :ref:`Execute <exec-block>` the instruction :math:`\BLOCK~[t_2^m]~\instr^\ast~\END`.
 
 .. math::
    \begin{array}{l}
    \begin{array}{lcl@{\qquad}l}
-   \val^n~(\INVOKE~a) &\stepto& \FRAME_n\{F\}~\BLOCK~[t_2^m]~\instr^\ast~\END~\END
+   \val^n~(\INVOKE~a) &\stepto& \FRAME_m\{F\}~\BLOCK~[t_2^m]~\instr^\ast~\END~\END
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & S.\FUNCS[a].\CODE = \{ \TYPE~x, \LOCALS~t^\ast, \BODY~\instr^\ast~\END \} \\
-     \wedge & S.\FUNCS[a].\MODULE.\TYPES[x] = [t_1^n] \to [t_2^m] \\
+     (\mbox{if} & S.\FUNCS[a] = f \\
+     \wedge & f.\CODE = \{ \TYPE~x, \LOCALS~t^\ast, \BODY~\instr^\ast~\END \} \\
+     \wedge & f.\MODULE.\TYPES[x] = [t_1^n] \to [t_2^m] \\
      \wedge & F = \{ \MODULE~f.\MODULE, ~\LOCALS~\val^n~(t.\CONST~0)^\ast \})
      \end{array} \\
    \end{array}
@@ -1008,7 +1010,7 @@ When the end of a funtion is reached without a jump (|RETURN|) or trap aborting 
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Let :math:`n` be the arity of :math:`F`.
+2. Let :math:`n` be the arity of the activation of :math:`F`.
 
 3. Assert: due to :ref:`validation <valid-instr-seq>`, there are :math:`n` values on the top of the stack.
 

--- a/document/execution/instructions.rst
+++ b/document/execution/instructions.rst
@@ -844,11 +844,11 @@ Control Instructions
 
 2. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\MODULE.\TABLES[0]` exists.
 
-3. Let :math:`a` be the :ref:`table address <syntax-tableaddr>` :math:`F.\MODULE.\TABLES[0]`.
+3. Let :math:`\X{ta}` be the :ref:`table address <syntax-tableaddr>` :math:`F.\MODULE.\TABLES[0]`.
 
-4. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\TABLES[a]` exists.
+4. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\TABLES[\X{ta}]` exists.
 
-5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\TABLES[a]`.
+5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\TABLES[\X{ta}]`.
 
 6. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\MODULE.\TYPES[x]` exists.
 

--- a/document/execution/instructions.rst
+++ b/document/execution/instructions.rst
@@ -890,7 +890,7 @@ Control Instructions
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
      (\mbox{if} & S.\TABLES[F.\MODULE.\TABLES[0]].\ELEM[i] = a \\
-    \wedge S.\FUNCS[a] = f \\
+     \wedge & S.\FUNCS[a] = f \\
      \wedge & F.\MODULE.\TYPES[x] = f.\MODULE.\TYPES[f.\CODE.\TYPE])
      \end{array} \\
    \begin{array}{lcl@{\qquad}l}
@@ -906,6 +906,10 @@ Control Instructions
 
 Instruction Sequences
 ~~~~~~~~~~~~~~~~~~~~~
+
+The following auxiliary rules define the semantics of executing an :ref:`instruction sequence <syntax-instr-seq>`
+that is part of a :ref:`structured control instruction <exec-instr-control>`.
+
 
 .. _exec-instr-seq-enter:
 
@@ -956,6 +960,11 @@ When the end of a labelled instruction sequence is reached without a jump or tra
 
 Function Calls
 ~~~~~~~~~~~~~~
+
+The following auxiliary rules define the semantics of invoking a :ref:`function instance <syntax-funcinst>`
+through one of the :ref:`call instructions <exec-instr-control>`
+and returning from it.
+
 
 .. _exec-invoke:
 

--- a/document/execution/instructions.rst
+++ b/document/execution/instructions.rst
@@ -994,9 +994,9 @@ Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
      (\mbox{if} & S.\FUNCS[a] = f \\
-     \wedge & f.\CODE = \{ \TYPE~x, \LOCALS~t^\ast, \BODY~\instr^\ast~\END \} \\
+     \wedge & f.\CODE = \{ \TYPE~x, \LOCALS~t^k, \BODY~\instr^\ast~\END \} \\
      \wedge & f.\MODULE.\TYPES[x] = [t_1^n] \to [t_2^m] \\
-     \wedge & F = \{ \MODULE~f.\MODULE, ~\LOCALS~\val^n~(t.\CONST~0)^\ast \})
+     \wedge & F = \{ \MODULE~f.\MODULE, ~\LOCALS~\val^n~(t.\CONST~0)^k \})
      \end{array} \\
    \end{array}
 

--- a/document/execution/instructions.rst
+++ b/document/execution/instructions.rst
@@ -1,0 +1,1051 @@
+.. _exec-instr:
+.. index:: instruction, function type, store
+
+Instructions
+------------
+
+
+.. _exec-instr-numeric:
+.. index:: numeric instruction
+   pair: execution; instruction
+   single: abstract syntax; instruction
+
+Numeric Instructions
+~~~~~~~~~~~~~~~~~~~~
+
+
+.. _exec-const:
+
+:math:`t\K{.}\CONST~c`
+......................
+
+1. Push the value :math:`t.\CONST~c` to the stack.
+
+.. note::
+   No formal reduction rule is needed for this instruction, since |CONST| instructions coincide with :ref:`values <syntax-val>`.
+
+
+.. _exec-unop:
+
+:math:`t\K{.}\unop`
+...................
+
+1. Assert: due to :ref:`validation <valid-unop>`, a value of :ref:`value type <syntax-valtype>` :math:`t` is on the top of the stack.
+
+2. Pop the value :math:`t.\CONST~c_1` from the stack.
+
+3. If :math:`\unop_t(c_1)` is defined, then:
+
+   a. Let :math:`c` be the result of computing :math:`\unop_t(c_1)`.
+
+   b. Push the value :math:`t.\CONST~c` to the stack.
+
+4. Else:
+
+   a. Trap.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (t\K{.}\CONST~c_1)~t\K{.}\unop &\stepto& (t\K{.}\CONST~c)
+     & (\mbox{if}~\unop_t(c_1) = c) \\
+   (t\K{.}\CONST~c_1)~t\K{.}\unop &\stepto& \TRAP
+     & (\mbox{otherwise})
+   \end{array}
+
+
+.. _exec-binop:
+
+:math:`t\K{.}\binop`
+....................
+
+1. Assert: due to :ref:`validation <valid-binop>`, two values of :ref:`value type <syntax-valtype>` :math:`t` are on the top of the stack.
+
+2. Pop the value :math:`t.\CONST~c_2` from the stack.
+
+3. Pop the value :math:`t.\CONST~c_1` from the stack.
+
+4. If :math:`\binop_t(c_1, c_2)` is defined, then:
+
+   a. Let :math:`c` be the result of computing :math:`\binop_t(c_1, c_2)`.
+
+   b. Push the value :math:`t.\CONST~c` to the stack.
+
+5. Else:
+
+   a. Trap.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (t\K{.}\CONST~c_1)~(t\K{.}\CONST~c_2)~t\K{.}\binop &\stepto& (t\K{.}\CONST~c)
+     & (\mbox{if}~\binop_t(c_1,c_2) = c) \\
+   (t\K{.}\CONST~c_1)~(t\K{.}\CONST~c_2)~t\K{.}\binop &\stepto& \TRAP
+     & (\mbox{otherwise})
+   \end{array}
+
+
+.. _exec-testop:
+
+:math:`t\K{.}\testop`
+.....................
+
+1. Assert: due to :ref:`validation <valid-testop>`, a value of :ref:`value type <syntax-valtype>` :math:`t` is on the top of the stack.
+
+2. Pop the value :math:`t.\CONST~c_1` from the stack.
+
+3. Let :math:`c` be the result of computing :math:`\testop_t(c_1)`.
+
+4. Push the value :math:`\I32.\CONST~c` to the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (t\K{.}\CONST~c_1)~t\K{.}\testop &\stepto& (t\K{.}\CONST~c)
+     & (\mbox{if}~\testop_t(c_1) = c) \\
+   \end{array}
+
+
+.. _exec-relop:
+
+:math:`t\K{.}\relop`
+....................
+
+1. Assert: due to :ref:`validation <valid-relop>`, two values of :ref:`value type <syntax-valtype>` :math:`t` are on the top of the stack.
+
+2. Pop the value :math:`t.\CONST~c_2` from the stack.
+
+3. Pop the value :math:`t.\CONST~c_1` from the stack.
+
+4. Let :math:`c` be the result of computing :math:`\relop_t(c_1, c_2)`.
+
+5. Push the value :math:`\I32.\CONST~c` to the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (t\K{.}\CONST~c_1)~(t\K{.}\CONST~c_2)~t\K{.}\relop &\stepto& (t\K{.}\CONST~c)
+     & (\mbox{if}~\relop_t(c_1,c_2) = c) \\
+   \end{array}
+
+
+.. _exec-cvtop:
+
+:math:`t_2\K{.}\cvtop/t_1`
+..........................
+
+1. Assert: due to :ref:`validation <valid-cvtop>`, a value of :ref:`value type <syntax-valtype>` :math:`t_1` is on the top of the stack.
+
+2. Pop the value :math:`t_1.\CONST~c_1` from the stack.
+
+3. If :math:`\cvtop_{t_1,t_2}(c_1)` is defined:
+
+   a. Let :math:`c_2` be the result of computing :math:`\cvtop_{t_1,t_2}(c_1)`.
+
+   b. Push the value :math:`t_2.\CONST~c_2` to the stack.
+
+4. Else:
+
+   a. Trap.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (t\K{.}\CONST~c_1)~t_2\K{.}\cvtop\K{/}t_1 &\stepto& (t_2\K{.}\CONST~c_2)
+     & (\mbox{if}~\cvtop_{t_1,t_2}(c_1) = c_2) \\
+   (t\K{.}\CONST~c_1)~t_2\K{.}\cvtop\K{/}t_1 &\stepto& \TRAP
+     & (\mbox{otherwise})
+   \end{array}
+
+
+.. _exec-instr-parametric:
+.. index:: parametric instructions
+   pair: execution; instruction
+   single: abstract syntax; instruction
+
+Parametric Instructions
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _exec-drop:
+
+:math:`\DROP`
+.............
+
+1. Assert: due to :ref:`validation <valid-drop>`, a value is on the top of the stack.
+
+2. Pop the value :math:`\val` from the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \val~\DROP &\stepto& \epsilon
+   \end{array}
+
+
+.. _exec-select:
+
+:math:`\SELECT`
+...............
+
+1. Assert: due to :ref:`validation <valid-select>`, a value :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+2. Pop the value :math:`\I32.\CONST~n` from the stack.
+
+3. Assert: due to :ref:`validation <valid-select>`, two more values (of the same :ref:`value type <syntax-valtype>`) are on the top of the stack.
+
+4. Pop the value :math:`\val_2` from the stack.
+
+5. Pop the value :math:`\val_1` from the stack.
+
+6. If :math:`n` is not :math:`0`, then:
+
+   a. Push the value :math:`\val_1` back to the stack.
+
+7. Else:
+
+   a. Push the value :math:`\val_2` back to the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \val_1~\val_2~(\I32\K{.}\CONST~n)~\SELECT &\stepto& \val_1
+     & (\mbox{if}~n \neq 0) \\
+   \val_1~\val_2~(\I32\K{.}\CONST~n)~\SELECT &\stepto& \val_2
+     & (\mbox{if}~n = 0) \\
+   \end{array}
+
+
+.. _exec-instr-variable:
+.. index:: variable instructions, local index, global index, address, global address, global instance, store, frame
+   pair: execution; instruction
+   single: abstract syntax; instruction
+
+Variable Instructions
+~~~~~~~~~~~~~~~~~~~~~
+
+.. _exec-get_local:
+
+:math:`\GETLOCAL~x`
+...................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-get_local>`, :math:`F.\LOCALS[x]` exists.
+
+3. Let :math:`\val` be the value :math:`F.\LOCALS[x]`.
+
+4. Push the value :math:`\val` to the stack.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   F; (\GETLOCAL~x) &\stepto& F; \val
+     & (\mbox{if}~F.\LOCALS[x] = \val) \\
+   \end{array}
+
+
+.. _exec-set_local:
+
+:math:`\SETLOCAL~x`
+...................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-set_local>`, :math:`F.\LOCALS[x]` exists.
+
+3. Assert: due to :ref:`validation <valid-set_local>`, a value is on the top of the stack.
+
+4. Pop the value :math:`\val` from the stack.
+
+5. Replace :math:`F.\LOCALS[x]` with the value :math:`\val`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   F; \val~(\SETLOCAL~x) &\stepto& F'; \epsilon
+     & (\mbox{if}~F' = F \with \LOCALS[x] = \val) \\
+   \end{array}
+
+
+.. _exec-tee_local:
+
+:math:`\TEELOCAL~x`
+...................
+
+1. Assert: due to :ref:`validation <valid-tee_local>`, a value is on the top of the stack.
+
+2. Pop the value :math:`\val` from the stack.
+
+3. Push the value :math:`\val` to the stack.
+
+4. Push the value :math:`\val` to the stack.
+
+5. :ref:`Execute <exec-set_local>` the instruction :math:`(\SETLOCAL~x)`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   F; \val~(\TEELOCAL~x) &\stepto& F'; \val~\val~(\SETLOCAL~x)
+   \end{array}
+
+
+.. _exec-get_global:
+
+:math:`\GETGLOBAL~x`
+....................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-get_global>`, :math:`F.\MODULE.\GLOBALS[x]` exists.
+
+3. Let :math:`a` be the :ref:`global address <syntax-globaladdr>` :math:`F.\MODULE.\GLOBALS[x]`.
+
+4. Assert: due to :ref:`validation <valid-get_global>`, :math:`S.\GLOBALS[a]` exists.
+
+5. Let :math:`\X{glob}` be the :ref:`global instance <syntax-globalinst>` :math:`S.\GLOBALS[a]`.
+
+6. Let :math:`\val` be the value :math:`\X{glob}.\VALUE`.
+
+7. Push the value :math:`\val` to the stack.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\GETGLOBAL~x) &\stepto& S; F; \val
+   \end{array}
+   \\ \qquad
+     (\mbox{if}~S.\GLOBALS[F.\MODULE.\GLOBALS[x]].\VALUE = \val) \\
+   \end{array}
+
+
+.. _exec-set_global:
+
+:math:`\SETGLOBAL~x`
+....................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-set_global>`, :math:`F.\MODULE.\GLOBALS[x]` exists.
+
+3. Let :math:`a` be the :ref:`global address <syntax-globaladdr>` :math:`F.\MODULE.\GLOBALS[x]`.
+
+4. Assert: due to :ref:`validation <valid-set_global>`, :math:`S.\GLOBALS[a]` exists.
+
+5. Let :math:`\X{glob}` be the :ref:`global instance <syntax-globalinst>` :math:`S.\GLOBALS[a]`.
+
+6. Assert: due to :ref:`validation <valid-set_global>`, a value is on the top of the stack.
+
+7. Pop the value :math:`\val` from the stack.
+
+8. Replace :math:`\X{glob}.\VALUE` with the value :math:`\val`.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; \val~(\SETGLOBAL~x) &\stepto& S'; F; \epsilon
+   \end{array}
+   \\ \qquad
+   (\mbox{if}~S' = S \with \GLOBALS[F.\MODULE.\GLOBALS[x]].\VALUE = \val) \\
+   \end{array}
+
+
+.. _exec-instr-memory:
+.. _exec-memarg:
+.. index:: memory instruction, memory index, store, frame, address, memory address, memory instance, store, frame, value type, width
+   pair: execution; instruction
+   single: abstract syntax; instruction
+
+Memory Instructions
+~~~~~~~~~~~~~~~~~~~
+
+.. _exec-load:
+.. _exec-loadn:
+
+:math:`t\K{.}\LOAD~\memarg` and :math:`t\K{.}\LOAD{N}\K{\_}\sx~\memarg`
+.......................................................................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-loadn>`, :math:`F.\MODULE.\MEMS[0]` exists.
+
+3. Let :math:`a` be the :ref:`memory address <syntax-memaddr>` :math:`F.\MODULE.\MEMS[0]`.
+
+4. Assert: due to :ref:`validation <valid-loadn>`, :math:`S.\MEMS[a]` exists.
+
+5. Let :math:`\X{mem}` be the :ref:`memory instance <syntax-meminst>` :math:`S.\MEMS[a]`.
+
+6. Assert: due to :ref:`validation <valid-loadn>`, a value :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+7. Pop the value :math:`\I32.\CONST~i` from the stack.
+
+8. Let :math:`\X{ea}` be :math:`i + \memarg.\OFFSET`.
+
+9. If :math:`N` is not part of the instruction, then:
+
+   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :ref:`value type <syntax-valtype>` of :math:`t`.
+
+10. If :math:`\X{ea} + N` is larger than the length of :math:`\X{mem}.\DATA`, then:
+
+    a. Trap.
+
+11. Let :math:`b^\ast` be the byte sequence :math:`\X{mem}.\DATA[\X{ea}:N]`.
+
+12. If :math:`N` and :math:`\sx` are part of the instruction, then:
+
+    a. Let :math:`n` be the integer for which :math:`\bytes_N(n) = b^\ast`.
+
+    b. Let :math:`c` be the result of computing :math:`\extend_{\sx,N}(n)`.
+
+13. Else:
+
+    a. Let :math:`c` be the constant for which :math:`\bytes_t(c) = b^\ast`.
+
+14. Push the value :math:`t.\CONST~c` to the stack.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(t.\LOAD~\memarg) &\stepto& S; F; (t.\CONST~c)
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     \wedge & \X{ea} + |t| \leq |S.\MEMS[F.\MODULE.\MEMS[0]].\DATA| \\
+     \wedge & \bytes_t(c) = S.\MEMS[F.\MODULE.\MEMS[0]].\DATA[\X{ea}:|t|])
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(t.\LOAD{N}\K{\_}\sx~\memarg) &\stepto&
+     S; F; (t.\CONST~\extend_{\sx,N}(n))
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     \wedge & \X{ea} + N \leq |S.\MEMS[F.\MODULE.\MEMS[0]].\DATA| \\
+     \wedge & \bytes_N(n) = S.\MEMS[F.\MODULE.\MEMS[0]].\DATA[\X{ea}:N])
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~k)~(t.\LOAD({N}\K{\_}\sx)^?~\memarg) &\stepto& S; F; \TRAP
+   \end{array}
+   \\ \qquad
+     (\mbox{otherwise}) \\
+   \end{array}
+
+.. note::
+   The alignment :math:`\memarg.\ALIGN` does not affect the semantics.
+   Unaligned access is supported for all types, and succeeds regardless of the annotation.
+   The only purpose of the annotation is to provide optimizatons hints.
+
+
+.. _exec-store:
+.. _exec-storen:
+
+:math:`t\K{.}\STORE~\memarg` and :math:`t\K{.}\STORE{N}~\memarg`
+................................................................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-storen>`, :math:`F.\MODULE.\MEMS[0]` exists.
+
+3. Let :math:`a` be the :ref:`memory address <syntax-memaddr>` :math:`F.\MODULE.\MEMS[0]`.
+
+4. Assert: due to :ref:`validation <valid-storen>`, :math:`S.\MEMS[a]` exists.
+
+5. Let :math:`\X{mem}` be the :ref:`memory instance <syntax-meminst>` :math:`S.\MEMS[a]`.
+
+6. Assert: due to :ref:`validation <valid-storen>`, a value :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+7. Pop the value :math:`\I32.\CONST~i` from the stack.
+
+8. Let :math:`\X{ea}` be :math:`i + \memarg.\OFFSET`.
+
+9. If :math:`N` is not part of the instruction, then:
+
+   a. Let :math:`N` be the :ref:`width <syntax-valtype>` :ref:`value type <syntax-valtype>` of :math:`t`.
+
+10. If :math:`\X{ea} + N` is larger than the length of :math:`\X{mem}.\DATA`, then:
+
+    a. Trap.
+
+11. Assert: due to :ref:`validation <valid-storen>`, a value of :ref:`value type <syntax-valtype>` :math:`t` is on the top of the stack.
+
+12. Pop the value :math:`t.\CONST~c` from the stack.
+
+13. If :math:`N` is part of the instruction, then:
+
+    a. Let :math:`n` be the result of computing :math:`\wrap_N(c)`.
+
+    b. Let :math:`b^\ast` be the byte sequence :math:`\bytes_N(n)`.
+
+14. Else:
+
+    a. Let :math:`b^\ast` be the byte sequence :math:`\bytes_t(c)`.
+
+15. Replace the bytes :math:`\X{mem}.\DATA[\X{ea}:N]` with :math:`b^\ast`.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(t.\STORE~\memarg) &\stepto& S'; F; \epsilon
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     \wedge & \X{ea} + |t| \leq |S.\MEMS[F.\MODULE.\MEMS[0]].\DATA| \\
+     \wedge & S' = S \with \MEMS[F.\MODULE.\MEMS[0]].\DATA[\X{ea}:|t|] = \bytes_t(c)
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(t.\STORE{N}~\memarg) &\stepto& S'; F; \epsilon
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     \wedge & \X{ea} + N \leq |S.\MEMS[F.\MODULE.\MEMS[0]].\DATA| \\
+     \wedge & S' = S \with \MEMS[F.\MODULE.\MEMS[0]].\DATA[\X{ea}:N] = \bytes_N(\wrap_N(c))
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~k)~(t.\STORE{N}^?~\memarg) &\stepto& S; F; \TRAP
+   \end{array}
+   \\ \qquad
+     (\mbox{otherwise}) \\
+   \end{array}
+
+
+.. _exec-current_memory:
+
+:math:`\CURRENTMEMORY`
+......................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-current_memory>`, :math:`F.\MODULE.\MEMS[0]` exists.
+
+3. Let :math:`a` be the :ref:`memory address <syntax-memaddr>` :math:`F.\MODULE.\MEMS[0]`.
+
+4. Assert: due to :ref:`validation <valid-current_memory>`, :math:`S.\MEMS[a]` exists.
+
+5. Let :math:`\X{mem}` be the :ref:`memory instance <syntax-meminst>` :math:`S.\MEMS[a]`.
+
+6. Let :math:`\X{sz}` be the length of :math:`\X{mem}.\DATA` divided by the :ref:`page size <page-size>`.
+
+7. Push the value :math:`\I32.\CONST~\X{sz}` to the stack.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; \CURRENTMEMORY &\stepto& S; F; (\I32.\CONST~\X{sz})
+   \end{array}
+   \\ \qquad
+     (\mbox{if}~|S.\MEMS[F.\MODULE.\MEMS[0]].\DATA| = \X{sz}\cdot64\,\F{Ki}) \\
+   \end{array}
+
+
+.. _exec-grow_memory:
+
+:math:`\GROWMEMORY`
+...................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-grow_memory>`, :math:`F.\MODULE.\MEMS[0]` exists.
+
+3. Let :math:`a` be the :ref:`memory address <syntax-memaddr>` :math:`F.\MODULE.\MEMS[0]`.
+
+4. Assert: due to :ref:`validation <valid-grow_memory>`, :math:`S.\MEMS[a]` exists.
+
+5. Let :math:`\X{mem}` be the :ref:`memory instance <syntax-meminst>` :math:`S.\MEMS[a]`.
+
+6. Let :math:`\X{sz}` be the length of :math:`S.\MEMS[a]` divided by the :ref:`page size <page-size>`.
+
+7. Assert: due to :ref:`validation <valid-grow_memory>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+8. Pop the value :math:`\I32.\CONST~n` from the stack.
+
+9. If :math:`\X{mem}.\MAX` is not empty and :math:`\X{sz} + n` is larger than :math:`\X{mem}.\MAX`, then:
+
+  a. Push the value :math:`\I32.\CONST~(-1)` to the stack.
+
+10. Else, either:
+
+    a. Let :math:`\X{len}` be :math:`n` multiplied with the :ref:`page size <page-size>`.
+
+    b. Append :math:`\X{len}` bytes with value :math:`\hex{00}` to :math:`S.\MEMS[a]`.
+
+    c. Push the value :math:`\I32.\CONST~\X{sz}` to the stack.
+
+11. Or:
+
+    a. Push the value :math:`\I32.\CONST~(-1)` to the stack.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~n)~\GROWMEMORY &\stepto& S'; F; (\I32.\CONST~\X{sz})
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & F.\MODULE.\MEMS[0] = a \\
+     \wedge & |S.\MEMS[a].\DATA| = \X{sz}\cdot64\,\F{Ki} \\
+     \wedge & (\X{sz} + n \leq S.\MEMS[a].\MAX \vee S.\MEMS[a].\MAX = \epsilon) \\
+     \wedge & S' = S \with \MEMS[a].\DATA = S.\MEMS[a].\DATA~(\hex{00})^{n\cdot64\,\F{Ki}}) \\
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~n)~\GROWMEMORY &\stepto& S; F; (\I32.\CONST~{-1})
+   \end{array}
+   \end{array}
+
+.. note::
+   The |GROWMEMORY| instruction is non-deterministic.
+   It may either succeed, returning the old memory size :math:`\X{sz}`,
+   or fail, returning :math:`{-1}`.
+   Failure *must* occur if the referenced memory instance has a maximum size defined that would be exceeded.
+   However, failure *can* occur in other cases as well.
+   In practice, the choice depends on the resources available to the :ref:`embedder <embedder>`.
+
+
+.. _exec-instr-control:
+.. _exec-label:
+.. index:: control instructions, structured control, label, block, branch, result type, label index, function index, type index, vector, address, table address, table instance, store, frame
+   pair: execution; instruction
+   single: abstract syntax; instruction
+
+Control Instructions
+~~~~~~~~~~~~~~~~~~~~
+
+.. _exec-nop:
+
+:math:`\NOP`
+............
+
+1. Do nothing.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \NOP &\stepto& \epsilon
+   \end{array}
+
+
+.. _exec-unreachable:
+
+:math:`\UNREACHABLE`
+....................
+
+1. Trap.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \UNREACHABLE &\stepto& \TRAP
+   \end{array}
+
+
+.. _exec-block:
+
+:math:`\BLOCK~[t^?]~\instr^\ast~\END`
+.....................................
+
+1. Let :math:`n` be the arity :math:`|t^?|` of the :ref:`result type <syntax-resulttype>` :math:`t^?`.
+
+2. Let :math:`L` be the label whose arity is :math:`n` and whose continuation is the end of the block.
+
+3. :ref:`Enter <exec-instr-seq-enter>` the instruction sequence :math:`\instr^\ast` with label :math:`L`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \BLOCK~[t^n]~\instr^\ast~\END &\stepto&
+     \LABEL_n\{\epsilon\}~\instr^\ast~\END
+   \end{array}
+
+
+.. _exec-loop:
+
+:math:`\LOOP~[t^?]~\instr^\ast~\END`
+....................................
+
+1. Let :math:`L` be the label whose arity is :math:`0` and whose continuation is the start of the loop.
+
+2. :ref:`Enter <exec-instr-seq-enter>` the instruction sequence :math:`\instr^\ast` with label :math:`L`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \LOOP~[t^?]~\instr^\ast~\END &\stepto&
+     \LABEL_0\{\LOOP~[t^?]~\instr^\ast~\END\}~\instr^\ast~\END
+   \end{array}
+
+
+.. _exec-if:
+
+:math:`\IF~[t^?]~\instr_1^\ast~\ELSE~\instr_2^\ast~\END`
+........................................................
+
+1. Assert: due to :ref:`validation <valid-if>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+2. Pop the value :math:`\I32.\CONST~c` from the stack.
+
+3. Let :math:`n` be the arity :math:`|t^?|` of the :ref:`result type <syntax-resulttype>` :math:`t^?`.
+
+4. Let :math:`L` be the label whose arity is :math:`n` and whose continuation is the end of the |IF| instruction.
+
+5. If :math:`c` is not :math:`0`, then:
+
+   a. :ref:`Enter <exec-instr-seq-enter>` the instruction sequence :math:`\instr_1^\ast` with label :math:`L`.
+
+6. Else:
+
+   a. :ref:`Enter <exec-instr-seq-enter>` the instruction sequence :math:`\instr_2^\ast` with label :math:`L`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (\I32.\CONST~c)~\IF~[t^n]~\instr_1^\ast~\ELSE~\instr_2^\ast~\END &\stepto&
+     \LABEL_n\{\epsilon\}~\instr_1^\ast~\END
+     & (\mbox{if}~c \neq 0) \\
+   (\I32.\CONST~c)~\IF~[t^n]~\instr_1^\ast~\ELSE~\instr_2^\ast~\END &\stepto&
+     \LABEL_n\{\epsilon\}~\instr_2^\ast~\END
+     & (\mbox{if}~c = 0) \\
+   \end{array}
+
+
+.. _exec-br:
+
+:math:`\BR~l`
+.............
+
+1. Assert: due to :ref:`validation <valid-br>`, the stack contains at least :math:`l+1` labels.
+
+2. Let :math:`L` be the :math:`l`-th label appearing on the stack, starting from the top and counting from zero.
+
+3. Let :math:`n` be the arity of :math:`L`.
+
+4. Assert: due to :ref:`validation <valid-br>`, there are at least :math:`n` values on the top of the stack.
+
+5. Pop the values :math:`\val^n` from the stack.
+
+6. Repeat :math:`l+1` times:
+
+   a. While the top of the stack is a value, do:
+
+      i. Pop the value from the stack.
+
+   b. Assert: due to :ref:`validation <valid-br>`, the top of the stack now is a label.
+
+   c. Pop the label from the stack.
+
+7. Push the values :math:`\val^n` to the stack.
+
+8. Jump to the continuation of :math:`L`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \LABEL_n\{\instr^\ast\}~\XB^l[\val^n~(\BR~l)]~\END &\stepto& \val^n~\instr^\ast
+   \end{array}
+
+
+.. _exec-br_if:
+
+:math:`\BRIF~l`
+...............
+
+1. Assert: due to :ref:`validation <valid-br_if>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+2. Pop the value :math:`\I32.\CONST~c` from the stack.
+
+3. If :math:`c` is not :math:`0`, then:
+
+   a. :ref:`Execute <exec-br>` the instruction :math:`(\BR~l)`.
+
+4. Else:
+
+   a. Do nothing.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (\I32.\CONST~c)~(\BRIF~l) &\stepto& (\BR~l)
+     & (\mbox{if}~c \neq 0) \\
+   (\I32.\CONST~c)~(\BRIF~l) &\stepto& \epsilon
+     & (\mbox{if}~c = 0) \\
+   \end{array}
+
+
+.. _exec-br_table:
+
+:math:`\BRTABLE~l^\ast~l_N`
+...........................
+
+1. Assert: due to :ref:`validation <valid-if>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+2. Pop the value :math:`\I32.\CONST~i` from the stack.
+
+3. If :math:`i` is smaller than the length of :math:`l^\ast`, then:
+
+   a. Let :math:`l_i` be the label :math:`l^\ast[i]`.
+
+   b. :ref:`Execute <exec-br>` the instruction :math:`(\BR~l_i)`.
+
+4. Else:
+
+   a. :ref:`Execute <exec-br>` the instruction :math:`(\BR~l_N)`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   (\I32.\CONST~i)~(\BRTABLE~l^\ast~l_N) &\stepto& (\BR~l_i)
+     & (\mbox{if}~l^\ast[i] = l_i) \\
+   (\I32.\CONST~i)~(\BRTABLE~l^\ast~l_N) &\stepto& (\BR~l_N)
+     & (\mbox{if}~|l^\ast| \leq i) \\
+   \end{array}
+
+
+.. _exec-return:
+
+:math:`\RETURN`
+...............
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Let :math:`n` be the arity of :math:`F`.
+
+3. Assert: due to :ref:`validation <valid-br>`, there are at least :math:`n` values on the top of the stack.
+
+4. Pop the results :math:`\val^n` from the stack.
+
+5. Assert: due to :ref:`validation <valid-return>`, the stack contains at least one :ref:`frame <syntax-frame>`.
+
+6. While the top of the stack is not a frame, do:
+
+   a. Pop the top element from the stack.
+
+7. Assert: the top of the stack is the frame :math:`F`.
+
+8. Pop the frame from the stack.
+
+9. Push :math:`\val^n` to the stack.
+
+10. Jump to the instruction after the original call.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \FRAME_n\{F\}~\XB^k[\val^n~\RETURN]~\END &\stepto& \val^n
+   \end{array}
+
+
+.. _exec-call:
+
+:math:`\CALL~x`
+...............
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-call>`, :math:`F.\MODULE.\FUNCS[x]` exists.
+
+3. Let :math:`a` be the :ref:`function address <syntax-funcaddr>` :math:`F.\MODULE.\FUNCS[x]`.
+
+4. :ref:`Invoke <exec-invoke>` the function instance at address :math:`a`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   F; (\CALL~x) &\stepto& F; (\INVOKE~a)
+     & (\mbox{if}~F.\MODULE.\FUNCS[x] = a)
+   \end{array}
+
+
+.. _exec-call_indirect:
+
+:math:`\CALLINDIRECT~x`
+.......................
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\MODULE.\TABLES[0]` exists.
+
+3. Let :math:`a` be the :ref:`table address <syntax-tableaddr>` :math:`F.\MODULE.\TABLES[0]`.
+
+4. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\TABLES[a]` exists.
+
+5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\TABLES[a]`.
+
+6. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`F.\MODULE.\TYPES[x]` exists.
+
+7. Let :math:`\X{ft}_{\F{expect}}` be the :ref:`function type <syntax-functype>` :math:`F.\MODULE.\TYPES[x]`.
+
+8. Assert: due to :ref:`validation <valid-call_indirect>`, a value with :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
+
+9. Pop the value :math:`\I32.\CONST~i` from the stack.
+
+10. If :math:`i` is not smaller than the length of :math:`\X{tab}.\ELEM`, then:
+
+    a. Trap.
+
+11. If :math:`\X{tab}.\ELEM[i]` is uninitialized, then:
+
+    a. Trap.
+
+12. Let :math:`a` be the :ref:`function address <syntax-funcaddr>` :math:`\X{tab}.\ELEM[i]`.
+
+13. Assert: due to :ref:`validation <valid-call_indirect>`, :math:`S.\FUNCS[a]` exists.
+
+14. Let :math:`\X{f}` be the :ref:`function instance <syntax-funcinst>` :math:`S.\FUNCS[a]`.
+
+15. Assert: due to :ref:`validation <valid-func>`, :math:`\X{func}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]` exists.
+
+16. Let :math:`\X{ft}_{\F{actual}}` be the :ref:`function type <syntax-functype>` :math:`\X{func}.\MODULE.\TYPES[\X{f}.\CODE.\TYPE]`.
+
+15. If :math:`\X{ft}_{\F{actual}}` and :math:`\X{ft}_{\F{expect}}` differ, then:
+
+    a. Trap.
+
+17. :ref:`Invoke <exec-invoke>` the function instance at address :math:`a`.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(\CALLINDIRECT~x) &\stepto& S; F; (\INVOKE~a)
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & S.\TABLES[F.\MODULE.\TABLES[0]].\ELEM[i] = a \\
+     \wedge & F.\MODULE.\TYPES[x] = f.\MODULE.\TYPES[S.\FUNCS[a].\CODE.\TYPE])
+     \end{array} \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F; (\I32.\CONST~i)~(\CALLINDIRECT~x) &\stepto& S; F; \TRAP
+   \end{array}
+   \\ \qquad
+     (\mbox{otherwise})
+   \end{array}
+
+
+.. _exec-instr-seq:
+.. index:: instruction, instruction sequence
+
+Instruction Sequences
+~~~~~~~~~~~~~~~~~~~~~
+
+.. _exec-instr-seq-enter:
+
+Entering :math:`\instr^\ast` with label :math:`L`
+.................................................
+
+1. Push :math:`L` to the stack.
+
+2. :ref:`Jump <exec-jump>` to the start of the instruction sequence :math:`\instr^\ast`.
+
+.. note::
+   No formal reduction rule is needed for entering an instruction sequence,
+   because the label :math:`L` is embedded in the :ref:`administrative instruction <syntax-instr-admin>` that is reduced to directly.
+
+
+.. _exec-instr-seq-exit:
+
+Exiting :math:`\instr^\ast` with label :math:`L`
+................................................
+
+When the end of a labelled instruction sequence is reached without a jump or trap aborting it, then the following steps are performed.
+
+1. Let :math:`n` be the arity of :math:`L`.
+
+2. Assert: due to :ref:`validation <valid-instr-seq>`, there are :math:`n` values on the top of the stack.
+
+3. Pop the results :math:`\val^n` from the stack.
+
+4. Assert: due to :ref:`validation <valid-instr-seq>`, the label :math:`L` is now on the top of the stack.
+
+5. Pop the label from the stack.
+
+6. Push :math:`\val^n` back to the stack.
+
+7. Jump to the position after the |END| of the :ref:`structured control instruction <syntax-instr-control>` associated with the label :math:`L`.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \LABEL_n\{\instr^\ast\}~\val^n~\END &\stepto& \val^n
+   \end{array}
+
+.. note::
+   This semantics also applies to the instruction sequence contained in a |LOOP| instruction.
+   Therefor, execution of a loop falls off the end if no backwards branch is performed explicitly.
+
+
+.. index:: ! invocation, function, function instance, label, frame
+
+Function Calls
+~~~~~~~~~~~~~~
+
+.. _exec-invoke:
+
+Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
+.................................................................
+
+1. Assert: due to :ref:`validation <valid-call>`, :math:`S.\FUNCS[a]` exists.
+
+2. Let :math:`f` be the :ref:`function instance <sytnax-funcinst>`, :math:`S.\FUNCS[a]`.
+
+3. Assert: due to :ref:`validation <valid-func>`, :math:`f.\MODULE.\TYPES[f.\CODE.\TYPE]` exists.
+
+4. Let :math:`[t_1^n] \to [t_2^m]` be the :ref:`function type <syntax-functype>` :math:`f.\MODULE.\TYPES[f.\CODE.\TYPE]`.
+
+5. Let :math:`t^n` be the list of :ref:`value types <syntax-valtype>` :math:`f.\CODE.\LOCALS`.
+
+6. Let :math:`\instr^\ast~\END` be the :ref:`expression <syntax-expr>` :math:`f.\CODE.\BODY`.
+
+7. Assert: due to :ref:`validation <valid-call>`, :math:`n` values are on the top of the stack.
+
+8. Pop the values :math:`\val^n` from the stack.
+
+9. Let :math:`\val_0^\ast` be the list of zero values of types :math:`t^\ast`.
+
+10. Let :math:`F` be the :ref:`frame <syntax-frame>` :math:`\{ \MODULE~f.\MODULE, \LOCALS~\val^n~\val_0^\ast \}`.
+
+11. Push :math:`F` to the stack.
+
+12. :ref:`Execute <exec-block>` the instruction :math:`\BLOCK~[t_2^m]~\instr^\ast~\END`.
+
+.. math::
+   \begin{array}{l}
+   \begin{array}{lcl@{\qquad}l}
+   \val^n~(\INVOKE~a) &\stepto& \FRAME_n\{F\}~\BLOCK~[t_2^m]~\instr^\ast~\END~\END
+   \end{array}
+   \\ \qquad
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\mbox{if} & S.\FUNCS[a].\CODE = \{ \TYPE~x, \LOCALS~t^\ast, \BODY~\instr^\ast~\END \} \\
+     \wedge & S.\FUNCS[a].\MODULE.\TYPES[x] = [t_1^n] \to [t_2^m] \\
+     \wedge & F = \{ \MODULE~f.\MODULE, ~\LOCALS~\val^n~(t.\CONST~0)^\ast \})
+     \end{array} \\
+   \end{array}
+
+
+.. _exec-invoke-exit:
+
+Returning from a function
+.........................
+
+When the end of a funtion is reached without a jump (|RETURN|) or trap aborting it, then the following steps are performed.
+
+1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
+
+2. Let :math:`n` be the arity of :math:`F`.
+
+3. Assert: due to :ref:`validation <valid-instr-seq>`, there are :math:`n` values on the top of the stack.
+
+4. Pop the results :math:`\val^n` from the stack.
+
+5. Assert: due to :ref:`validation <valid-func>`, the frame :math:`F` is now on the top of the stack.
+
+6. Pop the frame from the stack.
+
+7. Push :math:`\val^n` back to the stack.
+
+8. Jump to the instruction after the original call.
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   \FRAME_n\{F\}~\val^n~\END &\stepto& \val^n
+   \end{array}
+
+
+.. _exec-expr:
+.. index:: expression
+   pair: execution; expression
+   single: abstract syntax; expression
+   single: expression; constant
+
+Expressions
+~~~~~~~~~~~
+
+:math:`\instr^\ast~\END`
+........................
+
+.. todo::
+   Define
+
+.. math::
+   \frac{
+     S; F; \instr^\ast \stepto^\ast S; F; v
+   }{
+     S; F; \instr^\ast~\END \stepto^\ast S; F; v
+   }

--- a/document/execution/modules.rst
+++ b/document/execution/modules.rst
@@ -1,0 +1,5 @@
+Modules
+-------
+
+.. todo::
+   Work in progress

--- a/document/execution/numerics.rst
+++ b/document/execution/numerics.rst
@@ -1,0 +1,52 @@
+.. _exec-numeric:
+
+Numerics
+--------
+
+.. todo::
+   Describe
+
+
+.. _aux-bytes:
+.. _aux-signed:
+.. _aux-extend:
+.. _aux-wrap:
+
+Auxiliary Operations
+~~~~~~~~~~~~~~~~~~~~
+
+.. math::
+   \begin{array}{lll@{\qquad}l}
+   \bytes_N(i) &=& \epsilon & (N = 0 \wedge i = 0) \\
+   \bytes_N(i) &=& b~\bytes_{N-8}(j) & (N \geq 8 \wedge i = 8\cdot j + b) \\
+   ~ \\
+   \bytes_{\K{i}N}(i) &=& \bytes_N(i) \\
+   \bytes_{\K{f}N}(b^N) &=& \F{reverse}(b^N) \\
+   \end{array}
+   
+.. math::
+   \begin{array}{lll@{\qquad}l}
+   \signed_N(i) &=& i & (0 \leq i < 2^{N-1}) \\
+   \signed_N(i) &=& i - 2^N & (2^{N-1} \leq i < 2^N) \\
+   \signed_N(-i) &=& -i & (0 < i \geq 2^{N-1}) \\
+   ~ \\
+   \extend_{\B{U},N}(i) &=& i \\
+   \extend_{\B{S},N}(i) &=& \signed_N(i) \\
+   \wrap_N(i) &=& i \mod 2^N \\
+   \end{array}
+
+.. Note::
+   The index :math:`N` of the |extend| function is the size extending *from*,
+   where as the index of the |wrap| function is the size wrapping *to*.
+
+
+Integer Operations
+~~~~~~~~~~~~~~~~~~
+
+
+Floating-Point Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Conversions
+~~~~~~~~~~~

--- a/document/execution/numerics.rst
+++ b/document/execution/numerics.rst
@@ -18,7 +18,7 @@ Auxiliary Operations
 .. math::
    \begin{array}{lll@{\qquad}l}
    \bytes_N(i) &=& \epsilon & (N = 0 \wedge i = 0) \\
-   \bytes_N(i) &=& b~\bytes_{N-8}(j) & (N \geq 8 \wedge i = 8\cdot j + b) \\
+   \bytes_N(i) &=& b~\bytes_{N-8}(j) & (N \geq 8 \wedge i = 2^8\cdot j + b) \\
    ~ \\
    \bytes_{\K{i}N}(i) &=& \bytes_N(i) \\
    \bytes_{\K{f}N}(b^N) &=& \F{reverse}(b^N) \\

--- a/document/execution/numerics.rst
+++ b/document/execution/numerics.rst
@@ -23,7 +23,9 @@ Auxiliary Operations
    \bytes_{\K{i}N}(i) &=& \bytes_N(i) \\
    \bytes_{\K{f}N}(b^N) &=& \F{reverse}(b^N) \\
    \end{array}
-   
+
+Note that |bytes| is a bijection, hence the function is invertible.
+
 .. math::
    \begin{array}{lll@{\qquad}l}
    \signed_N(i) &=& i & (0 \leq i < 2^{N-1}) \\

--- a/document/execution/runtime.rst
+++ b/document/execution/runtime.rst
@@ -1,0 +1,518 @@
+.. index:: ! runtime
+
+Runtime Structure
+-----------------
+
+
+.. _syntax-val:
+.. index:: ! value, constant
+   pair: abstract syntax; value
+
+Values
+~~~~~~
+
+WebAssembly computations manipulate *values* of the four basic :ref:`value types <syntax-valtype>`: :ref:`uninterpreted integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each, respectively.
+
+In most places of the semantics, values of different types can occur.
+In order to avoid ambiguities, values are therefor represented with an abstract syntax that makes their type explicit.
+It is convenient to reuse the same notation as for the |CONST| :ref:`instructions <syntax-const>` producing them:
+
+.. math::
+   \begin{array}{llll}
+   \production{(value)} & \val &::=&
+     \I32.\CONST~\i32 ~|~
+     \I64.\CONST~\i64 ~|~
+     \F32.\CONST~\f32 ~|~
+     \F64.\CONST~\f64
+   \end{array}
+
+
+.. _store:
+.. _syntax-store:
+.. index:: ! store, function instance, table instance, memory instance, global instance, module
+   pair: abstract syntax; store
+
+Store
+~~~~~
+
+The *store* represents all *mutable* global state that can be manipulated by WebAssembly programs.
+It consists of the runtime representation of all *instances* of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tableinst>`, :ref:`memories <syntax-meminst>`, and :ref:`globals <syntax-globalinst>` that have been *allocated* during the life time of the abstract machine. [#gc]_
+
+Syntactically, the store is defined as a :ref:`record <syntax-record>` listing the existing instances of each category:
+
+.. math::
+   \begin{array}{llll}
+   \production{(store)} & \store &::=& \{~
+     \begin{array}[t]{l@{~}ll}
+     \FUNCS & \funcinst^\ast, \\
+     \TABLES & \tableinst^\ast, \\
+     \MEMS & \meminst^\ast, \\
+     \GLOBALS & \globalinst^\ast ~\} \\
+     \end{array}
+   \end{array}
+
+.. [#gc]
+   In practice, implementations may apply techniques like garbage collection to remove objects from the store that are no longer referenced.
+   However, such techniques are not semantically observable,
+   and hence outside the scope of this specification.
+
+
+Convention
+..........
+
+* The meta variable :math:`S` ranges over stores where clear from context.
+
+
+.. _syntax-addr:
+.. _syntax-funcaddr:
+.. _syntax-tableaddr:
+.. _syntax-memaddr:
+.. _syntax-globaladdr:
+.. index:: ! address, store, function instance, table instance, memory instance, global instance
+   pair: abstract syntax; function address
+   pair: abstract syntax; table address
+   pair: abstract syntax; memory address
+   pair: abstract syntax; global address
+   pair: function; address
+   pair: table; address
+   pair: memory; address
+   pair: global; address
+
+Addresses
+~~~~~~~~~
+
+:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, and :ref:`global instances <syntax-globalinst>` in the :ref:`store <syntax-store>` are referenced with abstract *addresses*.
+These are simply indices into the respective store component.
+
+.. math::
+   \begin{array}{llll}
+   \production{(address)} & \addr &::=&
+     0 ~|~ 1 ~|~ 2 ~|~ \dots \\
+   \production{(function address)} & \funcaddr &::=&
+     \addr \\
+   \production{(table address)} & \tableaddr &::=&
+     \addr \\
+   \production{(memory address)} & \memaddr &::=&
+     \addr \\
+   \production{(global address)} & \globaladdr &::=&
+     \addr \\
+   \end{array}
+
+.. note::
+   There is no specific limit on the number of allocations of store objects,
+   hence logical addresses can be arbitrarily large natural numbers.
+
+   A *memory address* |memaddr| denotes the abstract address *of* a memory *instance* in the store,
+   not an offset *inside* a memory instance.
+
+
+.. _syntax-moduleinst:
+.. index:: ! instance, function type, function instance, table instance, memory instance, global instance, export instance, table address, memory address, global address, index
+   pair: abstract syntax; module instance
+   pair: module; instance
+
+Module Instances
+~~~~~~~~~~~~~~~~
+
+A *module instance* is the runtime representation of a :ref:`module <syntax-module>`.
+It is created by :ref:`instantiating <instantiation>` a module,
+and collects runtime representations of all entities that are imported, defined, or exported by the module.
+
+.. math::
+   \begin{array}{llll}
+   \production{(module instance)} & \moduleinst &::=& \{
+     \begin{array}[t]{l@{~}ll}
+     \TYPES & \functype^\ast, \\
+     \FUNCS & \funcaddr^\ast, \\
+     \TABLES & \tableaddr^\ast, \\
+     \MEMS & \memaddr^\ast, \\
+     \GLOBALS & \globaladdr^\ast \\
+     \EXPORTS & \exportinst^\ast ~\} \\
+     \end{array}
+   \end{array}
+
+Each component contains runtime instances corresponding to respective entities from the original module -- whether imported or defined -- in the order of their static :ref:`indices <syntax-index>`.
+:ref:`Function instances <syntax-funcinst>`, :ref:`table instances <syntax-tableinst>`, :ref:`memory instances <syntax-meminst>`, and :ref:`global instances <syntax-globalinst>` are referenced with an indirection through their respective :ref:`addresses <syntax-addr>` in the :ref:`store <syntax-store>`.
+
+It is an invariant of the semantics that all :ref:`export instances <syntax-exportinst>` in a given module instance have different :ref:`names <syntax-name>`.
+
+
+.. _syntax-funcinst:
+.. index:: ! function instance, module instance, function, closure
+   pair: abstract syntax; function instance
+   pair: function; instance
+
+Function Instances
+~~~~~~~~~~~~~~~~~~
+
+A *function instance* is the runtime representation of a :ref:`function <syntax-func>`.
+It is effectively a *closure* of the original function over the runtime :ref:`module instance <syntax-moduleinst>` of its own :ref:`module <syntax-module>`.
+The module instance is used to resolve references to other non-local definitions during execution of the function.
+
+.. math::
+   \begin{array}{llll}
+   \production{(function instance)} & \funcinst &::=&
+     \{ \MODULE~\moduleinst, \CODE~\func \} \\
+   \end{array}
+
+Function instances are immutable, and their identity is not observable by WebAssembly code.
+However, the :ref:`embedder <embedder>` might provide implicit or explicit means for distinguishing them.
+
+.. todo:: Host functions?
+
+
+.. _syntax-tableinst:
+.. _syntax-funcelem:
+.. index:: ! table instance, table, function address
+   pair: abstract syntax; table instance
+   pair: table; instance
+
+Table Instances
+~~~~~~~~~~~~~~~
+
+A *table instance* is the runtime representation of a :ref:`table <syntax-table>`.
+It holds a vector of *function elements* and an optional maximum size, if one was specified at the definition site of the table.
+
+Each function element is either empty, representing an uninitialized table entry, or a :ref:`function address <syntax-funcaddr>`.
+Function elements can be mutated through the execution of an :ref:`element segment <syntax-elem>` or by external means provided by the :ref:`embedder <embedder>`.
+
+.. math::
+   \begin{array}{llll}
+   \production{(table instance)} & \tableinst &::=&
+     \{ \ELEM~\vec(\funcelem), \MAX~\u32^? \} \\
+   \production{(function element)} & \funcelem &::=&
+     \funcaddr^? \\
+   \end{array}
+
+It is an invariant of the semantics that the length of the element vector never exceeds the maximum size, if present.
+
+.. note::
+   Other table elements may be added in future versions of WebAssembly.
+
+
+.. _syntax-meminst:
+.. _page-size:
+.. index:: ! memory instance, memory, byte, ! page size, memory type
+   pair: abstract syntax; memory instance
+   pair: memory; instance
+
+Memory Instances
+~~~~~~~~~~~~~~~~
+
+A *memory instance* is the runtime representation of a linear :ref:`memory <syntax-mem>`.
+It holds a vector of bytes and an optional maximum size, if one was specified at the definition site of the memory.
+
+The length of the vector always is a multiple of the WebAssembly *page size*, which is defined to be the constant :math:`65536` -- abbreviated :math:`64\,\F{Ki}`.
+Like in a :ref:`memory type <syntax-memtype>`, the maximum size in a memory instance is given in units of this page size.
+
+The bytes can be mutated through :ref:`memory instructions <syntax-instr-memory>`, the execution of a :ref:`data segment <syntax-data>`, or by external means provided by the :ref:`embedder <embedder>`.
+
+.. math::
+   \begin{array}{llll}
+   \production{(memory instance)} & \meminst &::=&
+     \{ \DATA~\vec(\byte), \MAX~\u32^? \} \\
+   \end{array}
+
+It is an invariant of the semantics that the length of the byte vector, divided by page size, never exceeds the maximum size, if present.
+
+
+.. _syntax-globalinst:
+.. index:: ! global instance, value
+   pair: abstract syntax; global instance
+   pair: global; instance
+
+Global Instances
+~~~~~~~~~~~~~~~~
+
+A *global instance* is the runtime representation of a :ref:`global <syntax-global>` variable.
+It holds an individual :ref:`value <syntax-val>` and a flag indicating whether it is mutable.
+
+The value of mutable globals can be mutated through specific instructions or by external means provided by the :ref:`embedder <embedder>`.
+
+.. math::
+   \begin{array}{llll}
+   \production{(global instance)} & \globalinst &::=&
+     \{ \VALUE~\val, \MUT~\mut \} \\
+   \end{array}
+
+
+.. _syntax-exportinst:
+.. index:: ! export instance, name, external value
+   pair: abstract syntax; export instance
+   pair: export; instance
+
+Export Instances
+~~~~~~~~~~~~~~~~
+
+An *export instance* is the runtime representation of an :ref:`export <syntax-export>`.
+It defines the export's :ref:`name <syntax-name>` and the :ref:`external value <syntax-externval>` being exported.
+
+.. math::
+   \begin{array}{llll}
+   \production{(export instance)} & \exportinst &::=&
+     \{ \NAME~\name, \VALUE~\externval \} \\
+   \end{array}
+
+
+.. _syntax-externval:
+.. index:: ! external value, function address, table address, memory address, global address
+   pair: abstract syntax; external value
+   pair: external; value
+
+External Values
+~~~~~~~~~~~~~~~
+
+An *external value* is the runtime representation of an entity that can be imported or exported.
+It is an :ref:`address <syntax-addr>` denoting either a :ref:`function instance <syntax-funcinst>`, :ref:`table instance <syntax-tableinst>`, :ref:`memory instance <syntax-meminst>`, or :ref:`global instances <syntax-globalinst>` in the shared :ref:`store <syntax-store>`.
+
+.. math::
+   \begin{array}{llll}
+   \production{(external value)} & \externval &::=&
+     \FUNC~\funcaddr ~|~
+     \TABLE~\tableaddr ~|~
+     \MEM~\memaddr ~|~
+     \GLOBAL~\globaladdr \\
+   \end{array}
+
+
+Conventions
+...........
+
+The following auxiliary notation is defined for sequences of external values.
+It filters out entries of a specific kind in an order-preserving fashion:
+
+.. math::
+   \begin{array}{lcl}
+   \funcs(\externval^\ast) &=& [\funcaddr ~|~ (\FUNC~\funcaddr) \in \externval^\ast] \\
+   \tables(\externval^\ast) &=& [\tableaddr ~|~ (\TABLE~\tableaddr) \in \externval^\ast] \\
+   \mems(\externval^\ast) &=& [\memaddr ~|~ (\MEM~\memaddr) \in \externval^\ast] \\
+   \globals(\externval^\ast) &=& [\globaladdr ~|~ (\GLOBAL~\globaladdr) \in \externval^\ast] \\
+   \end{array}
+
+
+.. _syntax-externtype:
+.. index:: ! external type, function type, table type, memory type, global type
+   pair: abstract syntax; external type
+   pair: external; type
+
+External Types
+~~~~~~~~~~~~~~
+
+*External types* classify :ref:`external values <syntax-externval>`, and thereby imports and exports, with their respective types.
+
+.. math::
+   \begin{array}{llll}
+   \production{external types} & \externtype &::=&
+     \FUNC~\functype ~|~
+     \TABLE~\tabletype ~|~
+     \MEM~\memtype ~|~
+     \GLOBAL~\globaltype \\
+   \end{array}
+
+
+Conventions
+...........
+
+The following auxiliary notation is defined for sequences of external types.
+It filters out entries of a specific kind in an order-preserving fashion:
+
+.. math::
+   \begin{array}{lcl}
+   \funcs(\externtype^\ast) &=& [\functype ~|~ (\FUNC~\functype) \in \externtype^\ast] \\
+   \tables(\externtype^\ast) &=& [\tabletype ~|~ (\TABLE~\tabletype) \in \externtype^\ast] \\
+   \mems(\externtype^\ast) &=& [\memtype ~|~ (\MEM~\memtype) \in \externtype^\ast] \\
+   \globals(\externtype^\ast) &=& [\globaltype ~|~ (\GLOBAL~\globaltype) \in \externtype^\ast] \\
+   \end{array}
+
+
+.. _stack:
+.. _frame:
+.. _label:
+.. _syntax-frame:
+.. _syntax-label:
+.. index:: ! stack, ! frame, ! label
+   pair: abstract syntax; frame
+   pair: abstract syntax; label
+
+Stack
+~~~~~
+
+Besides the :ref:`store <store>`, most :ref:`instructions <syntax-instr>` interact with an implicit *stack*.
+The stack contains three kinds of entries:
+
+* *Values*: the *operands* (arguments and results) of instructions.
+
+* *Labels*: an active (entered) :ref:`structured control instruction <syntax-instr-control>` that can be targeted by branches.
+
+* *Locals*: the *call frame* of an active :ref:`function <syntax-func>` call.
+
+These entries can occur on the stack in any order during the execution of a program.
+Stack entries are described by abstract syntax as follows.
+
+.. note::
+   It is possible to model the WebAssebmly semantics using separate stacks for operands, control constructs, and calls.
+   However, because the stacks are interdependent, additional book keeping about associated stack heights would be required.
+   For the purpose of this specification, an interleaved representation is simpler.
+
+
+Values
+......
+
+Values are represented by :ref:`themselves <syntax-val>`.
+
+Labels
+......
+
+Labels carry an argument arity :math:`n` and their associated branch *target*, which is expressed syntactically as an :ref:`instruction <syntax-instr>` sequence:
+
+.. math::
+   \begin{array}{llll}
+   \production{(label)} & \label &::=&
+     \LABEL_n\{\instr^\ast\} \\
+   \end{array}
+
+Intuitively, :math:`\instr^\ast` is the *continuation* to execute when the branch is taken, "replacing" the original control construct.
+
+.. note::
+   For example, a loop label has the form
+
+   .. math::
+      \LABEL_n\{\LOOP~[t^?]~\dots~\END\}
+
+   When performing a branch to this label, this restarts the loop from the  beginning.
+   Conversely, a simple block label has the form
+
+   .. math::
+      \LABEL_n\{\epsilon\}
+
+   When branching, the empty continuation ends the targeted block and proceeds with consecutive instructions.
+
+Frames
+......
+
+Frames carry the return arity of the respective function,
+hold the values of its locals (including arguments) in the order corresponding to their static :ref:`local indices <syntax-localidx>`,
+and a reference to the function's own :ref:`module instance <syntax-moduleinst>`:
+
+.. math::
+   \begin{array}{llll}
+   \production{(activation)} & \X{activation} &::=&
+     \FRAME_n\{\frame\} \\
+   \production{(frame)} & \frame &::=&
+     \{ \LOCALS~\val^\ast, \MODULE~\moduleinst\} \\
+   \end{array}
+
+The values of the locals are mutated by respective :ref:`variable instructions <syntax-instr-var>`.
+
+.. note::
+   In the current version of WebAssembly, the arities of labels and activations cannot be larger than :math:`1`.
+   This may be generalized in future versions.
+
+
+Conventions
+...........
+
+* The meta variable :math:`L` ranges over labels where clear from context.
+
+* The meta variable :math:`F` ranges over frames where clear from context.
+
+
+.. _syntax-instr-admin:
+.. _syntax-ctxt-eval:
+.. _syntax-ctxt-label:
+.. index:: ! administrative instructions, ! block context, ! evaluation context, function, function instance, function address, label, frame, instruction, trap
+   pair:: abstract syntax; administrative instruction
+
+Administrative Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+   This section is only relevant for the :ref:`formal notation <exec-notation>`.
+
+In order to express the reduction of :ref:`traps <trap>` and :ref:`control instructions <syntax-instr-control>`, the syntax of instructions is extended to include the following *administrative instructions*:
+
+.. math::
+   \begin{array}{llll}
+   \production{(administrative instruction)} & \instr &::=&
+     \dots ~|~ \\&&&
+     \TRAP ~|~ \\&&&
+     \INVOKE~\funcaddr ~|~ \\&&&
+     \LABEL_n\{\instr^\ast\}~\instr^\ast~\END ~|~ \\&&&
+     \FRAME_n\{\frame\}~\instr^\ast~\END ~|~ \\
+   \end{array}
+
+The |TRAP| instruction represents the occurrence of a trap.
+Traps are bubbled up through nested instruction sequences, ultimately reducing the entire program to a single |TRAP| instruction.
+
+The |INVOKE| instruction represents the imminent invocation of a :ref:`function instance <syntax-funcinst>`, identified by its :ref:`address <syntax-funcaddr>`.
+It unifies the handling of different forms of calls.
+
+The |LABEL| and |FRAME| instructions model :ref:`labels <syntax-label>` and :ref:`frames <syntax-frame>` :ref:`"on the stack" <exec-notation>`.
+The administrative syntax maintains the nesting structure of the original :ref:`structured control instruction <syntax-instr-control>` or :ref:`function body <syntax-func>` and their :ref:`instruction sequences <syntax-instr-seq>`.
+That way, the end of the inner instruction sequence is tracked when part of an outer sequence.
+
+.. note::
+   For example, the :ref:`reduction rule <exec-block>` for |BLOCK| is:
+
+   .. math::
+      \BLOCK~[t^n]~\instr^\ast~\END \quad\stepto\quad
+      \LABEL_n\{\epsilon\}~\instr^\ast~\END
+
+   This replaces the block with a label instruction,
+   which can be interpreted as "pushing" the label on the stack.
+   When |END| is reached, i.e., the inner instruction sequence has been reduced to the empty sequence -- or a sequence of |CONST| instructions, the representation of non-empty local operand stack -- then the |LABEL| instruction is eliminated courtesy of its own :ref:`reduction rule <exec-label>`:
+
+   .. math::
+      \LABEL_n\{\instr^\ast\}~\val^\ast~\END \quad\stepto\quad \val^\ast
+
+   This can be interpreted as removing the label from the stack and only leaving the locally accumulated operand values.
+
+.. commented out
+   Both rules can be seen in concert in the following example:
+
+   .. math::
+      \begin{array}{@{}ll}
+      & (\F32.\CONST~1)~\BLOCK~[]~(\F32.\CONST~2)~\F32.\NEG~\END~\F32.\ADD \\
+      \stepto & (\F32.\CONST~1)~\LABEL_0\{\}~(\F32.\CONST~2)~\F32.\NEG~\END~\F32.\ADD \\
+      \stepto & (\F32.\CONST~1)~\LABEL_0\{\}~(\F32.\CONST~{-}2)~\END~\F32.\ADD \\
+      \stepto & (\F32.\CONST~1)~(\F32.\CONST~{-}2)~\F32.\ADD \\
+      \stepto & (\F32.\CONST~{-}1) \\
+      \end{array}
+
+To express :ref:`branches <syntax-instr-control>`, the following syntax of *block contexts* is defined, indexed by the count :math:`k` of labels surrounding the hole:
+
+.. math::
+   \begin{array}{llll}
+   \production{(label contexts)} & \XB^0 &::=&
+     \val^\ast~[\_]~\instr^\ast \\
+   \production{(label contexts)} & \XB^{k+1} &::=&
+     \val^\ast~\LABEL_n\{\instr^\ast\}~\XB^k~\END~\instr^\ast \\
+   \end{array}
+
+.. note::
+   Given this definition, the :ref:`reduction <exec-br>` of a simple branch can be defined as follows:
+
+   .. math::
+      \LABEL_0\{\instr^\ast\}~\XB^l[\BR~l]~\END \quad\stepto\quad \instr^\ast
+
+   When a branch occurs in a block context,
+   this rule replaces the targeted label and associated instruction sequence with the label's continuation.
+
+Finally, the following definition of *evaluation context* and associated structural rules enable reduction inside instruction sequences and administrative forms and the propagation of traps:
+
+.. math::
+   \begin{array}{llll}
+   \production{(evaluation contexts)} & E &::=&
+     [\_] ~|~
+     \val^\ast~E~\instr^\ast ~|~
+     \LABEL_n\{\instr^\ast\}~E~\END ~|~
+     \FRAME_n\{\frame\}~E~\END \\
+   \end{array}
+
+.. math::
+   \begin{array}{lcl@{\qquad}l}
+   S; F; E[\instr^\ast] &\stepto& S'; F'; E[{\instr'}^\ast]
+     & (\mbox{if}~S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
+   S; F; E[\TRAP] &\stepto& S; F; \TRAP
+     & (\mbox{if}~E \neq [\_]) \\
+   \end{array}

--- a/document/execution/runtime.rst
+++ b/document/execution/runtime.rst
@@ -100,6 +100,10 @@ These are simply indices into the respective store component.
    \end{array}
 
 .. note::
+   Addresses are *dynamic*, globally unique references to runtime objects,
+   in contrast to :ref:`indices <syntax-index>`,
+   which are *static*, module-local references to their original definitions.
+
    There is no specific limit on the number of allocations of store objects,
    hence logical addresses can be arbitrarily large natural numbers.
 

--- a/document/execution/runtime.rst
+++ b/document/execution/runtime.rst
@@ -15,7 +15,7 @@ Values
 WebAssembly computations manipulate *values* of the four basic :ref:`value types <syntax-valtype>`: :ref:`integers <syntax-int>` and :ref:`floating-point data <syntax-float>` of 32 or 64 bit width each, respectively.
 
 In most places of the semantics, values of different types can occur.
-In order to avoid ambiguities, values are therefor represented with an abstract syntax that makes their type explicit.
+In order to avoid ambiguities, values are therefore represented with an abstract syntax that makes their type explicit.
 It is convenient to reuse the same notation as for the |CONST| :ref:`instructions <syntax-const>` producing them:
 
 .. math::

--- a/document/index.rst
+++ b/document/index.rst
@@ -11,9 +11,7 @@ WebAssembly Specification
    introduction/index
    syntax/index
    validation/index
-   instantiation/index
    execution/index
-   instructions/index
    binary/index
    appendix-properties/index
    appendix-algorithm/index

--- a/document/instantiation/index.rst
+++ b/document/instantiation/index.rst
@@ -1,8 +1,0 @@
-Instantiation
-=============
-
-.. toctree::
-   :maxdepth: 2
-
-   conventions
-   instantiation

--- a/document/math.def
+++ b/document/math.def
@@ -20,6 +20,7 @@
 .. Auxiliary definitions for grammars
 
 .. |production| mathdef:: \void
+.. |with| mathdef:: ~\xref{syntax/conventions}{syntax-record}{\mbox{with}}~
 
 
 .. Values, terminals
@@ -32,31 +33,31 @@
 
 .. |byte| mathdef:: \xref{syntax/values}{syntax-byte}{\X{byte}}
 
-.. |uX#1| mathdef:: {\X{uint}_{#1}}
-.. |sX#1| mathdef:: {\X{sint}_{#1}}
-.. |iX#1| mathdef:: {\X{int}_{#1}}
-.. |fX#1| mathdef:: {\X{float}_{#1}}
+.. |uX#1| mathdef:: {\X{u}#1}
+.. |sX#1| mathdef:: {\X{s}#1}
+.. |iX#1| mathdef:: {\X{i}#1}
+.. |fX#1| mathdef:: {\X{f}#1}
 
 .. |uN| mathdef:: \xref{syntax/values}{syntax-int}{\uX{N}}
-.. |u1| mathdef:: \xref{syntax/values}{syntax-int}{\uX{1}}
-.. |u8| mathdef:: \xref{syntax/values}{syntax-int}{\uX{8}}
-.. |u16| mathdef:: \xref{syntax/values}{syntax-int}{\uX{16}}
-.. |u32| mathdef:: \xref{syntax/values}{syntax-int}{\uX{32}}
-.. |u64| mathdef:: \xref{syntax/values}{syntax-int}{\uX{64}}
+.. |u1| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{1}}}
+.. |u8| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{8}}}
+.. |u16| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{16}}}
+.. |u32| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{32}}}
+.. |u64| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{64}}}
 
 .. |sN| mathdef:: \xref{syntax/values}{syntax-int}{\sX{N}}
-.. |s8| mathdef:: \xref{syntax/values}{syntax-int}{\sX{8}}
-.. |s16| mathdef:: \xref{syntax/values}{syntax-int}{\sX{16}}
-.. |s32| mathdef:: \xref{syntax/values}{syntax-int}{\sX{32}}
-.. |s64| mathdef:: \xref{syntax/values}{syntax-int}{\sX{64}}
+.. |s8| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{8}}}
+.. |s16| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{16}}}
+.. |s32| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{32}}}
+.. |s64| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{64}}}
 
 .. |iN| mathdef:: \xref{syntax/values}{syntax-int}{\iX{N}}
-.. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\iX{32}}
-.. |i64| mathdef:: \xref{syntax/values}{syntax-int}{\iX{64}}
+.. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{32}}}
+.. |i64| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{64}}}
 
 .. |fN| mathdef:: \xref{syntax/values}{syntax-float}{\fX{N}}
-.. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\fX{32}}
-.. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\fX{64}}
+.. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\fX{\X{32}}}
+.. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\fX{\X{64}}}
 
 .. |vec| mathdef:: \xref{syntax/values}{syntax-vec}{\X{vec}}
 .. |name| mathdef:: \xref{syntax/values}{syntax-name}{\X{name}}
@@ -67,29 +68,29 @@
 
 .. |Bbyte| mathdef:: \xref{binary/values}{binary-byte}{\B{byte}}
 
-.. |BuX#1| mathdef:: {\B{uint}_{#1}}
-.. |BsX#1| mathdef:: {\B{sint}_{#1}}
-.. |BiX#1| mathdef:: {\B{int}_{#1}}
-.. |BfX#1| mathdef:: {\B{float}_{#1}}
+.. |BuX#1| mathdef:: {\B{u}#1}
+.. |BsX#1| mathdef:: {\B{s}#1}
+.. |BiX#1| mathdef:: {\B{i}#1}
+.. |BfX#1| mathdef:: {\B{f}#1}
 
 .. |BuN| mathdef:: \xref{binary/values}{binary-int}{\BuX{N}}
-.. |Bu1| mathdef:: \xref{binary/values}{binary-int}{\BuX{1}}
-.. |Bu8| mathdef:: \xref{binary/values}{binary-int}{\BuX{8}}
-.. |Bu16| mathdef:: \xref{binary/values}{binary-int}{\BuX{16}}
-.. |Bu32| mathdef:: \xref{binary/values}{binary-int}{\BuX{32}}
-.. |Bu64| mathdef:: \xref{binary/values}{binary-int}{\BuX{64}}
+.. |Bu1| mathdef:: \xref{binary/values}{binary-int}{\BuX{\B{1}}}
+.. |Bu8| mathdef:: \xref{binary/values}{binary-int}{\BuX{\B{8}}}
+.. |Bu16| mathdef:: \xref{binary/values}{binary-int}{\BuX{\B{16}}}
+.. |Bu32| mathdef:: \xref{binary/values}{binary-int}{\BuX{\B{32}}}
+.. |Bu64| mathdef:: \xref{binary/values}{binary-int}{\BuX{\B{64}}}
 
 .. |BsN| mathdef:: \xref{binary/values}{binary-int}{\BsX{N}}
-.. |Bs32| mathdef:: \xref{binary/values}{binary-int}{\BsX{32}}
-.. |Bs64| mathdef:: \xref{binary/values}{binary-int}{\BsX{64}}
+.. |Bs32| mathdef:: \xref{binary/values}{binary-int}{\BsX{\B{32}}}
+.. |Bs64| mathdef:: \xref{binary/values}{binary-int}{\BsX{\B{64}}}
 
 .. |BiN| mathdef:: \xref{binary/values}{binary-int}{\BiX{N}}
-.. |Bi32| mathdef:: \xref{binary/values}{binary-int}{\BiX{32}}
-.. |Bi64| mathdef:: \xref{binary/values}{binary-int}{\BiX{64}}
+.. |Bi32| mathdef:: \xref{binary/values}{binary-int}{\BiX{\B{32}}}
+.. |Bi64| mathdef:: \xref{binary/values}{binary-int}{\BiX{\B{64}}}
 
 .. |BfN| mathdef:: \xref{binary/values}{binary-float}{\BfX{N}}
-.. |Bf32| mathdef:: \xref{binary/values}{binary-float}{\BfX{32}}
-.. |Bf64| mathdef:: \xref{binary/values}{binary-float}{\BfX{64}}
+.. |Bf32| mathdef:: \xref{binary/values}{binary-float}{\BfX{\B{32}}}
+.. |Bf64| mathdef:: \xref{binary/values}{binary-float}{\BfX{\B{64}}}
 
 .. |Bvec| mathdef:: \xref{binary/values}{binary-vec}{\B{vec}}
 .. |Bname| mathdef:: \xref{binary/values}{binary-name}{\B{name}}
@@ -100,13 +101,16 @@
 
 .. Types, terminals
 
+.. |I8| mathdef:: \xref{execution/runtime}{syntax-storagetype}{\K{i8}}
+.. |I16| mathdef:: \xref{execution/runtime}{syntax-storagetype}{\K{i16}}
 .. |I32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i32}}
 .. |I64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i64}}
 .. |F32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f32}}
 .. |F64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f64}}
 
 .. |ANYFUNC| mathdef:: \xref{syntax/types}{syntax-elemtype}{\K{anyfunc}}
-.. |MUT| mathdef:: \xref{syntax/types}{syntax-mut}{\K{mut}}
+.. |MVAR| mathdef:: \xref{syntax/types}{syntax-mut}{\K{var}}
+.. |MCONST| mathdef:: \xref{syntax/types}{syntax-mut}{\K{var}}
 
 .. |MIN| mathdef:: \K{min}
 .. |MAX| mathdef:: \K{max}
@@ -121,7 +125,6 @@
 .. |tabletype| mathdef:: \xref{syntax/types}{syntax-tabletype}{\X{tabletype}}
 .. |elemtype| mathdef:: \xref{syntax/types}{syntax-elemtype}{\X{elemtype}}
 .. |memtype| mathdef:: \xref{syntax/types}{syntax-memtype}{\X{memtype}}
-.. |externtype| mathdef:: \xref{syntax/types}{syntax-externtype}{\X{externtype}}
 .. |limits| mathdef:: \xref{syntax/types}{syntax-limits}{\X{limits}}
 .. |mut| mathdef:: \xref{syntax/types}{syntax-mut}{\X{mut}}
 
@@ -136,7 +139,6 @@
 .. |Btabletype| mathdef:: \xref{binary/types}{binary-tabletype}{\B{tabletype}}
 .. |Belemtype| mathdef:: \xref{binary/types}{binary-elemtype}{\B{elemtype}}
 .. |Bmemtype| mathdef:: \xref{binary/types}{binary-memtype}{\B{memtype}}
-.. |Bexterntype| mathdef:: \xref{binary/types}{binary-externtype}{\B{externtype}}
 .. |Blimits| mathdef:: \xref{binary/types}{binary-limits}{\B{limits}}
 .. |Bmut| mathdef:: \xref{binary/types}{binary-mut}{\B{mut}}
 
@@ -169,6 +171,7 @@
 .. |GLOBALS| mathdef:: \K{globals}
 .. |LOCALS| mathdef:: \K{locals}
 .. |LABELS| mathdef:: \K{labels}
+.. |LRETURN| mathdef:: \K{return}
 .. |IMPORTS| mathdef:: \K{imports}
 .. |EXPORTS| mathdef:: \K{exports}
 
@@ -178,8 +181,6 @@
 .. |TABLE| mathdef:: \K{table}
 .. |MEM| mathdef:: \K{mem}
 .. |GLOBAL| mathdef:: \K{global}
-.. |LOCAL| mathdef:: \K{local}
-.. |LABEL| mathdef:: \K{label}
 .. |IMPORT| mathdef:: \K{import}
 .. |EXPORT| mathdef:: \K{export}
 .. |CODE| mathdef:: \K{code}
@@ -251,10 +252,10 @@
 
 .. Modules, meta functions
 
-.. |funcs| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{funcs}}
-.. |tables| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{tables}}
-.. |mems| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{mems}}
-.. |globals| mathdef:: \xref{syntax/types}{syntax-externtype}{\F{globals}}
+.. |funcs| mathdef:: \xref{execution/runtime}{syntax-externtype}{\F{funcs}}
+.. |tables| mathdef:: \xref{execution/runtime}{syntax-externtype}{\F{tables}}
+.. |mems| mathdef:: \xref{execution/runtime}{syntax-externtype}{\F{mems}}
+.. |globals| mathdef:: \xref{execution/runtime}{syntax-externtype}{\F{globals}}
 
 
 .. Instructions, terminals
@@ -331,14 +332,35 @@
 .. |DEMOTE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{demote}}
 .. |REINTERPRET| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{reinterpret}}
 
+.. |TRAP| mathdef:: \xref{execution/runtime}{syntax-instr-admin}{\K{trap}}
+.. |LABEL| mathdef:: \xref{execution/runtime}{syntax-instr-admin}{\K{label}}
+.. |FRAME| mathdef:: \xref{execution/runtime}{syntax-instr-admin}{\K{frame}}
+
+.. |INVOKE| mathdef:: \xref{execution/instructions}{syntax-instr-admin}{\K{invoke}}
+.. |INSTANTIATE| mathdef:: \xref{execution/modules}{syntax-instantiate}{\K{instantiate}}
+.. |INITIALIZE| mathdef:: \xref{execution/modules}{syntax-instantiate}{\K{initialize}}
+.. |INITGLOBAL| mathdef:: \xref{execution/modules}{syntax-instantiate}{\K{init\_global}}
+.. |INITTABLE| mathdef:: \xref{execution/modules}{syntax-instantiate}{\K{init\_table}}
+.. |INITMEM| mathdef:: \xref{execution/modules}{syntax-instantiate}{\K{init\_mem}}
+
 
 .. Instructions, non-terminals
 
-.. |unop| mathdef:: \X{unop}
-.. |binop| mathdef:: \X{binop}
-.. |testop| mathdef:: \X{testop}
-.. |relop| mathdef:: \X{relop}
-.. |cvtop| mathdef:: \X{cvtop}
+.. |unop| mathdef:: \xref{syntax/instructions}{syntax-unop}{\X{unop}}
+.. |binop| mathdef:: \xref{syntax/instructions}{syntax-binop}{\X{binop}}
+.. |testop| mathdef:: \xref{syntax/instructions}{syntax-testop}{\X{testop}}
+.. |relop| mathdef:: \xref{syntax/instructions}{syntax-relop}{\X{relop}}
+.. |cvtop| mathdef:: \xref{syntax/instructions}{syntax-cvtop}{\X{cvtop}}
+
+.. |iunop| mathdef:: \xref{syntax/instructions}{syntax-iunop}{\X{iunop}}
+.. |ibinop| mathdef:: \xref{syntax/instructions}{syntax-ibinop}{\X{ibinop}}
+.. |itestop| mathdef:: \xref{syntax/instructions}{syntax-itestop}{\X{itestop}}
+.. |irelop| mathdef:: \xref{syntax/instructions}{syntax-irelop}{\X{irelop}}
+
+.. |funop| mathdef:: \xref{syntax/instructions}{syntax-funop}{\X{funop}}
+.. |fbinop| mathdef:: \xref{syntax/instructions}{syntax-fbinop}{\X{fbinop}}
+.. |ftestop| mathdef:: \xref{syntax/instructions}{syntax-ftestop}{\X{ftestop}}
+.. |frelop| mathdef:: \xref{syntax/instructions}{syntax-frelop}{\X{frelop}}
 
 .. |sx| mathdef:: \xref{syntax/instructions}{syntax-sx}{\X{sx}}
 .. |memarg| mathdef:: \xref{syntax/instructions}{syntax-memarg}{\X{memarg}}
@@ -353,3 +375,50 @@
 
 .. |Binstr| mathdef:: \xref{binary/instructions}{binary-instr}{\B{instr}}
 .. |Bexpr| mathdef:: \xref{binary/instructions}{binary-expr}{\B{expr}}
+
+
+.. Runtime, terminals
+
+.. |MUT| mathdef:: \K{mut}
+
+
+.. Runtime, non-terminals
+
+.. |val| mathdef:: \xref{execution/runtime}{syntax-val}{\X{val}}
+
+.. |addr| mathdef:: \xref{execution/runtime}{syntax-addr}{\X{addr}}
+.. |funcaddr| mathdef:: \xref{execution/runtime}{syntax-funcaddr}{\X{funcaddr}}
+.. |tableaddr| mathdef:: \xref{execution/runtime}{syntax-tableaddr}{\X{tableaddr}}
+.. |memaddr| mathdef:: \xref{execution/runtime}{syntax-memaddr}{\X{memaddr}}
+.. |globaladdr| mathdef:: \xref{execution/runtime}{syntax-globaladdr}{\X{globaladdr}}
+
+.. |moduleinst| mathdef:: \xref{execution/runtime}{syntax-moduleinst}{\X{moduleinst}}
+.. |funcinst| mathdef:: \xref{execution/runtime}{syntax-funcinst}{\X{funcinst}}
+.. |tableinst| mathdef:: \xref{execution/runtime}{syntax-tableinst}{\X{tableinst}}
+.. |funcelem| mathdef:: \xref{execution/runtime}{syntax-funcelem}{\X{funcelem}}
+.. |meminst| mathdef:: \xref{execution/runtime}{syntax-meminst}{\X{meminst}}
+.. |globalinst| mathdef:: \xref{execution/runtime}{syntax-globalinst}{\X{globalinst}}
+.. |exportinst| mathdef:: \xref{execution/runtime}{syntax-exportinst}{\X{exportinst}}
+
+.. |externval| mathdef:: \xref{execution/runtime}{syntax-externval}{\X{externval}}
+.. |externtype| mathdef:: \xref{execution/runtime}{syntax-externtype}{\X{externtype}}
+.. |storagetype| mathdef:: \xref{execution/runtime}{syntax-storagetype}{\X{storagetype}}
+
+.. |store| mathdef:: \xref{execution/runtime}{syntax-store}{\X{store}}
+.. |frame| mathdef:: \xref{execution/runtime}{syntax-frame}{\X{frame}}
+.. |label| mathdef:: \xref{execution/runtime}{syntax-label}{\X{label}}
+
+.. |XB| mathdef:: \xref{execution/runtime}{syntax-ctxt-block}{B}
+
+
+.. Execution, notation
+
+.. |stepto| mathdef:: \hookrightarrow
+.. |mod| mathdef:: \mathbin{\F{mod}}
+
+.. Numerics, meta functions
+
+.. |bytes| mathdef:: \xref{execution/numerics}{aux-bytes}{\F{bytes}}
+.. |signed| mathdef:: \xref{execution/numerics}{aux-signed}{\F{signed}}
+.. |extend| mathdef:: \xref{execution/numerics}{aux-extend}{\F{extend}}
+.. |wrap| mathdef:: \xref{execution/numerics}{aux-wrap}{\F{wrap}}

--- a/document/syntax/conventions.rst
+++ b/document/syntax/conventions.rst
@@ -42,7 +42,7 @@ The following conventions are adopted in defining grammar rules for abstract syn
 Auxiliary Notation
 ~~~~~~~~~~~~~~~~~~
 
-When dealing with syntactic constructs the following notations and conventions are also used:
+When dealing with syntactic constructs the following notation is also used:
 
 * :math:`\epsilon` denotes the empty sequence.
 
@@ -50,7 +50,7 @@ When dealing with syntactic constructs the following notations and conventions a
 
 * :math:`s[i]` denotes the :math:`i`-th element of a sequence :math:`s`, starting from :math:`0`.
 
-* :math:`s[i:n]` denotes the sub-sequence of length :math:`n` of a sequence :math:`s` that consists of its :math:`i`-th to :math:`(i+n-1)`-th element.
+* :math:`s[i:n]` denotes the sub-sequence :math:`s[i]~\dots~s[i+n-1]` of a sequence :math:`s`.
 
 * :math:`s \with [i] = A` denotes the same sequence as :math:`s`,
   except that the :math:`i`-the element is replaced with :math:`A`.
@@ -58,10 +58,12 @@ When dealing with syntactic constructs the following notations and conventions a
 * :math:`s \with [i:n] = A^n` denotes the same sequence as :math:`s`,
   except that the sub-sequence :math:`s[i:n]` is replaced with :math:`A^n`.
 
-* :math:`x^n`, where :math:`x` is a non-terminal symbol, is treated as a meta variable ranging over respective sequences of :math:`x` (similarly for :math:`x^\ast`, :math:`x^+`, :math:`x^?`).
+Moreover, the following conventions are employed:
+
+* The notation :math:`x^n`, where :math:`x` is a non-terminal symbol, is treated as a meta variable ranging over respective sequences of :math:`x` (similarly for :math:`x^\ast`, :math:`x^+`, :math:`x^?`).
 
 * When given a sequence :math:`x^n`,
-  then the ocurrences of :math:`x` in a sequence written :math:`(A_1~x~A_2)^n` are assumed to be in pointwise correspondence with :math:`x^n`
+  then the occurrences of :math:`x` in a sequence written :math:`(A_1~x~A_2)^n` are assumed to be in point-wise correspondence with :math:`x^n`
   (similarly for :math:`x^\ast`, :math:`x^+`, :math:`x^?`).
   This implicitly expresses a form of mapping syntactic constructions over a sequence.
 

--- a/document/syntax/conventions.rst
+++ b/document/syntax/conventions.rst
@@ -72,8 +72,6 @@ The following notation is adopted for manipulating such records:
 
 The update notation for sequences and records generalizes recursively to nested components accessed by "paths" :math:`\X{pth} ::= ([\dots] \;| \;.\K{field})^+`:
 
-* :math:`s~\mbox{with}~[i]\X{pth} = x` denotes the same sequence as :math:`s`,
-  except that the :math:`s[i]` is replaced with :math:`s[i]~\mbox{with}~\X{pth} = x`.
+* :math:`s~\mbox{with}~[i]\,\X{pth} = x` is short for :math:`s~\mbox{with}~[i] = (s[i]~\mbox{with}~\X{pth} = x)`.
 
-* :math:`r~\mbox{with}~\K{field}\X{pth} = x` denotes the same record as :math:`r`,
-  except that the :math:`\K{field}` component is replaced with :math:`r.\K{field}~\mbox{with}~\X{pth} = x`.
+* :math:`r~\mbox{with}~\K{field}\,\X{pth} = x` is short for :math:`r~\mbox{with}~\K{field} = (r.\K{field}~\mbox{with}~\X{pth} = x)`.

--- a/document/syntax/conventions.rst
+++ b/document/syntax/conventions.rst
@@ -30,6 +30,9 @@ The following conventions are adopted in defining grammar rules for abstract syn
 * :math:`A^\ast` is a possibly empty sequence of iterations of :math:`A`.
   (This is a shorthand for :math:`A^n` used where :math:`n` is not relevant.)
 
+* :math:`A^+` is a possibly empty sequence of iterations of :math:`A`.
+  (This is a shorthand for :math:`A^n` where :math:`n \geq 1`.)
+
 * :math:`A^?` is an optional occurrence of :math:`A`.
   (This is a shorthand for :math:`A^n` where :math:`n \leq 1`.)
 
@@ -47,6 +50,14 @@ When dealing with syntactic constructs the following notation is also used:
 
 * :math:`s[i]` denotes the :math:`i`-th element of a sequence :math:`s`, starting from :math:`0`.
 
+* :math:`s[i:n]` denotes the sub-sequence of length :math:`n` a sequence :math:`s` that consists of its :math:`i`-th to :math:`(i+n-1)`-the element.
+
+* :math:`s~\mbox{with}~[i] = x` denotes the same sequence as :math:`s`,
+  except that the :math:`i`-the element is replaced with :math:`x`.
+
+* :math:`s~\mbox{with}~[i:n] = x^n` denotes the same sequence as :math:`s`,
+  except that the sub-sequence :math:`s[i:n]` is replaced with :math:`x^n`.
+
 Productions of the following form are interpreted as *records* that map a fixed set of fields :math:`\K{field}_i` to values :math:`x_i`, respectively:
 
 .. math::
@@ -55,3 +66,14 @@ Productions of the following form are interpreted as *records* that map a fixed 
 The following notation is adopted for manipulating such records:
 
 * :math:`r.\K{field}` denotes the :math:`\K{field}` component of :math:`r`.
+
+* :math:`r~\mbox{with}~\K{field} = x` denotes the same record as :math:`r`,
+  except that the :math:`\K{field}` component is replaced with :math:`x`.
+
+The update notation for sequences and records generalizes recursively to nested components accessed by "paths" :math:`\X{pth} ::= ([\dots] \;| \;.\K{field})^+`:
+
+* :math:`s~\mbox{with}~[i]\X{pth} = x` denotes the same sequence as :math:`s`,
+  except that the :math:`s[i]` is replaced with :math:`s[i]~\mbox{with}~\X{pth} = x`.
+
+* :math:`r~\mbox{with}~\K{field}\X{pth} = x` denotes the same record as :math:`r`,
+  except that the :math:`\K{field}` component is replaced with :math:`r.\K{field}~\mbox{with}~\X{pth} = x`.

--- a/document/syntax/conventions.rst
+++ b/document/syntax/conventions.rst
@@ -42,7 +42,7 @@ The following conventions are adopted in defining grammar rules for abstract syn
 Auxiliary Notation
 ~~~~~~~~~~~~~~~~~~
 
-When dealing with syntactic constructs the following notation is also used:
+When dealing with syntactic constructs the following notations and conventions are also used:
 
 * :math:`\epsilon` denotes the empty sequence.
 
@@ -50,28 +50,37 @@ When dealing with syntactic constructs the following notation is also used:
 
 * :math:`s[i]` denotes the :math:`i`-th element of a sequence :math:`s`, starting from :math:`0`.
 
-* :math:`s[i:n]` denotes the sub-sequence of length :math:`n` a sequence :math:`s` that consists of its :math:`i`-th to :math:`(i+n-1)`-the element.
+* :math:`s[i:n]` denotes the sub-sequence of length :math:`n` of a sequence :math:`s` that consists of its :math:`i`-th to :math:`(i+n-1)`-th element.
 
-* :math:`s~\mbox{with}~[i] = x` denotes the same sequence as :math:`s`,
-  except that the :math:`i`-the element is replaced with :math:`x`.
+* :math:`s \with [i] = A` denotes the same sequence as :math:`s`,
+  except that the :math:`i`-the element is replaced with :math:`A`.
 
-* :math:`s~\mbox{with}~[i:n] = x^n` denotes the same sequence as :math:`s`,
-  except that the sub-sequence :math:`s[i:n]` is replaced with :math:`x^n`.
+* :math:`s \with [i:n] = A^n` denotes the same sequence as :math:`s`,
+  except that the sub-sequence :math:`s[i:n]` is replaced with :math:`A^n`.
 
-Productions of the following form are interpreted as *records* that map a fixed set of fields :math:`\K{field}_i` to values :math:`x_i`, respectively:
+* :math:`x^n`, where :math:`x` is a non-terminal symbol, is treated as a meta variable ranging over respective sequences of :math:`x` (similarly for :math:`x^\ast`, :math:`x^+`, :math:`x^?`).
+
+* When given a sequence :math:`x^n`,
+  then the ocurrences of :math:`x` in a sequence written :math:`(A_1~x~A_2)^n` are assumed to be in pointwise correspondence with :math:`x^n`
+  (similarly for :math:`x^\ast`, :math:`x^+`, :math:`x^?`).
+  This implicitly expresses a form of mapping syntactic constructions over a sequence.
+
+Productions of the following form are interpreted as *records* that map a fixed set of fields :math:`\K{field}_i` to "values" :math:`A_i`, respectively:
 
 .. math::
-   \X{r} ~::=~ \{ \K{field}_1~x_1, \K{field}_2~x_2, \dots \}
+   \X{r} ~::=~ \{ \K{field}_1~A_1, \K{field}_2~A_2, \dots \}
 
 The following notation is adopted for manipulating such records:
 
-* :math:`r.\K{field}` denotes the :math:`\K{field}` component of :math:`r`.
+* :math:`r.\K{field}` denotes the value of the :math:`\K{field}` component of :math:`r`.
 
-* :math:`r~\mbox{with}~\K{field} = x` denotes the same record as :math:`r`,
-  except that the :math:`\K{field}` component is replaced with :math:`x`.
+* :math:`r \with \K{field} = A` denotes the same record as :math:`r`,
+  except that the value of the :math:`\K{field}` component is replaced with :math:`A`.
 
 The update notation for sequences and records generalizes recursively to nested components accessed by "paths" :math:`\X{pth} ::= ([\dots] \;| \;.\K{field})^+`:
 
-* :math:`s~\mbox{with}~[i]\,\X{pth} = x` is short for :math:`s~\mbox{with}~[i] = (s[i]~\mbox{with}~\X{pth} = x)`.
+* :math:`s \with [i]\,\X{pth} = A` is short for :math:`s \with [i] = (s[i] \with \X{pth} = A)`.
 
-* :math:`r~\mbox{with}~\K{field}\,\X{pth} = x` is short for :math:`r~\mbox{with}~\K{field} = (r.\K{field}~\mbox{with}~\X{pth} = x)`.
+* :math:`r \with \K{field}\,\X{pth} = A` is short for :math:`r \with \K{field} = (r.\K{field} \with \X{pth} = A)`.
+
+where :math:`r \with .\K{field} = A` is shortened to :math:`r \with \K{field} = A`.

--- a/document/syntax/instructions.rst
+++ b/document/syntax/instructions.rst
@@ -268,6 +268,7 @@ The precise semantics of memory instructions is :ref:`described <exec-instr-memo
 
 
 .. _syntax-instr-control:
+.. _syntax-isntr-seq:
 .. _syntax-label:
 .. index:: ! control instruction, ! structured control, ! label, ! block, ! branch, ! unwinding, result type, label index, function index, type index, vector
    pair: abstract syntax; instruction

--- a/document/syntax/instructions.rst
+++ b/document/syntax/instructions.rst
@@ -25,6 +25,19 @@ The following sections group instructions into a number of different categories.
 
 .. _syntax-sx:
 .. _syntax-instr-numeric:
+.. _syntax-const:
+.. _syntax-unop:
+.. _syntax-binop:
+.. _syntax-testop:
+.. _syntax-relop:
+.. _syntax-iunop:
+.. _syntax-ibinop:
+.. _syntax-itestop:
+.. _syntax-irelop:
+.. _syntax-funop:
+.. _syntax-fbinop:
+.. _syntax-ftestop:
+.. _syntax-frelop:
 .. index:: ! numeric instruction
    pair: abstract syntax; instruction
 
@@ -40,59 +53,73 @@ These operations closely match respective operations available in hardware.
      \K{32} ~|~ \K{64} \\
    \production{signedness} & \sx &::=&
      \K{u} ~|~ \K{s} \\
-   \production{instructions} & \instr &::=&
-     \K{i}\X{nn}\K{.const}~\xref{syntax/values}{syntax-int}{\iX{\X{nn}}} ~|~
-     \K{f}\X{nn}\K{.const}~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} ~|~ \\&&&
-     \K{i}\X{nn}\K{.eqz} ~|~ \\&&&
-     \K{i}\X{nn}\K{.eq} ~|~
-     \K{i}\X{nn}\K{.ne} ~|~
-     \K{i}\X{nn}\K{.lt\_}\sx ~|~
-     \K{i}\X{nn}\K{.gt\_}\sx ~|~
-     \K{i}\X{nn}\K{.le\_}\sx ~|~
-     \K{i}\X{nn}\K{.ge\_}\sx ~|~ \\&&&
-     \K{f}\X{nn}\K{.eq} ~|~
-     \K{f}\X{nn}\K{.ne} ~|~
-     \K{f}\X{nn}\K{.lt} ~|~
-     \K{f}\X{nn}\K{.gt} ~|~
-     \K{f}\X{nn}\K{.le} ~|~
-     \K{f}\X{nn}\K{.ge} ~|~ \\&&&
-     \K{i}\X{nn}\K{.clz} ~|~
-     \K{i}\X{nn}\K{.ctz} ~|~
-     \K{i}\X{nn}\K{.popcnt} ~|~ \\&&&
-     \K{i}\X{nn}\K{.add} ~|~
-     \K{i}\X{nn}\K{.sub} ~|~
-     \K{i}\X{nn}\K{.mul} ~|~
-     \K{i}\X{nn}\K{.div\_}\sx ~|~
-     \K{i}\X{nn}\K{.rem\_}\sx ~|~ \\&&&
-     \K{i}\X{nn}\K{.and} ~|~
-     \K{i}\X{nn}\K{.or} ~|~
-     \K{i}\X{nn}\K{.xor} ~|~ \\&&&
-     \K{i}\X{nn}\K{.shl} ~|~
-     \K{i}\X{nn}\K{.shr\_}\sx ~|~
-     \K{i}\X{nn}\K{.rotl} ~|~
-     \K{i}\X{nn}\K{.rotr} ~|~ \\&&&
-     \K{f}\X{nn}\K{.abs} ~|~
-     \K{f}\X{nn}\K{.neg} ~|~
-     \K{f}\X{nn}\K{.sqrt} ~|~ \\&&&
-     \K{f}\X{nn}\K{.ceil} ~|~ 
-     \K{f}\X{nn}\K{.floor} ~|~ 
-     \K{f}\X{nn}\K{.trunc} ~|~ 
-     \K{f}\X{nn}\K{.nearest} ~|~ \\&&&
-     \K{f}\X{nn}\K{.add} ~|~
-     \K{f}\X{nn}\K{.sub} ~|~
-     \K{f}\X{nn}\K{.mul} ~|~
-     \K{f}\X{nn}\K{.div} ~|~ \\&&&
-     \K{f}\X{nn}\K{.min} ~|~
-     \K{f}\X{nn}\K{.max} ~|~
-     \K{f}\X{nn}\K{.copysign} ~|~ \\&&&
-     \K{i32.wrap/i64} ~|~
-     \K{i64.extend\_}\sx/\K{i32} ~|~
-     \K{i}\X{nn}\K{.trunc\_}\sx/\K{f}\X{mm} ~|~ \\&&&
-     \K{f32.demote/f64} ~|~
-     \K{f64.promote/f32} ~|~
-     \K{f}\X{nn}\K{.convert\_}\sx/\K{i}\X{mm} ~|~ \\&&&
-     \K{i}\X{nn}\K{.reinterpret/f}\X{nn} ~|~
-     \K{f}\X{nn}\K{.reinterpret/i}\X{nn} \\
+   \production{instruction} & \instr &::=&
+     \K{i}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-int}{\iX{\X{nn}}} ~|~
+     \K{f}\X{nn}\K{.}\CONST~\xref{syntax/values}{syntax-float}{\fX{\X{nn}}} ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\iunop ~|~
+     \K{f}\X{nn}\K{.}\funop ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\ibinop ~|~
+     \K{f}\X{nn}\K{.}\fbinop ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\itestop ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\irelop ~|~
+     \K{f}\X{nn}\K{.}\frelop ~|~ \\&&&
+     \K{i32.}\WRAP\K{/i64} ~|~
+     \K{i64.}\EXTEND\K{\_}\sx/\K{i32} ~|~
+     \K{i}\X{nn}\K{.}\TRUNC\K{\_}\sx/\K{f}\X{mm} ~|~ \\&&&
+     \K{f32.}\TRUNC\K{/f64} ~|~
+     \K{f64.}\PROMOTE\K{/f32} ~|~
+     \K{f}\X{nn}\K{.}\CONVERT\K{\_}\sx/\K{i}\X{mm} ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\REINTERPRET\K{/f}\X{nn} ~|~
+     \K{f}\X{nn}\K{.}\REINTERPRET\K{/i}\X{nn} \\
+   \production{integer unary operator} & \iunop &::=&
+     \K{clz} ~|~
+     \K{ctz} ~|~
+     \K{popcnt} \\
+   \production{integer binary operator} & \ibinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{mul} ~|~
+     \K{div\_}\sx ~|~
+     \K{rem\_}\sx ~|~ \\&&&
+     \K{and} ~|~
+     \K{or} ~|~
+     \K{xor} ~|~
+     \K{shl} ~|~
+     \K{shr\_}\sx ~|~
+     \K{rotl} ~|~
+     \K{rotr} \\
+   \production{floating-point unary operator} & \funop &::=&
+     \K{abs} ~|~
+     \K{neg} ~|~
+     \K{sqrt} ~|~
+     \K{ceil} ~|~ 
+     \K{floor} ~|~ 
+     \K{trunc} ~|~ 
+     \K{nearest} \\
+   \production{floating-point binary operator} & \fbinop &::=&
+     \K{add} ~|~
+     \K{sub} ~|~
+     \K{mul} ~|~
+     \K{div} ~|~
+     \K{min} ~|~
+     \K{max} ~|~
+     \K{copysign} \\
+   \production{integer test operator} & \itestop &::=&
+     \K{eqz} \\
+   \production{integer relational operator} & \irelop &::=&
+     \K{eq} ~|~
+     \K{ne} ~|~
+     \K{lt\_}\sx ~|~
+     \K{gt\_}\sx ~|~
+     \K{le\_}\sx ~|~
+     \K{ge\_}\sx \\
+   \production{floating-point relational operator} & \frelop &::=&
+     \K{eq} ~|~
+     \K{ne} ~|~
+     \K{lt} ~|~
+     \K{gt} ~|~
+     \K{le} ~|~
+     \K{ge} \\
    \end{array}
 
 Numeric instructions are divided by :ref:`value type <syntax-valtype>`.
@@ -116,6 +143,28 @@ where a signedness annotation |sx| distinguishes whether the operands are to be 
 For the other integer instructions, the use of 2's complement for the signed interpretation means that they behave the same regardless of signedness.
 
 
+Conventions
+...........
+
+Occasionally, it is convenient to group operators together according to the following grammar shorthands:
+
+.. math::
+   \begin{array}{llll}
+   \production{unary operator} & \unop &::=& \iunop ~|~ \funop \\
+   \production{binary operator} & \binop &::=& \ibinop ~|~ \fbinop \\
+   \production{test operator} & \testop &::=& \itestop \\
+   \production{relational operator} & \relop &::=& \irelop ~|~ \frelop \\
+   \production{conversion operator} & \cvtop &::=&
+     \WRAP ~|~
+     \EXTEND\K{\_}\sx ~|~
+     \TRUNC\K{\_}\sx ~|~
+     \CONVERT\K{\_}\sx ~|~
+     \DEMOTE ~|~
+     \PROMOTE ~|~
+     \REINTERPRET \\
+   \end{array}
+
+
 .. _syntax-instr-parametric:
 .. index:: ! parametric instruction
    pair: abstract syntax; instruction
@@ -127,7 +176,7 @@ Instructions in this group can operate on operands of any :ref:`value type <synt
 
 .. math::
    \begin{array}{llll}
-   \production{instructions} & \instr &::=&
+   \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
      \DROP ~|~ \\&&&
      \SELECT
@@ -149,7 +198,7 @@ Variable instructions are concerned with the access to :ref:`local <syntax-local
 
 .. math::
    \begin{array}{llll}
-   \production{instructions} & \instr &::=&
+   \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
      \GETLOCAL~\localidx ~|~ \\&&&
      \SETLOCAL~\localidx ~|~ \\&&&
@@ -163,6 +212,8 @@ The |TEELOCAL| instruction is like |SETLOCAL| but also returns its argument.
 
 
 .. _syntax-instr-memory:
+.. _syntax-load:
+.. _syntax-store:
 .. _syntax-memarg:
 .. index:: ! memory instruction, memory index
    pair: abstract syntax; instruction
@@ -176,18 +227,18 @@ Instructions in this group are concerned with :ref:`linear memory <sec-memory>`.
    \begin{array}{llll}
    \production{memory immediate} & \memarg &::=&
      \{ \OFFSET~\u32, \ALIGN~\u32 \} \\
-   \production{instructions} & \instr &::=&
+   \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
-     \K{i}\X{nn}\K{.load}~\memarg ~|~
-     \K{f}\X{nn}\K{.load}~\memarg ~|~ \\&&&
-     \K{i}\X{nn}\K{.store}~\memarg ~|~
-     \K{f}\X{nn}\K{.store}~\memarg ~|~ \\&&&
-     \K{i}\X{nn}\K{.load8\_}\sx~\memarg ~|~
-     \K{i}\X{nn}\K{.load16\_}\sx~\memarg ~|~
-     \K{i64.load32\_}\sx~\memarg ~|~ \\&&&
-     \K{i}\X{nn}\K{.store8}~\memarg ~|~
-     \K{i}\X{nn}\K{.store16}~\memarg ~|~
-     \K{i64.store32}~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\LOAD~\memarg ~|~
+     \K{f}\X{nn}\K{.}\LOAD~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\STORE~\memarg ~|~
+     \K{f}\X{nn}\K{.}\STORE~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\LOAD\K{8\_}\sx~\memarg ~|~
+     \K{i}\X{nn}\K{.}\LOAD\K{16\_}\sx~\memarg ~|~
+     \K{i64.}\LOAD\K{32\_}\sx~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\STORE\K{8}~\memarg ~|~
+     \K{i}\X{nn}\K{.}\STORE\K{16}~\memarg ~|~
+     \K{i64.}\STORE\K{32}~\memarg ~|~ \\&&&
      \CURRENTMEMORY ~|~ \\&&&
      \GROWMEMORY \\
    \end{array}
@@ -228,7 +279,7 @@ Instructions in this group affect the flow of control.
 
 .. math::
    \begin{array}{llll}
-   \production{instructions} & \instr &::=&
+   \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
      \NOP ~|~ \\&&&
      \UNREACHABLE ~|~ \\&&&
@@ -301,7 +352,7 @@ Expressions
 
 .. math::
    \begin{array}{llll}
-   \production{expressions} & \expr &::=&
+   \production{expression} & \expr &::=&
      \instr^\ast~\END \\
    \end{array}
 

--- a/document/syntax/modules.rst
+++ b/document/syntax/modules.rst
@@ -13,7 +13,7 @@ and provide initialization logic in the form of :ref:`data <syntax-data>` and :r
 
 .. math::
    \begin{array}{lllll}
-   \production{modules} & \module &::=& \{ &
+   \production{module} & \module &::=& \{ &
      \TYPES~\vec(\functype), \\&&&&
      \FUNCS~\vec(\func), \\&&&&
      \TABLES~\vec(\table), \\&&&&
@@ -61,13 +61,13 @@ Each class of definition has its own *index space*, as distinguished by the foll
 
 .. math::
    \begin{array}{llll}
-   \production{type indices} & \typeidx &::=& \u32 \\
-   \production{function indices} & \funcidx &::=& \u32 \\
-   \production{table indices} & \tableidx &::=& \u32 \\
-   \production{memory indices} & \memidx &::=& \u32 \\
-   \production{global indices} & \globalidx &::=& \u32 \\
-   \production{local indices} & \localidx &::=& \u32 \\
-   \production{label indices} & \labelidx &::=& \u32 \\
+   \production{type index} & \typeidx &::=& \u32 \\
+   \production{function index} & \funcidx &::=& \u32 \\
+   \production{table index} & \tableidx &::=& \u32 \\
+   \production{memory index} & \memidx &::=& \u32 \\
+   \production{global index} & \globalidx &::=& \u32 \\
+   \production{local index} & \localidx &::=& \u32 \\
+   \production{label index} & \labelidx &::=& \u32 \\
    \end{array}
 
 The index space for functions, tables, memories and globals includes respective imports declared in the same module.
@@ -114,7 +114,7 @@ The |FUNCS| component of a module defines a vector of *functions* with the follo
 
 .. math::
    \begin{array}{llll}
-   \production{functions} & \func &::=&
+   \production{function} & \func &::=&
      \{ \TYPE~\typeidx, \LOCALS~\vec(\valtype), \BODY~\expr \} \\
    \end{array}
 
@@ -142,7 +142,7 @@ The |TABLES| component of a module defines a vector of *tables* described by the
 
 .. math::
    \begin{array}{llll}
-   \production{tables} & \table &::=&
+   \production{table} & \table &::=&
      \{ \TYPE~\tabletype \} \\
    \end{array}
 
@@ -172,7 +172,7 @@ The |MEMS| component of a module defines a vector of *linear memories* (or *memo
 
 .. math::
    \begin{array}{llll}
-   \production{memories} & \mem &::=&
+   \production{memory} & \mem &::=&
      \{ \TYPE~\memtype \} \\
    \end{array}
 
@@ -203,7 +203,7 @@ The |GLOBALS| component of a module defines a vector of *global variables* (or *
 
 .. math::
    \begin{array}{llll}
-   \production{globals} & \global &::=&
+   \production{global} & \global &::=&
      \{ \TYPE~\globaltype, \INIT~\expr \} \\
    \end{array}
 
@@ -229,7 +229,7 @@ The |ELEM| component of a module defines a vector of *element segments* that ini
 
 .. math::
    \begin{array}{llll}
-   \production{element segments} & \elem &::=&
+   \production{element segment} & \elem &::=&
      \{ \TABLE~\tableidx, \OFFSET~\expr, \INIT~\vec(\funcidx) \} \\
    \end{array}
 
@@ -254,7 +254,7 @@ The |DATA| component of a module defines a vector of *data segments* that initia
 
 .. math::
    \begin{array}{llll}
-   \production{data segments} & \data &::=&
+   \production{data segment} & \data &::=&
      \{ \MEM~\memidx, \OFFSET~\expr, \INIT~\vec(\byte) \} \\
    \end{array}
 
@@ -276,7 +276,7 @@ The |START| component of a module optionally declares the :ref:`function index <
 
 .. math::
    \begin{array}{llll}
-   \production{start functions} & \start &::=&
+   \production{start function} & \start &::=&
      \{ \FUNC~\funcidx \} \\
    \end{array}
 
@@ -296,9 +296,9 @@ The |EXPORTS| component of a module defines a set of *exports* that become acces
 
 .. math::
    \begin{array}{llll}
-   \production{exports} & \export &::=&
+   \production{export} & \export &::=&
      \{ \NAME~\name, \DESC~\exportdesc \} \\
-   \production{export descriptions} & \exportdesc &::=&
+   \production{export description} & \exportdesc &::=&
      \FUNC~\funcidx ~|~ \\&&&
      \TABLE~\tableidx ~|~ \\&&&
      \MEM~\memidx ~|~ \\&&&
@@ -311,6 +311,20 @@ which are referenced through a respective descriptor.
 
 .. note::
    In the current version of WebAssembly, only *immutable* globals may be exported.
+
+
+Conventions
+...........
+
+The following auxiliary notation is defined for sequences of exports, filtering out indices of a specific kind in an order-preserving fashion:
+
+* :math:`\funcs(\export^\ast) = [\funcidx ~|~ \FUNC~\funcidx \in (\export.\DESC)^\ast]`
+
+* :math:`\tables(\export^\ast) = [\tableidx ~|~ \TABLE~\tableidx \in (\export.\DESC)^\ast]`
+
+* :math:`\mems(\export^\ast) = [\memidx ~|~ \MEM~\memidx \in (\export.\DESC)^\ast]`
+
+* :math:`\globals(\export^\ast) = [\globalidx ~|~ \GLOBAL~\globalidx \in (\export.\DESC)^\ast]`
 
 
 .. _syntax-import:
@@ -328,9 +342,9 @@ The |IMPORTS| component of a module defines a set of *imports* that are required
 
 .. math::
    \begin{array}{llll}
-   \production{imports} & \import &::=&
+   \production{import} & \import &::=&
      \{ \MODULE~\name, \NAME~\name, \DESC~\importdesc \} \\
-   \production{import descriptions} & \importdesc &::=&
+   \production{import description} & \importdesc &::=&
      \FUNC~\typeidx ~|~ \\&&&
      \TABLE~\tabletype ~|~ \\&&&
      \MEM~\memtype ~|~ \\&&&

--- a/document/syntax/types.rst
+++ b/document/syntax/types.rst
@@ -18,7 +18,7 @@ Value Types
 
 .. math::
    \begin{array}{llll}
-   \production{value types} & \valtype &::=&
+   \production{value type} & \valtype &::=&
      \I32 ~|~ \I64 ~|~ \F32 ~|~ \F64 \\
    \end{array}
 
@@ -50,7 +50,7 @@ which is a sequence of values.
 
 .. math::
    \begin{array}{llll}
-   \production{result types} & \resulttype &::=&
+   \production{result type} & \resulttype &::=&
      [\valtype^?] \\
    \end{array}
 
@@ -72,7 +72,7 @@ mapping a vector of parameters to a vector of results.
 
 .. math::
    \begin{array}{llll}
-   \production{function types} & \functype &::=&
+   \production{function type} & \functype &::=&
      [\vec(\valtype)] \to [\vec(\valtype)] \\
    \end{array}
 
@@ -115,7 +115,7 @@ Memory Types
 
 .. math::
    \begin{array}{llll}
-   \production{memory types} & \memtype &::=&
+   \production{memory type} & \memtype &::=&
      \limits \\
    \end{array}
 
@@ -139,9 +139,9 @@ Table Types
 
 .. math::
    \begin{array}{llll}
-   \production{table types} & \tabletype &::=&
+   \production{table type} & \tabletype &::=&
      \limits~\elemtype \\
-   \production{element types} & \elemtype &::=&
+   \production{element type} & \elemtype &::=&
      \ANYFUNC \\
    \end{array}
 
@@ -170,43 +170,9 @@ Global Types
 
 .. math::
    \begin{array}{llll}
-   \production{global types} & \globaltype &::=&
+   \production{global type} & \globaltype &::=&
      \mut^?~\valtype \\
    \production{mutability} & \mut &::=&
-     \CONST ~|~
-     \MUT \\
+     \MCONST ~|~
+     \MVAR \\
    \end{array}
-
-
-.. _syntax-externtype:
-.. index:: ! external type, function type, table type, memory type, global type
-   pair: abstract syntax; external type
-   pair: external; type
-
-External Types
-~~~~~~~~~~~~~~
-
-*External types* classify imports and exports and their respective types.
-
-.. math::
-   \begin{array}{llll}
-   \production{external types} & \externtype &::=&
-     \FUNC~\functype ~|~ \\&&&
-     \TABLE~\tabletype ~|~ \\&&&
-     \MEM~\memtype ~|~ \\&&&
-     \GLOBAL~\globaltype \\
-   \end{array}
-
-
-Conventions
-...........
-
-The following auxiliary notation is defined for sequences of external types, filtering out entries of a specific kind in an order-preserving fashion:
-
-* :math:`\funcs(\externtype^\ast) = [\functype ~|~ \FUNC~\functype \in \externtype^\ast]`
-
-* :math:`\tables(\externtype^\ast) = [\tabletype ~|~ \TABLE~\tabletype \in \externtype^\ast]`
-
-* :math:`\mems(\externtype^\ast) = [\memtype ~|~ \MEM~\memtype \in \externtype^\ast]`
-
-* :math:`\globals(\externtype^\ast) = [\globaltype ~|~ \GLOBAL~\globaltype \in \externtype^\ast]`

--- a/document/syntax/values.rst
+++ b/document/syntax/values.rst
@@ -18,7 +18,7 @@ In the abstract syntax they are represented as hexadecimal literals.
 
 .. math::
    \begin{array}{llll}
-   \production{bytes} & \byte &::=&
+   \production{byte} & \byte &::=&
      \hex{00} ~|~ \dots ~|~ \hex{FF} \\
    \end{array}
 
@@ -50,20 +50,17 @@ Different classes of *integers* with different value ranges are distinguished by
 
 .. math::
    \begin{array}{llll}
-   \production{unsigned integers} & \uN &::=&
+   \production{unsigned integer} & \uN &::=&
      0 ~|~ 1 ~|~ \dots ~|~ 2^N{-}1 \\
-   \production{signed integers} & \sN &::=&
+   \production{signed integer} & \sN &::=&
      -2^{N-1} ~|~ \dots ~|~ {-}1 ~|~ 0 ~|~ 1 ~|~ \dots ~|~ 2^{N-1}{-}1 \\
-   \production{uninterpreted integers} & \iN &::=&
-     \uN ~|~ \sN \\
+   \production{uninterpreted integer} & \iN &::=&
+     \uN \\
    \end{array}
 
 The latter class defines *uninterpreted* integers, whose signedness interpretation can vary depending on context.
-In those contexts, a conversion based on 2's complement will be applied for values that are out-of-range for a chosen interpretation.
-That is, semantically, when interpreted as unsigned, negative values :math:`-n` convert to :math:`2^N-n`,
-and when interpreted as signed, positive values :math:`n \geq 2^{N-1}` convert to :math:`n-2^N`.
-
-.. todo:: once there, link to definition of conversion
+In the abstract syntax, they are represented as unsigned.
+However, some operations :ref:`convert <aus-signed>` them to signed based on a 2's complement interpretation.
 
 
 Conventions
@@ -85,7 +82,7 @@ Floating-Point
 
 .. math::
    \begin{array}{llll}
-   \production{floating-point numbers} & \fN &::=&
+   \production{floating-point number} & \fN &::=&
      \byte^{N/8} \\
    \end{array}
 
@@ -105,7 +102,7 @@ A vector can have at most :math:`2^{32}-1` elements.
 
 .. math::
    \begin{array}{lllll}
-   \production{vectors} & \vec(A) &::=&
+   \production{vector} & \vec(A) &::=&
      A^n
      & (n < 2^{32})\\
    \end{array}
@@ -122,9 +119,9 @@ Names
 
 .. math::
    \begin{array}{llll}
-   \production{names} & \name &::=&
+   \production{name} & \name &::=&
      \codepoint^\ast \\
-   \production{code points} & \codepoint &::=&
+   \production{code point} & \codepoint &::=&
      \unicode{0000} ~|~ \dots ~|~ \unicode{D7FF} ~|~
      \unicode{E000} ~|~ \dots ~|~ \unicode{10FFFF} \\
    \end{array}

--- a/document/validation/conventions.rst
+++ b/document/validation/conventions.rst
@@ -83,8 +83,8 @@ In addition to field access :math:`C.\K{field}` the following notation is adopte
 
 .. _valid-notation-textual:
 
-Textual Notation
-~~~~~~~~~~~~~~~~
+Prose Notation
+~~~~~~~~~~~~~~
 
 Validation is specified by stylised rules for each relevant part of the :ref:`abstract syntax <syntax>`.
 The rules not only state constraints defining when a phrase is valid,

--- a/document/validation/conventions.rst
+++ b/document/validation/conventions.rst
@@ -39,10 +39,11 @@ which collects relevant information about the surrounding :ref:`module <syntax-m
 * *Globals*: the list of globals declared in the current module, represented by their global type.
 * *Locals*: the list of locals declared in the current function (including parameters), represented by their value type.
 * *Labels*: the stack of labels accessible from the current position, represented by their result type.
+* *Return*: the return type of the current function, represented as a result type.
 
 In other words, a context contains a sequence of suitable :ref:`types <syntax-types>` for each :ref:`index space <syntax-index>`,
 describing each defined entry in that space.
-Locals and labels are only used for validating :ref:`instructions <syntax-instr>` in :ref:`function bodies <syntax-func>`, and are left empty elsewhere.
+Locals, labels and return type are only used for validating :ref:`instructions <syntax-instr>` in :ref:`function bodies <syntax-func>`, and are left empty elsewhere.
 The label stack is the only part of the context that changes as validation of an instruction sequence proceeds.
 
 It is convenient to define contexts as :ref:`records <syntax-record>` :math:`C` with abstract syntax:
@@ -57,7 +58,8 @@ It is convenient to define contexts as :ref:`records <syntax-record>` :math:`C` 
         & \MEMS & \memtype^\ast, \\
         & \GLOBALS & \globaltype^\ast, \\
         & \LOCALS & \valtype^\ast, \\
-        & \LABELS & \resulttype^\ast ~\} \\
+        & \LABELS & \resulttype^\ast, \\
+        & \LRETURN & \resulttype^? ~\} \\
      \end{array}
    \end{array}
 
@@ -79,27 +81,35 @@ In addition to field access :math:`C.\K{field}` the following notation is adopte
    because the :ref:`label index <syntax-labelidx>` space is indexed relatively, that is, in reverse order of addition.
 
 
+.. _valid-notation-textual:
+
 Textual Notation
 ~~~~~~~~~~~~~~~~
 
 Validation is specified by stylised rules for each relevant part of the :ref:`abstract syntax <syntax>`.
 The rules not only state constraints defining when a phrase is valid,
 they also classify it with a type.
-A phrase :math:`A` is said to be "valid with type :math:`T`",
-if all constraints expressed by the respective rules are met.
-The form of :math:`T` depends on what :math:`A` is.
+The following conventions are adopted in stating these rules.
 
-.. note::
-   For example, if :math:`A` is a :ref:`function <syntax-func>`,
-   then  :math:`T` is a :ref:`function type <syntax-functype>`;
-   for an :math:`A` that is a :ref:`global <syntax-global>`,
-   :math:`T` is a :ref:`global type <syntax-globaltype>`;
-   and so on.
+* A phrase :math:`A` is said to be "valid with type :math:`T`"
+  if and only if all constraints expressed by the respective rules are met.
+  The form of :math:`T` depends on what :math:`A` is.
 
-The rules implicitly assume a given :ref:`context <context>` :math:`C`.
-In some places, this context is locally extended to a context :math:`C'` with additional entries.
-The formulation "Under context :math:`C'`, ... *statement* ..." is adopted to express that the following statement must apply under the assumptions embodied in the extended context.
+  .. note::
+     For example, if :math:`A` is a :ref:`function <syntax-func>`,
+     then  :math:`T` is a :ref:`function type <syntax-functype>`;
+     for an :math:`A` that is a :ref:`global <syntax-global>`,
+     :math:`T` is a :ref:`global type <syntax-globaltype>`;
+     and so on.
 
+* The rules implicitly assume a given :ref:`context <context>` :math:`C`.
+
+* In some places, this context is locally extended to a context :math:`C'` with additional entries.
+  The formulation "Under context :math:`C'`, ... *statement* ..." is adopted to express that the following statement must apply under the assumptions embodied in the extended context.
+
+
+.. _valid-notation:
+.. index:: ! typing rules
 
 Formal Notation
 ~~~~~~~~~~~~~~~
@@ -129,7 +139,7 @@ The conclusion always is a judgment :math:`C \vdash A : T`,
 and there is one respective rule for each relevant construct :math:`A` of the abstract syntax.
 
 .. note::
-   For example, the typing rule for the :ref:`instruction <syntax-instr-numeric>` :math:`\I32.\ADD` can be given as an axiom:
+   For example, the typing rule for the :math:`\I32.\ADD` instruction can be given as an axiom:
 
    .. math::
       \frac{
@@ -145,7 +155,7 @@ and there is one respective rule for each relevant construct :math:`A` of the ab
 
    .. math::
       \frac{
-        C.\LOCAL[x] = t
+        C.\LOCALS[x] = t
       }{
         C \vdash \GETLOCAL~x : [] \to [t]
       }
@@ -153,7 +163,7 @@ and there is one respective rule for each relevant construct :math:`A` of the ab
    Here, the premise enforces that the immediate :ref:`local index <syntax-localidx>` :math:`x` exists in the context.
    The instruction produces a value of its respective type :math:`t`
    (and does not consume any values).
-   If :math:`C.\LOCAL[x]` does not exist then the premise does not hold,
+   If :math:`C.\LOCALS[x]` does not exist then the premise does not hold,
    and the instruction is ill-typed.
 
    Finally, a :ref:`structured <syntax-instr-control>` instruction requires

--- a/document/validation/instructions.rst
+++ b/document/validation/instructions.rst
@@ -70,65 +70,9 @@ In both cases, the unconstrained types or type sequences can be chosen arbitrari
 Numeric Instructions
 ~~~~~~~~~~~~~~~~~~~~
 
-In this section, the following grammar shorthands are adopted:
-
-.. math::
-   \begin{array}{llll}
-   \production{unary operators} & \unop &::=&
-     \CLZ ~|~
-     \CTZ ~|~
-     \POPCNT ~|~
-     \ABS ~|~
-     \NEG ~|~
-     \SQRT ~|~
-     \CEIL ~|~
-     \FLOOR ~|~
-     \TRUNC ~|~
-     \NEAREST \\
-   \production{binary operators} & \binop &::=&
-     \ADD ~|~
-     \SUB ~|~
-     \MUL ~|~
-     \DIV ~|~
-     \DIV\K{\_}\sx ~|~
-     \REM\K{\_}\sx ~|~
-     \FMIN ~|~
-     \FMAX ~|~
-     \COPYSIGN ~|~ \\&&&
-     \AND ~|~
-     \OR ~|~
-     \XOR ~|~
-     \SHL ~|~
-     \SHR\K{\_}\sx ~|~
-     \ROTL ~|~
-     \ROTR \\
-   \production{test operators} & \testop &::=&
-     \EQZ \\
-   \production{relational operators} & \relop &::=&
-     \EQ ~|~
-     \NE ~|~
-     \LT ~|~
-     \GT ~|~
-     \LE ~|~
-     \GE ~|~
-     \LT\K{\_}\sx ~|~
-     \GT\K{\_}\sx ~|~
-     \LE\K{\_}\sx ~|~
-     \GE\K{\_}\sx \\
-   \production{conversion operators} & \cvtop &::=&
-     \WRAP ~|~
-     \EXTEND\K{\_}\sx ~|~
-     \TRUNC\K{\_}\sx ~|~
-     \CONVERT\K{\_}\sx ~|~
-     \DEMOTE ~|~
-     \PROMOTE ~|~
-     \REINTERPRET \\
-   \end{array}
-
-
 .. _valid-const:
 
-:math:`t \K{.const}~c`
+:math:`t\K{.}\CONST~c`
 ......................
 
 * The instruction is valid with type :math:`[] \to [t]`.
@@ -136,7 +80,7 @@ In this section, the following grammar shorthands are adopted:
 .. math::
    \frac{
    }{
-     C \vdash t\K{.const}~c : [] \to [t]
+     C \vdash t\K{.}\CONST~c : [] \to [t]
    }
 
 
@@ -321,7 +265,7 @@ Variable Instructions
 
 * The global :math:`C.\GLOBALS[x]` must be defined in the context.
 
-* Let :math:`\mut~t` be the :ref:`value type <syntax-globaltype>` :math:`C.\LOCALS[x]`.
+* Let :math:`\mut~t` be the :ref:`global type <syntax-globaltype>` :math:`C.\GLOBALS[x]`.
 
 * Then the instruction is valid with type :math:`[] \to [t]`.
 
@@ -342,13 +286,13 @@ Variable Instructions
 
 * Let :math:`\mut~t` be the :ref:`global type <syntax-globaltype>` :math:`C.\GLOBALS[x]`.
 
-* The mutability :math:`\mut` must be |MUT|.
+* The mutability :math:`\mut` must be |MVAR|.
 
 * Then the instruction is valid with type :math:`[t] \to []`.
 
 .. math::
    \frac{
-     C.\GLOBALS[x] = \MUT~t
+     C.\GLOBALS[x] = \MVAR~t
    }{
      C \vdash \SETGLOBAL~x : [t] \to []
    }
@@ -365,8 +309,8 @@ Memory Instructions
 
 .. _valid-load:
 
-:math:`t\K{.load}~\memarg`
-..........................
+:math:`t\K{.}\LOAD~\memarg`
+...........................
 
 * The memory :math:`C.\MEMS[0]` must be defined in the context.
 
@@ -386,8 +330,8 @@ Memory Instructions
 
 .. _valid-loadn:
 
-:math:`t\K{.load}N\K{\_}\sx~\memarg`
-....................................
+:math:`t\K{.}\LOAD{N}\K{\_}\sx~\memarg`
+.......................................
 
 * The memory :math:`C.\MEMS[0]` must be defined in the context.
 
@@ -407,8 +351,8 @@ Memory Instructions
 
 .. _valid-store:
 
-:math:`t\K{.store}~\memarg`
-...........................
+:math:`t\K{.}\STORE~\memarg`
+............................
 
 * The memory :math:`C.\MEMS[0]` must be defined in the context.
 
@@ -428,8 +372,8 @@ Memory Instructions
 
 .. _valid-storen:
 
-:math:`t\K{.store}N~\memarg`
-............................
+:math:`t\K{.}\STORE{N}~\memarg`
+...............................
 
 * The memory :math:`C.\MEMS[0]` must be defined in the context.
 
@@ -674,21 +618,25 @@ Control Instructions
 :math:`\RETURN`
 ...............
 
-* The label vector :math:`C.\LABELS` must not be empty in the context.
+* The return type :math:`C.\LRETURN` must not be empty in the context.
 
-* Let :math:`[t^?]` be the :ref:`result type <syntax-resulttype>` that is the last element of :math:`C.\LABELS`.
+* Let :math:`[t^?]` be the :ref:`result type <syntax-resulttype>` of :math:`C.\LRETURN`.
 
 * Then the instruction is valid with type :math:`[t_1^\ast~t^?] \to [t_2^\ast]`, for any sequences of :ref:`value types <syntax-valtype>` :math:`t_1^\ast` and :math:`t_2^\ast`.
 
 .. math::
    \frac{
-     C.\LABELS[|C.\LABELS|-1] = [t^?]
+     C.\LRETURN = [t^?]
    }{
      C \vdash \RETURN : [t_1^\ast~t^?] \to [t_2^\ast]
    }
 
 .. note::
    The |RETURN| instruction is :ref:`stack-polymorphic <polymorphism>`.
+
+   :math:`C.\LRETURN` is empty (:math:`\epsilon`) when validating an expression that is not a function body.
+   This differs from it being set to the empty result type (:math:`[]`),
+   which is the case for functions not returning anything.
 
 
 .. _valid-call:
@@ -734,7 +682,7 @@ Control Instructions
 
 
 .. _valid-instr-seq:
-.. index:: instruction
+.. index:: instruction, instruction sequence
 
 Instruction Sequences
 ~~~~~~~~~~~~~~~~~~~~~

--- a/document/validation/modules.rst
+++ b/document/validation/modules.rst
@@ -51,9 +51,11 @@ Functions :math:`\func` are classified by :ref:`function types <syntax-functype>
 * Let :math:`C'` be the same :ref:`context <context>` as :math:`C`,
   but with:
 
-  * the |LOCALS| set to the sequence of :ref:`value types <syntax-valtype>` :math:`t_1^\ast~t^\ast`, concatenating parameters and locals,
+  * |LOCALS| set to the sequence of :ref:`value types <syntax-valtype>` :math:`t_1^\ast~t^\ast`, concatenating parameters and locals,
 
-  * the |LABELS| set to the singular sequence containing only :ref:`result type <syntax-valtype>` :math:`[t_2^\ast]`.
+  * |LABELS| set to the singular sequence containing only :ref:`result type <syntax-valtype>` :math:`[t_2^\ast]`.
+
+  * |LRETURN| set to the :ref:`result type <syntax-valtype>` :math:`[t_2^\ast]`.
 
 * Under the context :math:`C'`,
   the expression :math:`\expr` must be valid with type :math:`t_2^\ast`.
@@ -64,7 +66,7 @@ Functions :math:`\func` are classified by :ref:`function types <syntax-functype>
    \frac{
      C.\TYPES[x] = [t_1^\ast] \to [t_2^?]
      \qquad
-     C,\LOCALS\,t_1^\ast~t^\ast,\LABELS~[t_2^?] \vdash \expr : [t_2^?]
+     C,\LOCALS\,t_1^\ast~t^\ast,\LRETURN~[t_2^?] \vdash \expr : [t_2^?]
    }{
      C \vdash \{ \TYPE~x, \LOCALS~t^\ast, \BODY~\expr \} : [t_1^\ast] \to [t_2^?]
    }
@@ -343,13 +345,13 @@ Export descriptions :math:`\exportdesc` are not classified by any type.
 
 * Let :math:`\mut~t` be the :ref:`global type <syntax-globaltype>` :math:`C.\GLOBALS[x]`.
 
-* The mutability :math:`\mut` must be |CONST|.
+* The mutability :math:`\mut` must be |MCONST|.
 
 * Then the export description is valid.
 
 .. math::
    \frac{
-     C.\GLOBALS[x] = \CONST~t
+     C.\GLOBALS[x] = \MCONST~t
    }{
      C \vdash \GLOBAL~x ~\F{ok}
    }
@@ -436,14 +438,14 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
 :math:`\GLOBAL~\mut~t`
 ......................
 
-* The mutability :math:`\mut` must be |CONST|.
+* The mutability :math:`\mut` must be |MCONST|.
 
 * Then the import description is valid with type :math:`\GLOBAL~t`.
 
 .. math::
    \frac{
    }{
-     C \vdash \GLOBAL~\CONST~t : \GLOBAL~\CONST~t
+     C \vdash \GLOBAL~\MCONST~t : \GLOBAL~\MCONST~t
    }
 
 
@@ -481,6 +483,8 @@ Instead, the context :math:`C` for validation of the module's content is constru
   * :math:`C.\LOCALS` is empty,
 
   * :math:`C.\LABELS` is empty.
+
+  * :math:`C.\LRETURN` is empty.
 
 * Under the context :math:`C`:
 
@@ -530,7 +534,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \quad
      (C \vdash \mem : \X{mt})^\ast
      \quad
-     (C_i \vdash \global : \X{gt})_i^\ast
+     (C' \vdash \global : \X{gt})^\ast
      \\
      (C \vdash \elem ~\F{ok})^\ast
      \quad
@@ -552,13 +556,13 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \\
      C = \{ \TYPES~\functype^\ast, \FUNCS~\X{ift}^\ast~\X{ft}^\ast, \TABLES~\X{itt}^\ast~\X{tt}^\ast, \MEMS~\X{imt}^\ast~\X{mt}^\ast, \GLOBALS~\X{igt}^\ast~\X{gt}^\ast \}
      \\
+     C' = \{ \GLOBALS~\X{igt}^\ast \}
+     \qquad
      |C.\TABLES| \leq 1
      \qquad
      |C.\MEMS| \leq 1
      \qquad
      \name^\ast ~\F{disjoint}
-     \qquad
-     (C_i = \{ \GLOBALS~[\X{igt}^\ast~\X{gt}^{i-1}] \})_i^\ast
      \end{array}
    }{
      \vdash \{
@@ -585,7 +589,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
    All types needed to construct :math:`C` can easily be determined from a simple pre-pass over the module that does not perform any actual validation.
 
    Globals, however, are not recursive.
-   The effect of defining the limited contexts :math:`C_i` for validating the module's globals is that their initialization expressions can only access imported and previously defined globals and nothing else.
+   The effect of defining the limited context :math:`C'` for validating the module's globals is that their initialization expressions can only access imported globals and nothing else.
 
 .. note::
    The restriction on the number of tables and memories may be lifted in future versions of WebAssembly.


### PR DESCRIPTION
First stab at of the execution semantics. Describes conventions, runtime structures, and the semantics of instructions. Still missing: the description of the numeric operations and the instantiation/linking of modules. Various other tweaks included.

Preview at https://webassembly.github.io/spec/