### PR TITLE
[spec] Allow impls to limit code point range

### DIFF
--- a/document/appendix/implementation.rst
+++ b/document/appendix/implementation.rst
@@ -51,9 +51,16 @@ An implementation may impose restrictions on the following dimensions of a modul
 * the length of an :ref:`element segment <syntax-elem>`
 * the length of a :ref:`data segment <syntax-data>`
 * the length of a :ref:`name <syntax-name>`
+* the range of :ref:`code points <syntax-codepoint>` in a :ref:`name <syntax-name>`
 
 If the limits of an implementation are exceeded for a given module,
 then the implementation may reject the :ref:`validation <valid>`, compilation, or :ref:`instantiation <exec-instantiate>` of that module with an embedder-specific error.
+
+.. note::
+   The last item allows embedders that operate in limited environments without support for
+   `Unicode <http://www.unicode.org/versions/latest/>`_ to limit the
+   names of :ref:`imports <syntax-import>` and :ref:`exports <syntax-export>`
+   to common subsets like `ASCII <http://webstore.ansi.org/RecordDetail.aspx?sku=INCITS+4-1986%5bR2012%5d>`_.
 
 
 .. _impl-binary:
@@ -83,6 +90,7 @@ For a module given in :ref:`text format <text>`, additional limitations may be i
 * the size of an individual :ref:`token <text-token>`
 * the nesting depth of :ref:`folded instructions <text-foldedinstr>`
 * the length of symbolic :ref:`identifiers <text-id>`
+* the range of literal :ref:`characters <text-char>` (code points) allowed in the :ref:`source text <source>`
 
 
 .. _impl-valid:


### PR DESCRIPTION
As discussed on https://github.com/WebAssembly/design/pull/1016, make it legal for implementations in environments that do not understand (all of) Unicode to only support smaller character subsets.