### PR TITLE
Make WasmFunctionBuilder.end() append the end opcode

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -107,6 +107,7 @@ class WasmFunctionBuilder {
   }
 
   end() {
+    this.body.push(kExprEnd);
     return this.module;
   }
 }


### PR DESCRIPTION
Initially as I read the api, I thought the `end` method would well end the function, but all it does is return the module builder (which is nice for chaining).

This change simplifies how to make empty function also
```js
const builder = new WasmModuleBuilder();
builder.addFunction(null, kSig_v_v).end().instantiate();
```
instead of
```js
const builder = new WasmModuleBuilder();
builder.addFunction(null, kSig_v_v).addBody([kExprEnd]).end().instantiate();
```

This changes the behavior of the `end` method and I don't know if someone else depends on this behavior, but I checked in this repo and `end` is not used
