### PR TITLE
Test js-api: add memory.grow test

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -101,7 +101,7 @@ class WasmFunctionBuilder {
   addBody(body) {
     for (let b of body) {
       if (typeof b !== 'number' || (b & (~0xFF)) !== 0 )
-        throw new Error('invalid body (entries have to be 8bit numbers): ' + body);
+        throw new Error('invalid body (entries have to be 8 bit numbers): ' + body);
     }
     this.body = body.slice();
     // Automatically add the end for the function block to the body.

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -100,8 +100,8 @@ class WasmFunctionBuilder {
 
   addBody(body) {
     for (let b of body) {
-      if (typeof b != 'number')
-        throw new Error('invalid body (entries have to be numbers): ' + body);
+      if (typeof b !== 'number' || (b & (~0xFF)) !== 0 )
+        throw new Error('invalid body (entries have to be 8bit numbers): ' + body);
     }
     this.body = body.slice();
     // Automatically add the end for the function block to the body.
@@ -115,7 +115,6 @@ class WasmFunctionBuilder {
   }
 
   end() {
-    this.body.push(kExprEnd);
     return this.module;
   }
 }

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -485,12 +485,12 @@ test(() => {
     var buf = mem.buffer;
     assert_equals(buf.byteLength, WasmPage);
     assert_equals(mem.grow(0), 1);
-    assert_equals(buf !== mem.buffer, true);
+    assert_not_equals(buf, mem.buffer)
     assert_equals(buf.byteLength, 0);
     buf = mem.buffer;
     assert_equals(buf.byteLength, WasmPage);
     assert_equals(mem.grow(1), 1);
-    assert_equals(buf !== mem.buffer, true);
+    assert_not_equals(buf, mem.buffer)
     assert_equals(buf.byteLength, 0);
     buf = mem.buffer;
     assert_equals(buf.byteLength, 2 * WasmPage);
@@ -500,7 +500,7 @@ test(() => {
     buf = mem.buffer;
     assert_equals(buf.byteLength, 0);
     assert_equals(mem.grow(0), 0);
-    assert_equals(buf !== mem.buffer, true);
+    assert_not_equals(buf, mem.buffer)
     assert_equals(buf.byteLength, 0);
     assert_equals(mem.buffer.byteLength, 0);
 }, "'WebAssembly.Memory.prototype.grow' method");

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -496,6 +496,13 @@ test(() => {
     assert_equals(buf.byteLength, 2 * WasmPage);
     assertThrows(() => mem.grow(1), Error);
     assert_equals(buf, mem.buffer);
+    mem = new Memory({initial:0, maximum:1});
+    buf = mem.buffer;
+    assert_equals(buf.byteLength, 0);
+    assert_equals(mem.grow(0), 0);
+    assert_equals(buf !== mem.buffer, true);
+    assert_equals(buf.byteLength, 0);
+    assert_equals(mem.buffer.byteLength, 0);
 }, "'WebAssembly.Memory.prototype.grow' method");
 
 test(() => {


### PR DESCRIPTION
Removed pushing `end` opcode on `.end()` since `.addBody()` now does it too.
Added test `Memory.prototype.grow(0)` with initial size 0