### PR TITLE
[spec] Fix documentation issues around `demote`/`promote`

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -67,7 +67,7 @@ These operations closely match respective operations available in hardware.
      \K{i32.}\WRAP\K{/i64} ~|~
      \K{i64.}\EXTEND\K{\_}\sx/\K{i32} ~|~
      \K{i}\X{nn}\K{.}\TRUNC\K{\_}\sx/\K{f}\X{mm} \\&&|&
-     \K{f32.}\TRUNC\K{/f64} ~|~
+     \K{f32.}\DEMOTE\K{/f64} ~|~
      \K{f64.}\PROMOTE\K{/f32} ~|~
      \K{f}\X{nn}\K{.}\CONVERT\K{\_}\sx/\K{i}\X{mm} \\&&|&
      \K{i}\X{nn}\K{.}\REINTERPRET\K{/f}\X{nn} ~|~

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -402,7 +402,7 @@ Numeric Instructions
      \text{f64.convert\_u/i32} &\Rightarrow& \F64.\CONVERT\K{\_u/}\I32 \\ &&|&
      \text{f64.convert\_s/i64} &\Rightarrow& \F64.\CONVERT\K{\_s/}\I64 \\ &&|&
      \text{f64.convert\_u/i64} &\Rightarrow& \F64.\CONVERT\K{\_u/}\I64 \\ &&|&
-     \text{f64.demote/f32} &\Rightarrow& \F64.\PROMOTE\K{/}\F32 \\ &&|&
+     \text{f64.promote/f32} &\Rightarrow& \F64.\PROMOTE\K{/}\F32 \\ &&|&
      \text{i32.reinterpret/f32} &\Rightarrow& \I32.\REINTERPRET\K{/}\F32 \\ &&|&
      \text{i64.reinterpret/f64} &\Rightarrow& \I64.\REINTERPRET\K{/}\F64 \\ &&|&
      \text{f32.reinterpret/i32} &\Rightarrow& \F32.\REINTERPRET\K{/}\I32 \\ &&|&


### PR DESCRIPTION
- [x] Fix `f32.trunc/f64` to `f32.demote/f64` in <https://webassembly.github.io/spec/syntax/instructions.html#syntax-instr-numeric>
- [x] Fix `f64.demote/f32` to `f64.promote/f32` in <https://webassembly.github.io/spec/text/instructions.html#numeric-instructions>