### PR TITLE
Test Harness wasm-module-builder.js fix table index segment

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -426,9 +426,9 @@ class WasmModuleBuilder {
       binary.emit_section(kElementSectionCode, section => {
         var inits = wasm.function_table_inits;
         section.emit_u32v(inits.length);
-        section.emit_u8(0); // table index
 
         for (let init of inits) {
+          section.emit_u8(0); // table index
           if (init.is_global) {
             section.emit_u8(kExprGetGlobal);
           } else {


### PR DESCRIPTION
 The table index for table segments must be emitted before each segments as documented in https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#element-section