### PR TITLE
Remove odd tests

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -14,6 +14,8 @@
  * limitations under the License.
 */
 
+const kC0DEFEFE = new Uint8Array([0xC0, 0xDE, 0xFE, 0xFE]);
+
 (function testJSAPI() {
 
 const WasmPage = 64 * 1024;
@@ -686,7 +688,7 @@ assertCompileError([1], TypeError);
 assertCompileError([{}], TypeError);
 assertCompileError([new Uint8Array()], CompileError);
 assertCompileError([new ArrayBuffer()], CompileError);
-assertCompileError([new Uint8Array([0xC0, 0xDE, 0xFE, 0xFE]), CompileError);
+assertCompileError([kC0DEFEFE], CompileError);
 
 num_tests = 1;
 function assertCompileSuccess(bytes) {
@@ -734,7 +736,7 @@ test(() => {
     assertInstantiateError([{}], TypeError);
     assertInstantiateError([new Uint8Array()], CompileError);
     assertInstantiateError([new ArrayBuffer()], CompileError);
-    assertInstantiateError([new Uint8Array([0xC0, 0xDE, 0xFE, 0xFE]), CompileError);
+    assertInstantiateError([kC0DEFEFE], CompileError);
     assertInstantiateError([importingModule], TypeError);
     assertInstantiateError([importingModule, null], TypeError);
     assertInstantiateError([importingModuleBinary, null], TypeError);

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -686,6 +686,7 @@ assertCompileError([1], TypeError);
 assertCompileError([{}], TypeError);
 assertCompileError([new Uint8Array()], CompileError);
 assertCompileError([new ArrayBuffer()], CompileError);
+assertCompileError([new Uint8Array([0xC0, 0xDE, 0xFE, 0xFE]), CompileError);
 
 num_tests = 1;
 function assertCompileSuccess(bytes) {
@@ -733,6 +734,7 @@ test(() => {
     assertInstantiateError([{}], TypeError);
     assertInstantiateError([new Uint8Array()], CompileError);
     assertInstantiateError([new ArrayBuffer()], CompileError);
+    assertInstantiateError([new Uint8Array([0xC0, 0xDE, 0xFE, 0xFE]), CompileError);
     assertInstantiateError([importingModule], TypeError);
     assertInstantiateError([importingModule, null], TypeError);
     assertInstantiateError([importingModuleBinary, null], TypeError);

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -733,8 +733,6 @@ test(() => {
     assertInstantiateError([{}], TypeError);
     assertInstantiateError([new Uint8Array()], CompileError);
     assertInstantiateError([new ArrayBuffer()], CompileError);
-    assertInstantiateError([new Uint8Array("hi!")], CompileError);
-    assertInstantiateError([new ArrayBuffer("hi!")], CompileError);
     assertInstantiateError([importingModule], TypeError);
     assertInstantiateError([importingModule, null], TypeError);
     assertInstantiateError([importingModuleBinary, null], TypeError);

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -686,8 +686,6 @@ assertCompileError([1], TypeError);
 assertCompileError([{}], TypeError);
 assertCompileError([new Uint8Array()], CompileError);
 assertCompileError([new ArrayBuffer()], CompileError);
-assertCompileError([new Uint8Array("hi!")], CompileError);
-assertCompileError([new ArrayBuffer("hi!")], CompileError);
 
 num_tests = 1;
 function assertCompileSuccess(bytes) {


### PR DESCRIPTION
These two tests don't make much sense to me because the string argument invokes the `length` constructor of `TypedArray`:
https://tc39.github.io/ecma262/#sec-typedarray-length
This then goes ToIndex / ToInteger etc, and the string becomes an integer.

What's the point of this test?