### PR TITLE
Add assert_not_equals to README.md

### DIFF
--- a/test/js-api/README.md
+++ b/test/js-api/README.md
@@ -15,5 +15,5 @@ library.
   a try/catch and maybe asserts in case of failure.
 - A function `promise_test(function, description)` where `function` returns a
   `Promise` run by `promise_test`; a rejection means a failure here.
-- Assertion functions: `assert_equals(x, y)`, `assert_true(x)`,
-  `assert_false(x)`, `assert_unreached()`.
+- Assertion functions: `assert_equals(x, y)`, `assert_not_equals(x, y)`,
+  `assert_true(x)`, `assert_false(x)`, `assert_unreached()`.


### PR DESCRIPTION
Tests with assert_not_equals have been added to the test suite, see test/js-api/jsapi.js.