### PR TITLE
Memory.grow(0) should use strict equality

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -485,7 +485,7 @@ test(() => {
     var buf = mem.buffer;
     assert_equals(buf.byteLength, WasmPage);
     assert_equals(mem.grow(0), 1);
-    assert_not_equals(buf, mem.buffer)
+    assert_true(buf !== mem.buffer)
     assert_equals(buf.byteLength, 0);
     buf = mem.buffer;
     assert_equals(buf.byteLength, WasmPage);
@@ -500,7 +500,7 @@ test(() => {
     buf = mem.buffer;
     assert_equals(buf.byteLength, 0);
     assert_equals(mem.grow(0), 0);
-    assert_not_equals(buf, mem.buffer)
+    assert_true(buf !== mem.buffer)
     assert_equals(buf.byteLength, 0);
     assert_equals(mem.buffer.byteLength, 0);
 }, "'WebAssembly.Memory.prototype.grow' method");


### PR DESCRIPTION
Specifically when memory is initialized with 0 memory, and then grown by zero, use strict equality as the buffers are different only by reference.