### PR TITLE
Fix result syntax

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -26,12 +26,13 @@ JS =		# set to JS shell command to run JS tests
 
 # Main targets
 
-.PHONY:		unopt opt libunopt libopt all land zip
+.PHONY:		default opt unopt libopt libunopt all land zip
 
-unopt:		$(UNOPT)
+default:	opt
 opt:		$(OPT)
-libunopt:	_build/$(LIB).cmo
+unopt:		$(UNOPT)
 libopt:		_build/$(LIB).cmx
+libunopt:	_build/$(LIB).cmo
 all:		unopt opt libunopt libopt test
 land:		all $(WINMAKE)
 zip: 		$(ZIP)

--- a/test/core/func.wast
+++ b/test/core/func.wast
@@ -34,7 +34,7 @@
 
   (func $complex
     (param i32 f32) (param $x i64) (param) (param i32)
-    (result i32)
+    (result) (result i32) (result)
     (local f32) (local $y i32) (local i64 i32) (local) (local f64 i32)
     (unreachable) (unreachable)
   )

--- a/test/core/type.wast
+++ b/test/core/type.wast
@@ -1,0 +1,50 @@
+;; Test type definitions
+
+(module
+  (type (func))
+  (type $t (func))
+
+  (type (func (param i32)))
+  (type (func (param $x i32)))
+  (type (func (result i32)))
+  (type (func (param i32) (result i32)))
+  (type (func (param $x i32) (result i32)))
+
+  (type (func (param f32 f64)))
+  (type (func (result i64 f32)))
+  (type (func (param i32 i64) (result f32 f64)))
+
+  (type (func (param f32) (param f64)))
+  (type (func (param $x f32) (param f64)))
+  (type (func (param f32) (param $y f64)))
+  (type (func (param $x f32) (param $y f64)))
+  (type (func (result i64) (result f32)))
+  (type (func (param i32) (param i64) (result f32) (result f64)))
+  (type (func (param $x i32) (param $y i64) (result f32) (result f64)))
+
+  (type (func (param f32 f64) (param $x i32) (param f64 i32 i32)))
+  (type (func (result i64 i64 f32) (result f32 i32)))
+  (type
+    (func (param i32 i32) (param i64 i32) (result f32 f64) (result f64 i32))
+  )
+
+  (type (func (param) (param $x f32) (param) (param) (param f64 i32) (param)))
+  (type
+    (func (result) (result) (result i64 i64) (result) (result f32) (result))
+  )
+  (type
+    (func
+      (param i32 i32) (param i64 i32) (param) (param $x i32) (param)
+      (result) (result f32 f64) (result f64 i32) (result)
+    )
+  )
+)
+
+(assert_malformed
+  (module quote "(type (result i32) (param i32))")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(type (result $x i32))")
+  "unexpected token"
+)


### PR DESCRIPTION
Fix spec deviations:

- allow multiple results in function defs
- disallow multiple results in block sig

This is consistent with the spec document and the binary format.