### PR TITLE
Test Harness wasm-module-builder.js allow long sections

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -74,7 +74,9 @@ class Binary extends Array {
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    this.push(...section);
+    for (let i = 0; i < section.length; ++i) {
+      this.push(section[i]);
+    }
   }
 }
 

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -74,8 +74,8 @@ class Binary extends Array {
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    for (let i = 0; i < section.length; ++i) {
-      this.push(section[i]);
+    for (const sectionByte of section) {
+      this.push(sectionByte);
     }
   }
 }


### PR DESCRIPTION
Spreading the section into arguments can become too long for some engines.