### PR TITLE
Harness-module-builder: Do not spread potentially big arrays as function parameters

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -69,12 +69,14 @@ class Binary extends Array {
     // Emit section name.
     this.emit_u8(section_code);
     // Emit the section to a temporary buffer: its full length isn't know yet.
-    let section = new Binary;
+    const section = new Binary;
     content_generator(section);
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    this.push(...section);
+    for (let i = 0; i < section.length; ++i) {
+      this.push(section[i]);
+    }
   }
 }
 

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -74,8 +74,8 @@ class Binary extends Array {
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    for (let i = 0; i < section.length; ++i) {
-      this.push(section[i]);
+    for (const b of section) {
+      this.push(b);
     }
   }
 }


### PR DESCRIPTION
Some engines have a limit to the number of arguments functions can have and there is no limit to the size of a section.