### PR TITLE
Fix decoding of f64 binary values

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -72,9 +72,8 @@ let u32 s =
   Int32.(add lo (shift_left hi 16))
 
 let u64 s =
-  let u64_of_u32 x = Int64.logand (Int64.of_int32 x) 0x00000000ffffffffL in
-  let lo = u64_of_u32 (u32 s) in
-  let hi = u64_of_u32 (u32 s) in
+  let lo = I64_convert.extend_u_i32 (u32 s) in
+  let hi = I64_convert.extend_u_i32 (u32 s) in
   Int64.(add lo (shift_left hi 32))
 
 let rec vuN n s =

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -72,8 +72,9 @@ let u32 s =
   Int32.(add lo (shift_left hi 16))
 
 let u64 s =
-  let lo = Int64.of_int32 (u32 s) in
-  let hi = Int64.of_int32 (u32 s) in
+  let u64_of_u32 x = Int64.logand (Int64.of_int32 x) 0x00000000ffffffffL in
+  let lo = u64_of_u32 (u32 s) in
+  let hi = u64_of_u32 (u32 s) in
   Int64.(add lo (shift_left hi 32))
 
 let rec vuN n s =

--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -180,6 +180,18 @@
 (assert_return (invoke "f64-hex-sep4") (f64.const 0xf0P+13))
 (assert_return (invoke "f64-hex-sep5") (f64.const 0x2af00a.1f3eep23))
 
+;; Test parsing a float from binary
+(module binary
+  ;; (func (export "4294967249") (result f64) (f64.const 4294967249))
+  "\00\61\73\6d\01\00\00\00\01\85\80\80\80\00\01\60"
+  "\00\01\7c\03\82\80\80\80\00\01\00\07\8e\80\80\80"
+  "\00\01\0a\34\32\39\34\39\36\37\32\34\39\00\00\0a"
+  "\91\80\80\80\00\01\8b\80\80\80\00\00\44\00\00\20"
+  "\fa\ff\ff\ef\41\0b"
+)
+
+(assert_return (invoke "4294967249") (f64.const 4294967249))
+
 (assert_malformed
   (module quote "(global f32 (f32.const _100))")
   "unknown operator"


### PR DESCRIPTION
This loads the u64 value in two u32 pieces, but was using
`Int64.of_int32` which sign-extends the i32 value. This causes the f64
value `4294967249` to be read as `4294965201`, for example.

Fixes #543.