### PR TITLE
[interpreter/test] Fix symbolic forward references and change inline type expansion

### DIFF
--- a/test/core/func.wast
+++ b/test/core/func.wast
@@ -31,6 +31,7 @@
   (func (result i32) (unreachable))
 
   (func (type $sig))
+  (func (type $empty-sig-duplicate))  ;; forward reference
 
   (func $complex
     (param i32 f32) (param $x i64) (param) (param i32)
@@ -157,12 +158,15 @@
   (func $empty-sig-2)  ;; should be assigned type $sig
   (func $complex-sig-2 (param f64 i64 f64 i64 f64 i64 f32 i32))
   (func $complex-sig-3 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-4 (param i64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-5 (param i64 i64 f64 i64 f64 i64 f32 i32))
 
   (type $empty-sig-duplicate (func))
-  (type $complex-sig-duplicate (func (param f64 i64 f64 i64 f64 i64 f32 i32)))
+  (type $complex-sig-duplicate (func (param i64 i64 f64 i64 f64 i64 f32 i32)))
   (table anyfunc
     (elem
       $complex-sig-3 $empty-sig-2 $complex-sig-1 $complex-sig-3 $empty-sig-1
+      $complex-sig-4 $complex-sig-5
     )
   )
 
@@ -172,19 +176,19 @@
   )
 
   (func (export "signature-implicit-reused")
-    ;; The implicit index 16 in this test depends on the function and
+    ;; The implicit index 18 in this test depends on the function and
     ;; type definitions, and may need adapting if they change.
-    (call_indirect 16
+    (call_indirect 18
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 0)
     )
-    (call_indirect 16
+    (call_indirect 18
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 2)
     )
-    (call_indirect 16
+    (call_indirect 18
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 3)
@@ -197,9 +201,14 @@
 
   (func (export "signature-implicit-duplicate")
     (call_indirect $complex-sig-duplicate
-      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 0)
+      (i32.const 5)
+    )
+    (call_indirect $complex-sig-duplicate
+      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 6)
     )
   )
 )

--- a/test/core/func.wast
+++ b/test/core/func.wast
@@ -31,7 +31,7 @@
   (func (result i32) (unreachable))
 
   (func (type $sig))
-  (func (type $empty-sig-duplicate))  ;; forward reference
+  (func (type $forward))  ;; forward reference
 
   (func $complex
     (param i32 f32) (param $x i64) (param) (param i32)
@@ -45,6 +45,7 @@
     (unreachable) (unreachable)
   )
 
+  (type $forward (func))
 
   ;; Typing of locals
 
@@ -150,67 +151,6 @@
   (func (export "init-local-i64") (result i64) (local i64) (get_local 0))
   (func (export "init-local-f32") (result f32) (local f32) (get_local 0))
   (func (export "init-local-f64") (result f64) (local f64) (get_local 0))
-
-
-  ;; Desugaring of implicit type signature
-  (func $empty-sig-1)  ;; should be assigned type $sig
-  (func $complex-sig-1 (param f64 i64 f64 i64 f64 i64 f32 i32))
-  (func $empty-sig-2)  ;; should be assigned type $sig
-  (func $complex-sig-2 (param f64 i64 f64 i64 f64 i64 f32 i32))
-  (func $complex-sig-3 (param f64 i64 f64 i64 f64 i64 f32 i32))
-  (func $complex-sig-4 (param i64 i64 f64 i64 f64 i64 f32 i32))
-  (func $complex-sig-5 (param i64 i64 f64 i64 f64 i64 f32 i32))
-
-  (type $empty-sig-duplicate (func))
-  (type $complex-sig-duplicate (func (param i64 i64 f64 i64 f64 i64 f32 i32)))
-  (table anyfunc
-    (elem
-      $complex-sig-3 $empty-sig-2 $complex-sig-1 $complex-sig-3 $empty-sig-1
-      $complex-sig-4 $complex-sig-5
-    )
-  )
-
-  (func (export "signature-explicit-reused")
-    (call_indirect $sig (i32.const 1))
-    (call_indirect $sig (i32.const 4))
-  )
-
-  (func (export "signature-implicit-reused")
-    ;; The implicit index 18 in this test depends on the function and
-    ;; type definitions, and may need adapting if they change.
-    (call_indirect 18
-      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
-      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 0)
-    )
-    (call_indirect 18
-      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
-      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 2)
-    )
-    (call_indirect 18
-      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
-      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 3)
-    )
-  )
-
-  (func (export "signature-explicit-duplicate")
-    (call_indirect $empty-sig-duplicate (i32.const 1))
-  )
-
-  (func (export "signature-implicit-duplicate")
-    (call_indirect $complex-sig-duplicate
-      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
-      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 5)
-    )
-    (call_indirect $complex-sig-duplicate
-      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
-      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
-      (i32.const 6)
-    )
-  )
 )
 
 (assert_return (invoke "local-first-i32") (i32.const 0))
