### PR TITLE
Update JavaScript WasmModuleBuilder with new functionality.

### DIFF
--- a/test/harness/wasm-constants.js
+++ b/test/harness/wasm-constants.js
@@ -87,7 +87,6 @@ let kWasmI32 = 0x7f;
 let kWasmI64 = 0x7e;
 let kWasmF32 = 0x7d;
 let kWasmF64 = 0x7c;
-let kWasmS128 = 0x7b;
 
 let kExternalFunction = 0;
 let kExternalTable = 1;
@@ -118,7 +117,6 @@ let kSig_v_l = makeSig([kWasmI64], []);
 let kSig_v_d = makeSig([kWasmF64], []);
 let kSig_v_dd = makeSig([kWasmF64, kWasmF64], []);
 let kSig_v_ddi = makeSig([kWasmF64, kWasmF64, kWasmI32], []);
-let kSig_s_v = makeSig([], [kWasmS128]);
 
 function makeSig(params, results) {
   return {params: params, results: results};

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -74,9 +74,7 @@ class Binary extends Array {
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    for (const sectionByte of section) {
-      this.push(sectionByte);
-    }
+    this.push(...section);
   }
 }
 
@@ -86,6 +84,15 @@ class WasmFunctionBuilder {
     this.name = name;
     this.type_index = type_index;
     this.body = [];
+  }
+
+  numLocalNames() {
+    if (this.local_names === undefined) return 0;
+    let num_local_names = 0;
+    for (let loc_name of this.local_names) {
+      if (loc_name !== undefined) ++num_local_names;
+    }
+    return num_local_names;
   }
 
   exportAs(name) {
@@ -100,8 +107,8 @@ class WasmFunctionBuilder {
 
   addBody(body) {
     for (let b of body) {
-      if (typeof b !== 'number' || (b & (~0xFF)) !== 0 )
-        throw new Error('invalid body (entries have to be 8 bit numbers): ' + body);
+      if (typeof b != 'number')
+        throw new Error('invalid body (entries have to be numbers): ' + body);
     }
     this.body = body.slice();
     // Automatically add the end for the function block to the body.
@@ -109,8 +116,14 @@ class WasmFunctionBuilder {
     return this;
   }
 
-  addLocals(locals) {
+  addBodyWithEnd(body) {
+    this.body = body;
+    return this;
+  }
+
+  addLocals(locals, names) {
     this.locals = locals;
+    this.local_names = names;
     return this;
   }
 
@@ -274,6 +287,11 @@ class WasmModuleBuilder {
     return this;
   }
 
+  setName(name) {
+    this.name = name;
+    return this;
+  }
+
   toArray(debug = false) {
     let binary = new Binary;
     let wasm = this;
@@ -333,16 +351,11 @@ class WasmModuleBuilder {
     }
 
     // Add functions declarations
-    let num_function_names = 0;
-    let names = false;
     if (wasm.functions.length > 0) {
       if (debug) print("emitting function decls @ " + binary.length);
       binary.emit_section(kFunctionSectionCode, section => {
         section.emit_u32v(wasm.functions.length);
         for (let func of wasm.functions) {
-          if (func.name !== undefined) {
-            ++num_function_names;
-          }
           section.emit_u32v(func.type_index);
         }
       });
@@ -365,10 +378,9 @@ class WasmModuleBuilder {
       if (debug) print("emitting memory @ " + binary.length);
       binary.emit_section(kMemorySectionCode, section => {
         section.emit_u8(1);  // one memory entry
-        const has_max = wasm.memory.max !== undefined;
-        section.emit_u32v(has_max ? kResizableMaximumFlag : 0);
+        section.emit_u32v(kResizableMaximumFlag);
         section.emit_u32v(wasm.memory.min);
-        if (has_max) section.emit_u32v(wasm.memory.max);
+        section.emit_u32v(wasm.memory.max);
       });
     }
 
@@ -543,19 +555,51 @@ class WasmModuleBuilder {
       binary.emit_bytes(exp);
     }
 
-    // Add function names.
-    if (num_function_names > 0) {
+    // Add names.
+    let num_function_names = 0;
+    let num_functions_with_local_names = 0;
+    for (let func of wasm.functions) {
+      if (func.name !== undefined) ++num_function_names;
+      if (func.numLocalNames() > 0) ++num_functions_with_local_names;
+    }
+    if (num_function_names > 0 || num_functions_with_local_names > 0 ||
+        wasm.name !== undefined) {
       if (debug) print('emitting names @ ' + binary.length);
       binary.emit_section(kUnknownSectionCode, section => {
         section.emit_string('name');
-        section.emit_section(kFunctionNamesCode, name_section => {
-          name_section.emit_u32v(num_function_names);
-          for (let func of wasm.functions) {
-            if (func.name === undefined) continue;
-            name_section.emit_u32v(func.index);
-            name_section.emit_string(func.name);
-          }
-        });
+        // Emit module name.
+        if (wasm.name !== undefined) {
+          section.emit_section(kModuleNameCode, name_section => {
+            name_section.emit_string(wasm.name);
+          });
+        }
+        // Emit function names.
+        if (num_function_names > 0) {
+          section.emit_section(kFunctionNamesCode, name_section => {
+            name_section.emit_u32v(num_function_names);
+            for (let func of wasm.functions) {
+              if (func.name === undefined) continue;
+              name_section.emit_u32v(func.index);
+              name_section.emit_string(func.name);
+            }
+          });
+        }
+        // Emit local names.
+        if (num_functions_with_local_names > 0) {
+          section.emit_section(kLocalNamesCode, name_section => {
+            name_section.emit_u32v(num_functions_with_local_names);
+            for (let func of wasm.functions) {
+              if (func.numLocalNames() == 0) continue;
+              name_section.emit_u32v(func.index);
+              name_section.emit_u32v(func.numLocalNames());
+              for (let i = 0; i < func.local_names.length; ++i) {
+                if (func.local_names[i] === undefined) continue;
+                name_section.emit_u32v(i);
+                name_section.emit_string(func.local_names[i]);
+              }
+            }
+          });
+        }
       });
     }
 
@@ -578,5 +622,9 @@ class WasmModuleBuilder {
     let module = new WebAssembly.Module(this.toBuffer());
     let instance = new WebAssembly.Instance(module, ffi);
     return instance;
+  }
+
+  toModule(debug = false) {
+    return new WebAssembly.Module(this.toBuffer(debug));
   }
 }


### PR DESCRIPTION
The original version of this file was a fork of the V8 module builder. This is just an update with the additional functionality that we have seen fit to add in our tests, including, e.g., the new names section format.