### PR TITLE
A^+ description changed

### DIFF
--- a/syntax/conventions.html
+++ b/syntax/conventions.html
@@ -113,7 +113,7 @@ including the decoding of the <a class="reference internal" href="../binary/inde
 <li><span class="math">\(A^n\)</span> is a sequence of <span class="math">\(n\geq 0\)</span> iterations  of <span class="math">\(A\)</span>.</li>
 <li><span class="math">\(A^\ast\)</span> is a possibly empty sequence of iterations of <span class="math">\(A\)</span>.
 (This is a shorthand for <span class="math">\(A^n\)</span> used where <span class="math">\(n\)</span> is not relevant.)</li>
-<li><span class="math">\(A^+\)</span> is a possibly empty sequence of iterations of <span class="math">\(A\)</span>.
+<li><span class="math">\(A^+\)</span> is a non empty sequence of iterations of <span class="math">\(A\)</span>.
 (This is a shorthand for <span class="math">\(A^n\)</span> where <span class="math">\(n \geq 1\)</span>.)</li>
 <li><span class="math">\(A^?\)</span> is an optional occurrence of <span class="math">\(A\)</span>.
 (This is a shorthand for <span class="math">\(A^n\)</span> where <span class="math">\(n \leq 1\)</span>.)</li>


### PR DESCRIPTION
A^+ can not be empty, so the description as "...possibly empty sequence of iterations..." was changed to "...non empty sequence of iterations..."