### PR TITLE
Typo: Mutability in global types is mandatory

### DIFF
--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -174,7 +174,7 @@ Global Types
 .. math::
    \begin{array}{llll}
    \production{global type} & \globaltype &::=&
-     \mut^?~\valtype \\
+     \mut~\valtype \\
    \production{mutability} & \mut &::=&
      \MCONST ~|~
      \MVAR \\


### PR DESCRIPTION
This PR fixes a typo in the spec document.