@@ -313,6 +253,98 @@
 (assert_return (invoke "init-local-i64") (i64.const 0))
 (assert_return (invoke "init-local-f32") (f32.const 0))
 (assert_return (invoke "init-local-f64") (f64.const 0))
+
+
+;; Expansion of inline function types
+
+(module
+  (func $f (result f64) (f64.const 0))  ;; adds implicit type definition
+  (func $g (param i32))                 ;; reuses explicit type definition
+  (type $t (func (param i32)))
+
+  (func $i32->void (type 0))                ;; (param i32)
+  (func $void->f64 (type 1) (f64.const 0))  ;; (result f64)
+  (func $check
+    (call $i32->void (i32.const 0))
+    (drop (call $void->f64))
+  )
+)
+
+(assert_invalid
+  (module
+    (func $f (result f64) (f64.const 0))  ;; adds implicit type definition
+    (func $g (param i32))                 ;; reuses explicit type definition
+    (func $h (result f64) (f64.const 1))  ;; reuses implicit type definition
+    (type $t (func (param i32)))
+
+    (func (type 2))  ;; does not exist
+  )
+  "unknown type"
+)
+
+
+(module
+  (type $sig (func))
+
+  (func $empty-sig-1)  ;; should be assigned type $sig
+  (func $complex-sig-1 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $empty-sig-2)  ;; should be assigned type $sig
+  (func $complex-sig-2 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-3 (param f64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-4 (param i64 i64 f64 i64 f64 i64 f32 i32))
+  (func $complex-sig-5 (param i64 i64 f64 i64 f64 i64 f32 i32))
+
+  (type $empty-sig-duplicate (func))
+  (type $complex-sig-duplicate (func (param i64 i64 f64 i64 f64 i64 f32 i32)))
+  (table anyfunc
+    (elem
+      $complex-sig-3 $empty-sig-2 $complex-sig-1 $complex-sig-3 $empty-sig-1
+      $complex-sig-4 $complex-sig-5
+    )
+  )
+
+  (func (export "signature-explicit-reused")
+    (call_indirect $sig (i32.const 1))
+    (call_indirect $sig (i32.const 4))
+  )
+
+  (func (export "signature-implicit-reused")
+    ;; The implicit index 3 in this test depends on the function and
+    ;; type definitions, and may need adapting if they change.
+    (call_indirect 3
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 0)
+    )
+    (call_indirect 3
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 2)
+    )
+    (call_indirect 3
+      (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 3)
+    )
+  )
+
+  (func (export "signature-explicit-duplicate")
+    (call_indirect $empty-sig-duplicate (i32.const 1))
+  )
+
+  (func (export "signature-implicit-duplicate")
+    (call_indirect $complex-sig-duplicate
+      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 5)
+    )
+    (call_indirect $complex-sig-duplicate
+      (i64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
+      (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
+      (i32.const 6)
+    )
+  )
+)
 
 (assert_return (invoke "signature-explicit-reused"))
 (assert_return (invoke "signature-implicit-reused"))

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -47,6 +47,10 @@
   (func (export "p5") (import "spectest" "print") (type 0))
   (func (export "p6") (import "spectest" "print") (type 0) (param i32) (result))
 
+  (import "spectest" "print" (func (type $forward)))
+  (func (import "spectest" "print") (type $forward))
+  (type $forward (func (param i32)))
+
   (table anyfunc (elem $print_i32 $print_f64))
 
   (func (export "print32") (param $i i32)


### PR DESCRIPTION
This PR fixes/changes identifier resolution for the text format:

1. Correctly handle forward references to type definitions, and add tests.
2. Tweak the expansion of inline function types by inserting type definitions at the _end_ of the module.

The latter should hardly affect any existing programs, because it's only observable if a program uses raw numeric type indices _and_ forward-references later type definitions with them.

See [comment below](https://github.com/WebAssembly/spec/pull/512#issuecomment-311778787) for an example.

DETAILS

All module-level symbolic names are in scope everywhere, but the interpreter did not handle forward references to type definitions correctly, and there were no tests. This PR fixes that, and handles name resolution and AST construction more consistently in 2 passes (apologies that the implementation of this in the parser has become a bit messy over time, I should probably separate it out at some point).

In this context it turned out that the expansion of inline function types was a big issue, because they were inserted in place. That's problematic for at least the following reasons:

- Inline types may or may not create a type definition, so in-place insertion of _implicit_ types has very brittle effects on the effective indices of _explicit_ type definitions following later, which become hard to predict.

- It makes it unnecessarily difficult to correctly define & implement the resolution of forward references to explicit type definitions in general, e.g. when they cross function definitions.

- It would be almost impossible to extend this behaviour cleanly to mutually recursive type definitions, as needed e.g. for GC types (prototyping those were how I stumbled over this issue).

The new behaviour implemented in this PR -- inserting all implicit type definitions, in order, at the end of the module -- is actually consistent with what is stated in the spec draft (which was more by accident than by design). However, the change required adjusting one existing test (in func.wast) that is using raw indices and was relying on the old behaviour, so clearly, other implementations will be affected.