### PR TITLE
[spec] Add embedder interface

### DIFF
--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -1,0 +1,526 @@
+.. index:: ! embedding, embedder, implementation, host
+.. _embed:
+
+Embedding
+---------
+
+A WebAssembly implementation will typically be *embedded* into a *host* environment.
+An *embedder* implements the connection between such a host environment and the WebAssembly semantics as defined in the main body of this specification.
+An embedder is expected to interact with the semantics in well-defined ways.
+
+This section defines a suitable interface to the WebAssembly semantics in the form of entry points through which an embedder can access it.
+The interface is intended to be complete, in the sense that an embedder does not need to reference other functional parts of the WebAssembly specification directly.
+
+.. note::
+   On the other hand, an embedder does not need to provide the host environment with access to all functionality defined in this interface.
+   For example, an implementation may not support :ref:`parsing <embed-parse-module>` of the :ref:`text format <text>`.
+
+In the description of the embedder interface, syntactic classes from the :ref:`abstract syntax <syntax>` and the :ref:`runtime's abstract machine <syntax-runtime>` are used as names for variables that range over the possible objects from that class.
+Hence, these syntactic classes can also be interpreted as types.
+
+.. _embed-error:
+
+Failure of an interface operation is indicated by an auxiliary syntactic class:
+
+.. math::
+   \begin{array}{llll}
+   \production{(error)} & \error &::=& \ERROR \\
+   \end{array}
+
+In addition to the error conditions specified explicitly in this section, implementations may also return errors when specific :ref:`implementation limitations <impl>` are reached.
+
+
+.. note::
+   Errors are abstract and unspecific with this definition.
+   Implementations can refine it to carry suitable classifications and diagnostic messages.
+
+
+
+.. index:: allocation, store
+.. _embed-store:
+
+Store
+~~~~~
+
+.. _embed-init-store:
+
+:math:`\F{init\_store}() : \store`
+..................................
+
+* Return the empty :ref:`store <syntax-store>`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{init\_store}() &=& \{ \SFUNCS~\epsilon,~ \SMEMS~\epsilon,~ \STABLES~\epsilon,~ \SGLOBALS~\epsilon \} \\
+   \end{array}
+
+
+
+.. index:: module
+.. _embed-module:
+
+Modules
+~~~~~~~
+
+.. index:: binary format
+.. _embed-decode-module:
+
+:math:`\F{decode\_module}(\byte^\ast) : \module ~|~ \error`
+...........................................................
+
+* If there exists a derivation for the :ref:`byte <syntax-byte>` sequence :math:`\byte^\ast` as a :math:`\Bmodule` according to the :ref:`binary grammar for modules <binary-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
+
+* Else, return :math:`\ERROR`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{decode\_module}(b^\ast) &=& m && (\iff \Bmodule \longrightarrow m{:}b^\ast) \\
+   \F{decode\_module}(b^\ast) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. index:: text format
+.. _embed-parse-module:
+
+:math:`\F{parse\_module}(\codepoint^\ast) : \module ~|~ \error`
+...............................................................
+
+* If there exists a derivation for the :ref:`source <syntax-source>` :math:`\codepoint^\ast` as a :math:`\Tmodule` according to the :ref:`text grammar for modules <text-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
+
+* Else, return :math:`\ERROR`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{parse\_module}(c^\ast) &=& m && (\iff \Tmodule \longrightarrow m{:}c^\ast) \\
+   \F{parse\_module}(c^\ast) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. index:: validation
+.. _embed-validate-module:
+
+:math:`\F{validate\_module}(\module) : \error^?`
+................................................
+
+* If :math:`\module` is :ref:`valid <valid-module>`, then return nothing.
+
+* Else, return :math:`\ERROR`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{validate\_module}(m) &=& \epsilon && (\iff {} \vdashmodule m : \externtype^\ast) \\
+   \F{validate\_module}(m) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. index:: instantiation, module instance
+.. _embed-instantiate-module:
+
+:math:`\F{instantiate\_module}(\store, \module, \externval^\ast) : (\store, \moduleinst ~|~ \error)`
+....................................................................................................
+
+* :ref:`Instantiate <exec-instantiation>` :math:`\module` in :math:`\store` with :ref:`external values <syntax-externval>` :math:`\externval^\ast` as imports:
+
+  * If it succeeds with a :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst`, then let :math:`\X{result}` be :math:`\moduleinst`.
+
+  * Else, let :math:`\X{result}` be :math:`\ERROR`.
+
+* Return the new store paired with :math:`\X{result}`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', \X{mi}) && (\iff S; \INSTANTIATE~m~\X{ev}^\ast \stepto^\ast S'; \epsilon) \\
+   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', \ERROR) && (\iff S; \INSTANTIATE~m~\X{ev}^\ast \stepto^\ast S'; \TRAP) \\
+   \end{array}
+
+.. note::
+   The store may be modified even in case of an error.
+
+
+.. index:: import
+.. _embed-imports:
+
+:math:`\F{module\_imports}(\module) : (\name, \name, \externtype)^\ast`
+.......................................................................
+
+* Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
+
+* Let :math:`\import^\ast` be the :ref:`imports <syntax-import>` :math:`\module.\MIMPORTS`.
+
+* Assert: the length of :math:`\import^\ast` equals the length of :math:`\externtype^\ast`.
+
+* For each :math:`\import_i` in :math:`\import^\ast` and corresponding :math:`\externtype_i` in :math:`\externtype^\ast`, do:
+
+  * Let :math:`\X{result}_i` be the triple :math:`(\import_i.\IMODULE, \import_i.\INAME, \externtype_i)`.
+
+* Return the concatenation of all :math:`\X{result}_i`, in index order.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{module\_imports}(m) &=& (\X{im}.\IMODULE, \X{im}.\INAME, \externtype)^\ast \\
+     && \qquad (\iff \X{im}^\ast = m.\MIMPORTS \wedge {} \vdashmodule m : \externtype^\ast \to {\externtype'}^\ast) \\
+   \end{array}
+
+
+.. index:: export
+.. _embed-exports:
+
+:math:`\F{module\_exports}(\module) : (\name, \externtype)^\ast`
+................................................................
+
+* Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
+
+* Let :math:`\export^\ast` be the :ref:`exports <syntax-export>` :math:`\module.\MEXPORTS`.
+
+* Assert: the length of :math:`\export^\ast` equals the length of :math:`\externtype^\ast`.
+
+* For each :math:`\export_i` in :math:`\export^\ast` and corresponding :math:`\externtype'_i` in :math:`{\externtype'}^\ast`, do:
+
+  * Let :math:`\X{result}_i` be the pair :math:`(\export_i.\ENAME, \externtype'_i)`.
+
+* Return the concatenation of all :math:`\X{result}_i`, in index order.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{module\_exports}(m) &=& (\X{ex}.\ENAME, \externtype')^\ast \\
+     && \qquad (\iff \X{ex}^\ast = m.\MEXPORTS \wedge {} \vdashmodule m : \externtype^\ast \to {\externtype'}^\ast) \\
+   \end{array}
+
+
+.. index:: module, store, module instance, export instance
+.. _embed-export:
+
+Exports
+~~~~~~~
+
+.. _embed-get-export:
+
+:math:`\F{get\_export}(\moduleinst, \name) : \externval ~|~ \error`
+...................................................................
+
+* For each :math:`\exportinst_i` in :math:`\moduleinst.\MIEXPORTS`, do:
+
+  * If the :ref:`name <syntax-name>` :math:`\exportinst_i.\EINAME` equals :math:`\name`, then:
+
+    * Return the :ref:`external value <syntax-externval>` :math:`\exportinst_i.\EIVALUE`.
+
+* Return :math:`\ERROR`.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{get\_export}(m, \name) &=& m.\MIEXPORTS[i].\EIVALUE && (\iff m.\MEXPORTS[i].\EINAME = \name) \\
+   \F{get\_export}(m, \name) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. index:: function, host function, function address, function instance, function type, store
+.. _embed-func:
+
+Functions
+~~~~~~~~~
+
+.. _embed-alloc-func:
+
+:math:`\F{alloc\_func}(\store, \functype, \hostfunc) : (\store, \funcaddr)`
+...........................................................................
+
+* Let :math:`\funcaddr` be the result of :ref:`allocating a host function <alloc-func>` in :math:`\store` with :ref:`function type <syntax-functype>` :math:`\functype` and host function code :math:`\hostfunc`.
+
+* Return the new store paired with :math:`\funcaddr`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{alloc\_func}(S, \X{ft}, \X{code}) &=& (S', \X{a}) && (\iff \alloctable(S, \X{ft}, \X{code}) = S', \X{a}) \\
+   \end{array}
+
+.. note::
+   This operation assumes that :math:`\hostfunc` satisfies the :ref:`pre- and post-conditions <exec-invoke-host>` required for a function instance with type :math:`\functype`.
+
+   Regular (non-host) function instances can only be created indirectly through :ref:`module instantiation <embed-instantiate-module>`.
+
+
+.. index:: invocation, value, result
+.. _embed-invoke-func:
+
+:math:`\F{invoke\_func}(\store, \funcaddr, \val^\ast) : (\store, \val^\ast ~|~ \error`)
+.......................................................................................
+
+* Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
+
+* :ref:`Invoke <exec-invocation>` the function :math:`\funcaddr` in :math:`\store` with :ref:`values <syntax-val>` :math:`\val^\ast` as arguments:
+
+  * If it succeeds with :ref:`values <syntax-val>` :math:`{\val'}^\ast` as results, then let :math:`\X{result}` be :math:`{\val'}^\ast`.
+
+  * Else it has trapped, hence let :math:`\X{result}` be :math:`\ERROR`.
+
+* Return the new store paired with :math:`\X{result}`.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{invoke\_func}(S, a, v^\ast) &=& (S', {v'}^\ast) && (\iff \invoke(S, a, v^\ast) = S', {v'}^\ast) \\
+   \F{invoke\_func}(S, a, v^\ast) &=& (S', \ERROR) && (\iff \invoke(S, a, v^\ast) = S', \TRAP) \\
+   \end{array}
+
+.. note::
+   The store may be modified even in case of an error.
+
+
+.. index:: table, table address, store, table instance, table type, element, function address
+.. _embed-table:
+
+Tables
+~~~~~~
+
+.. _embed-alloc-table:
+
+:math:`\F{alloc\_table}(\store, \tabletype) : (\store, \tableaddr)`
+...................................................................
+
+* Let :math:`\tableaddr` be the result of :ref:`allocating a table <alloc-table>` in :math:`\store` with :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
+
+* Return the new store paired with :math:`\tableaddr`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{alloc\_table}(S, \X{tt}) &=& (S', \X{a}) && (\iff \alloctable(S, \X{tt}) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-read-table:
+
+:math:`\F{read\_table}(\store, \tableaddr, i) : \funcaddr ~|~ \error`
+.....................................................................
+
+* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+
+* Assert: :math:`i` is a non-negative integer.
+
+* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+
+* If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+
+* If :math:`\X{ti}.\TIELEM[i]` contains a :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`, then return :math:`\X{fa}`.
+
+* Else :math:`\X{ti}.\TIELEM[i]` is empty, hence return :math:`\ERROR`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{read\_table}(S, a, i) &=& \X{fa} && (\iff S.\STABLES[a].\TIELEM[i] = \X{fa}) \\
+   \F{read\_table}(S, a, i) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-write-table:
+
+:math:`\F{write\_table}(\store, \tableaddr, i, \funcaddr) : \store ~|~ \error`
+..............................................................................
+
+* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+
+* Assert: :math:`i` is a non-negative integer.
+
+* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+
+* If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+
+* Replace :math:`\X{ti}.\TIELEM[i]` with the :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`.
+
+* Return the updated store.
+
+.. math::
+   \begin{array}{lclll}
+   \F{write\_table}(S, a, i, \X{fa}) &=& S' && (\iff S' = S \with \STABLES[a].\TIELEM[i] = \X{fa}) \\
+   \F{write\_table}(S, a, i, \X{fa}) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-grow-table:
+
+:math:`\F{grow\_table}(\store, \tableaddr, n) : \store ~|~ \error`
+..................................................................
+
+* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+
+* Assert: :math:`n` is a non-negative integer.
+
+* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+
+* If :math:`\X{ti}.\TIMAX` is non-empty and smaller than :math:`n` added to the length of :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+
+* Append :math:`n` empty elements to :math:`\X{ti}.\TIELEM`.
+
+* Return the updated store.
+
+.. math::
+   \begin{array}{lclll}
+   \F{grow\_table}(S, a, n) &=& S' && (
+     \begin{array}[t]{@{}r@{~}l@{}}
+     \iff & \X{ti} = S.\STABLES[a] \\
+     \wedge & (\X{ti}.\TIMAX = \epsilon \vee |\X{ti}.\TIELEM| + n \leq \X{ti}.\TIMAX) \\
+     \wedge & S' = S \with \STABLES[a].\TIELEM = \X{ti}.\TIELEM~(\epsilon)^n) \\
+     \end{array} \\
+   \F{grow\_table}(S, a, n) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. index:: memory, memory address, store, memory instance, memory type, byte
+.. _embed-mem:
+
+Memories
+~~~~~~~~
+
+.. _embed-alloc-mem:
+
+:math:`\F{alloc\_mem}(\store, \memtype) : (\store, \memaddr)`
+................................................................
+
+* Let :math:`\memaddr` be the result of :ref:`allocating a memory <alloc-mem>` in :math:`\store` with :ref:`memory type <syntax-memtype>` :math:`\memtype`.
+
+* Return the new store paired with :math:`\memaddr`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{alloc\_mem}(S, \X{mt}) &=& (S', \X{a}) && (\iff \allocmem(S, \X{mt}) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-read-mem:
+
+:math:`\F{read\_mem}(\store, \memaddr, i) : \byte ~|~ \error`
+.............................................................
+
+* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+
+* Assert: :math:`i` is a non-negative integer.
+
+* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+
+* If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
+
+* Else, return the  :ref:`byte <syntax-byte>` :math:`\X{mi}.\MIDATA[i]`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{read\_mem}(S, a, i) &=& b && (\iff S.\SMEMS[a].\MIDATA[i] = b) \\
+   \F{read\_mem}(S, a, i) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-write-mem:
+
+:math:`\F{write\_mem}(\store, \memaddr, i, \byte) : \store ~|~ \error`
+......................................................................
+
+* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+
+* Assert: :math:`i` is a non-negative integer.
+
+* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+
+* If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
+
+* Replace :math:`\X{mi}.\MIDATA[i]` with :math:`\byte`.
+
+* Return the updated store.
+
+.. math::
+   \begin{array}{lclll}
+   \F{write\_mem}(S, a, i, b) &=& S' && (\iff S' = S \with \SMEMS[a].\MIDATA[i] = b) \\
+   \F{write\_mem}(S, a, i, b) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-grow-mem:
+
+:math:`\F{grow\_mem}(\store, \memaddr, n) : \store ~|~ \error`
+..............................................................
+
+* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+
+* Assert: :math:`n` is a non-negative integer.
+
+* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+
+* If :math:`\X{mi}.\MIMAX` is non-empty and smaller than :math:`n` added to the length of :math:`\X{mi}.\MIDATA` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`, then return :math:`\ERROR`.
+
+* Append :math:`n` times the :ref:`page size <page-size>` :math:`64\,\F{Ki}` zero :ref:`bytes <syntax-byte>` to :math:`\X{mi}.\MIDATA`.
+
+* Return the updated store.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{grow\_mem}(S, a, n) &=& S' && (
+     \begin{array}[t]{@{}r@{~}l@{}}
+     \iff & \X{mi} = S.\SMEMS[a] \\
+     \wedge & (\X{mi}.\MIMAX = \epsilon \vee |\X{mi}.\MIDATA|/64\,\F{Ki} + n \leq \X{mi}.\TIMAX) \\
+     \wedge & S' = S \with \SMEMS[a].\MIDATA = \X{mi}.\MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}}) \\
+     \end{array} \\
+   \F{grow\_mem}(S, a, n) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+
+.. index:: global, global address, store, global instance, global type, value
+.. _embed-global:
+
+Globals
+~~~~~~~
+
+.. _embed-alloc-global:
+
+:math:`\F{alloc\_global}(\store, \globaltype, \val) : (\store, \globaladdr)`
+............................................................................
+
+* Let :math:`\globaladdr` be the result of :ref:`allocating a global <alloc-global>` in :math:`\store` with :ref:`global type <syntax-globaltype>` :math:`\globaltype` and initialization value :math:`\val`.
+
+* Return the new store paired with :math:`\globaladdr`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{alloc\_global}(S, \X{gt}, v) &=& (S', \X{a}) && (\iff \allocglobal(S, \X{gt}, v) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-read-global:
+
+:math:`\F{read\_global}(\store, \globaladdr) : \val`
+....................................................
+
+* Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
+
+* Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
+
+* Return the :ref:`value <syntax-val>` :math:`\X{gi}.\GIVALUE`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{read\_global}(S, a) &=& v && (\iff S.\SGLOBALS[a].\GIVALUE = v) \\
+   \end{array}
+
+
+.. _embed-write-global:
+
+:math:`\F{write\_global}(\store, \globaladdr, \val) : \store ~|~ \error`
+........................................................................
+
+* Assert: :math:`\store.\SGLOBALS[a]` exists.
+
+* Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
+
+* If :math:`\X{gi}.\GIMUT` is not :math:`\MVAR`, then return :math:`\ERROR`.
+
+* Replace :math:`\X{gi}.\GIVALUE` with the :ref:`value <syntax-val>` :math:`\val`.
+
+* Return the updated store.
+
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{write\_global}(S, a, v) &=& S' && (\iff S.\SGLOBALS[a].\GIMUT = \MVAR \wedge S' = S \with \SGLOBALS[a].\GIVALUE = v) \\
+   \F{write\_global}(S, a, v) &=& \ERROR && (\otherwise) \\
+   \end{array}

--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -129,8 +129,8 @@ Modules
 
 .. math::
    \begin{array}{lclll}
-   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', \X{mi}) && (\iff S; \INSTANTIATE~m~\X{ev}^\ast \stepto^\ast S'; \epsilon) \\
-   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', \ERROR) && (\iff S; \INSTANTIATE~m~\X{ev}^\ast \stepto^\ast S'; \TRAP) \\
+   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', F.\AMODULE) && (\iff \instantiate(S, m, \X{ev}^\ast) \stepto^\ast S'; F; \epsilon) \\
+   \F{instantiate\_module}(S, m, \X{ev}^\ast) &=& (S', \ERROR) && (\iff \instantiate(S, m, \X{ev}^\ast) \stepto^\ast S'; F; \TRAP) \\
    \end{array}
 
 .. note::
@@ -242,6 +242,23 @@ Functions
    Regular (non-host) function instances can only be created indirectly through :ref:`module instantiation <embed-instantiate-module>`.
 
 
+.. _embed-type-func:
+
+:math:`\F{type\_func}(\store, \funcaddr) : \functype`
+.....................................................
+
+1. Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVFUNC~\funcaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\functype`.
+
+3. Return :math:`\functype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_func}(S, a) &=& \X{ft} && (\iff S \vdashexternval \EVFUNC~a : \ETFUNC~\X{ft}) \\
+   \end{array}
+
+
 .. index:: invocation, value, result
 .. _embed-invoke-func:
 
@@ -261,29 +278,12 @@ Functions
 .. math::
    ~ \\
    \begin{array}{lclll}
-   \F{invoke\_func}(S, a, v^\ast) &=& (S', {v'}^\ast) && (\iff \invoke(S, a, v^\ast) = S', {v'}^\ast) \\
-   \F{invoke\_func}(S, a, v^\ast) &=& (S', \ERROR) && (\iff \invoke(S, a, v^\ast) = S', \TRAP) \\
+   \F{invoke\_func}(S, a, v^\ast) &=& (S', {v'}^\ast) && (\iff \invoke(S, a, v^\ast) \stepto^\ast S'; F; {v'}^\ast) \\
+   \F{invoke\_func}(S, a, v^\ast) &=& (S', \ERROR) && (\iff \invoke(S, a, v^\ast) \stepto^\ast S'; F; \TRAP) \\
    \end{array}
 
 .. note::
    The store may be modified even in case of an error.
-
-
-.. _embed-type-func:
-
-:math:`\F{type\_func}(\store, \funcaddr) : \functype`
-.....................................................
-
-1. Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
-
-2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVFUNC~\funcaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\functype`.
-
-3. Return :math:`\functype`.
-
-.. math::
-   \begin{array}{lclll}
-   \F{type\_func}(S, a) &=& \X{ft} && (\iff S \vdashexternval \EVFUNC~a : \ETFUNC~\X{ft}) \\
-   \end{array}
 
 
 .. index:: table, table address, store, table instance, table type, element, function address
@@ -304,6 +304,23 @@ Tables
 .. math::
    \begin{array}{lclll}
    \F{alloc\_table}(S, \X{tt}) &=& (S', \X{a}) && (\iff \alloctable(S, \X{tt}) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-type-table:
+
+:math:`\F{type\_table}(\store, \tableaddr) : \tabletype`
+........................................................
+
+1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVTABLE~\tableaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~\tabletype`.
+
+3. Return :math:`\tabletype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_table}(S, a) &=& \X{tt} && (\iff S \vdashexternval \EVTABLE~a : \ETTABLE~\X{tt}) \\
    \end{array}
 
 
@@ -379,23 +396,6 @@ Tables
    \end{array}
 
 
-.. _embed-type-table:
-
-:math:`\F{type\_table}(\store, \tableaddr) : \tabletype`
-........................................................
-
-1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
-
-2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVTABLE~\tableaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~\tabletype`.
-
-3. Return :math:`\tabletype`.
-
-.. math::
-   \begin{array}{lclll}
-   \F{type\_table}(S, a) &=& \X{tt} && (\iff S \vdashexternval \EVTABLE~a : \ETTABLE~\X{tt}) \\
-   \end{array}
-
-
 .. index:: memory, memory address, store, memory instance, memory type, byte
 .. _embed-mem:
 
@@ -414,6 +414,23 @@ Memories
 .. math::
    \begin{array}{lclll}
    \F{alloc\_mem}(S, \X{mt}) &=& (S', \X{a}) && (\iff \allocmem(S, \X{mt}) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-type-mem:
+
+:math:`\F{type\_mem}(\store, \memaddr) : \memtype`
+..................................................
+
+1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVMEM~\memaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETMEM~\memtype`.
+
+3. Return :math:`\memtype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_mem}(S, a) &=& \X{mt} && (\iff S \vdashexternval \EVMEM~a : \ETMEM~\X{mt}) \\
    \end{array}
 
 
@@ -487,23 +504,6 @@ Memories
    \end{array}
 
 
-.. _embed-type-mem:
-
-:math:`\F{type\_mem}(\store, \memaddr) : \memtype`
-..................................................
-
-1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
-
-2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVMEM~\memaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETMEM~\memtype`.
-
-3. Return :math:`\memtype`.
-
-.. math::
-   \begin{array}{lclll}
-   \F{type\_mem}(S, a) &=& \X{mt} && (\iff S \vdashexternval \EVMEM~a : \ETMEM~\X{mt}) \\
-   \end{array}
-
-
 
 .. index:: global, global address, store, global instance, global type, value
 .. _embed-global:
@@ -523,6 +523,23 @@ Globals
 .. math::
    \begin{array}{lclll}
    \F{alloc\_global}(S, \X{gt}, v) &=& (S', \X{a}) && (\iff \allocglobal(S, \X{gt}, v) = S', \X{a}) \\
+   \end{array}
+
+
+.. _embed-type-global:
+
+:math:`\F{type\_global}(\store, \globaladdr) : \globaltype`
+...........................................................
+
+1. Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~\globaladdr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~\globaltype`.
+
+3. Return :math:`\globaltype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_global}(S, a) &=& \X{gt} && (\iff S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~\X{gt}) \\
    \end{array}
 
 
@@ -563,21 +580,4 @@ Globals
    \begin{array}{lclll}
    \F{write\_global}(S, a, v) &=& S' && (\iff S.\SGLOBALS[a].\GIMUT = \MVAR \wedge S' = S \with \SGLOBALS[a].\GIVALUE = v) \\
    \F{write\_global}(S, a, v) &=& \ERROR && (\otherwise) \\
-   \end{array}
-
-
-.. _embed-type-global:
-
-:math:`\F{type\_global}(\store, \globaladdr) : \globaltype`
-...........................................................
-
-1. Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
-
-2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~\globaladdr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~\globaltype`.
-
-3. Return :math:`\globaltype`.
-
-.. math::
-   \begin{array}{lclll}
-   \F{type\_global}(S, a) &=& \X{gt} && (\iff S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~\X{gt}) \\
    \end{array}

--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -47,7 +47,7 @@ Store
 :math:`\F{init\_store}() : \store`
 ..................................
 
-* Return the empty :ref:`store <syntax-store>`.
+1. Return the empty :ref:`store <syntax-store>`.
 
 .. math::
    \begin{array}{lclll}
@@ -68,13 +68,13 @@ Modules
 :math:`\F{decode\_module}(\byte^\ast) : \module ~|~ \error`
 ...........................................................
 
-* If there exists a derivation for the :ref:`byte <syntax-byte>` sequence :math:`\byte^\ast` as a :math:`\Bmodule` according to the :ref:`binary grammar for modules <binary-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
+1. If there exists a derivation for the :ref:`byte <syntax-byte>` sequence :math:`\byte^\ast` as a :math:`\Bmodule` according to the :ref:`binary grammar for modules <binary-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
 
-* Else, return :math:`\ERROR`.
+2. Else, return :math:`\ERROR`.
 
 .. math::
    \begin{array}{lclll}
-   \F{decode\_module}(b^\ast) &=& m && (\iff \Bmodule \longrightarrow m{:}b^\ast) \\
+   \F{decode\_module}(b^\ast) &=& m && (\iff \Bmodule \stackrel\ast\Longrightarrow m{:}b^\ast) \\
    \F{decode\_module}(b^\ast) &=& \ERROR && (\otherwise) \\
    \end{array}
 
@@ -85,13 +85,13 @@ Modules
 :math:`\F{parse\_module}(\codepoint^\ast) : \module ~|~ \error`
 ...............................................................
 
-* If there exists a derivation for the :ref:`source <syntax-source>` :math:`\codepoint^\ast` as a :math:`\Tmodule` according to the :ref:`text grammar for modules <text-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
+1. If there exists a derivation for the :ref:`source <text-source>` :math:`\codepoint^\ast` as a :math:`\Tmodule` according to the :ref:`text grammar for modules <text-module>`, yielding a :ref:`module <syntax-module>` :math:`m`, then return :math:`m`.
 
-* Else, return :math:`\ERROR`.
+2. Else, return :math:`\ERROR`.
 
 .. math::
    \begin{array}{lclll}
-   \F{parse\_module}(c^\ast) &=& m && (\iff \Tmodule \longrightarrow m{:}c^\ast) \\
+   \F{parse\_module}(c^\ast) &=& m && (\iff \Tmodule \stackrel\ast\Longrightarrow m{:}c^\ast) \\
    \F{parse\_module}(c^\ast) &=& \ERROR && (\otherwise) \\
    \end{array}
 
@@ -102,13 +102,13 @@ Modules
 :math:`\F{validate\_module}(\module) : \error^?`
 ................................................
 
-* If :math:`\module` is :ref:`valid <valid-module>`, then return nothing.
+1. If :math:`\module` is :ref:`valid <valid-module>`, then return nothing.
 
-* Else, return :math:`\ERROR`.
+2. Else, return :math:`\ERROR`.
 
 .. math::
    \begin{array}{lclll}
-   \F{validate\_module}(m) &=& \epsilon && (\iff {} \vdashmodule m : \externtype^\ast) \\
+   \F{validate\_module}(m) &=& \epsilon && (\iff {} \vdashmodule m : \externtype^\ast \to {\externtype'}^\ast) \\
    \F{validate\_module}(m) &=& \ERROR && (\otherwise) \\
    \end{array}
 
@@ -119,13 +119,13 @@ Modules
 :math:`\F{instantiate\_module}(\store, \module, \externval^\ast) : (\store, \moduleinst ~|~ \error)`
 ....................................................................................................
 
-* :ref:`Instantiate <exec-instantiation>` :math:`\module` in :math:`\store` with :ref:`external values <syntax-externval>` :math:`\externval^\ast` as imports:
+1. Try :ref:`instantiating <exec-instantiation>` :math:`\module` in :math:`\store` with :ref:`external values <syntax-externval>` :math:`\externval^\ast` as imports:
 
-  * If it succeeds with a :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst`, then let :math:`\X{result}` be :math:`\moduleinst`.
+  a. If it succeeds with a :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst`, then let :math:`\X{result}` be :math:`\moduleinst`.
 
-  * Else, let :math:`\X{result}` be :math:`\ERROR`.
+  b. Else, let :math:`\X{result}` be :math:`\ERROR`.
 
-* Return the new store paired with :math:`\X{result}`.
+2. Return the new store paired with :math:`\X{result}`.
 
 .. math::
    \begin{array}{lclll}
@@ -143,17 +143,17 @@ Modules
 :math:`\F{module\_imports}(\module) : (\name, \name, \externtype)^\ast`
 .......................................................................
 
-* Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
+1. Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
 
-* Let :math:`\import^\ast` be the :ref:`imports <syntax-import>` :math:`\module.\MIMPORTS`.
+2. Let :math:`\import^\ast` be the :ref:`imports <syntax-import>` :math:`\module.\MIMPORTS`.
 
-* Assert: the length of :math:`\import^\ast` equals the length of :math:`\externtype^\ast`.
+3. Assert: the length of :math:`\import^\ast` equals the length of :math:`\externtype^\ast`.
 
-* For each :math:`\import_i` in :math:`\import^\ast` and corresponding :math:`\externtype_i` in :math:`\externtype^\ast`, do:
+4. For each :math:`\import_i` in :math:`\import^\ast` and corresponding :math:`\externtype_i` in :math:`\externtype^\ast`, do:
 
-  * Let :math:`\X{result}_i` be the triple :math:`(\import_i.\IMODULE, \import_i.\INAME, \externtype_i)`.
+  a. Let :math:`\X{result}_i` be the triple :math:`(\import_i.\IMODULE, \import_i.\INAME, \externtype_i)`.
 
-* Return the concatenation of all :math:`\X{result}_i`, in index order.
+5. Return the concatenation of all :math:`\X{result}_i`, in index order.
 
 .. math::
    ~ \\
@@ -169,17 +169,17 @@ Modules
 :math:`\F{module\_exports}(\module) : (\name, \externtype)^\ast`
 ................................................................
 
-* Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
+1. Assert: :math:`\module` is :ref:`valid <valid-module>` with external import types :math:`\externtype^\ast` and external export types :math:`{\externtype'}^\ast`.
 
-* Let :math:`\export^\ast` be the :ref:`exports <syntax-export>` :math:`\module.\MEXPORTS`.
+2. Let :math:`\export^\ast` be the :ref:`exports <syntax-export>` :math:`\module.\MEXPORTS`.
 
-* Assert: the length of :math:`\export^\ast` equals the length of :math:`\externtype^\ast`.
+3. Assert: the length of :math:`\export^\ast` equals the length of :math:`\externtype^\ast`.
 
-* For each :math:`\export_i` in :math:`\export^\ast` and corresponding :math:`\externtype'_i` in :math:`{\externtype'}^\ast`, do:
+4. For each :math:`\export_i` in :math:`\export^\ast` and corresponding :math:`\externtype'_i` in :math:`{\externtype'}^\ast`, do:
 
-  * Let :math:`\X{result}_i` be the pair :math:`(\export_i.\ENAME, \externtype'_i)`.
+  a. Let :math:`\X{result}_i` be the pair :math:`(\export_i.\ENAME, \externtype'_i)`.
 
-* Return the concatenation of all :math:`\X{result}_i`, in index order.
+5. Return the concatenation of all :math:`\X{result}_i`, in index order.
 
 .. math::
    ~ \\
@@ -200,13 +200,13 @@ Exports
 :math:`\F{get\_export}(\moduleinst, \name) : \externval ~|~ \error`
 ...................................................................
 
-* For each :math:`\exportinst_i` in :math:`\moduleinst.\MIEXPORTS`, do:
+1. Assert: due to :ref:`validity <valid-moduleinst>` of the :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst`, all its :ref:`export names <syntax-exportinst>` are different.
 
-  * If the :ref:`name <syntax-name>` :math:`\exportinst_i.\EINAME` equals :math:`\name`, then:
+2. If there exists an :math:`\exportinst_i` in :math:`\moduleinst.\MIEXPORTS` such that :ref:`name <syntax-name>` :math:`\exportinst_i.\EINAME` equals :math:`\name`, then:
 
-    * Return the :ref:`external value <syntax-externval>` :math:`\exportinst_i.\EIVALUE`.
+   a. Return the :ref:`external value <syntax-externval>` :math:`\exportinst_i.\EIVALUE`.
 
-* Return :math:`\ERROR`.
+3. Else, return :math:`\ERROR`.
 
 .. math::
    ~ \\
@@ -227,13 +227,13 @@ Functions
 :math:`\F{alloc\_func}(\store, \functype, \hostfunc) : (\store, \funcaddr)`
 ...........................................................................
 
-* Let :math:`\funcaddr` be the result of :ref:`allocating a host function <alloc-func>` in :math:`\store` with :ref:`function type <syntax-functype>` :math:`\functype` and host function code :math:`\hostfunc`.
+1. Let :math:`\funcaddr` be the result of :ref:`allocating a host function <alloc-func>` in :math:`\store` with :ref:`function type <syntax-functype>` :math:`\functype` and host function code :math:`\hostfunc`.
 
-* Return the new store paired with :math:`\funcaddr`.
+2. Return the new store paired with :math:`\funcaddr`.
 
 .. math::
    \begin{array}{lclll}
-   \F{alloc\_func}(S, \X{ft}, \X{code}) &=& (S', \X{a}) && (\iff \alloctable(S, \X{ft}, \X{code}) = S', \X{a}) \\
+   \F{alloc\_func}(S, \X{ft}, \X{code}) &=& (S', \X{a}) && (\iff \allochostfunc(S, \X{ft}, \X{code}) = S', \X{a}) \\
    \end{array}
 
 .. note::
@@ -245,18 +245,18 @@ Functions
 .. index:: invocation, value, result
 .. _embed-invoke-func:
 
-:math:`\F{invoke\_func}(\store, \funcaddr, \val^\ast) : (\store, \val^\ast ~|~ \error`)
-.......................................................................................
+:math:`\F{invoke\_func}(\store, \funcaddr, \val^\ast) : (\store, \val^\ast ~|~ \error`)`
+........................................................................................
 
-* Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
+1. Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
 
-* :ref:`Invoke <exec-invocation>` the function :math:`\funcaddr` in :math:`\store` with :ref:`values <syntax-val>` :math:`\val^\ast` as arguments:
+2. Try :ref:`invoking <exec-invocation>` the function :math:`\funcaddr` in :math:`\store` with :ref:`values <syntax-val>` :math:`\val^\ast` as arguments:
 
-  * If it succeeds with :ref:`values <syntax-val>` :math:`{\val'}^\ast` as results, then let :math:`\X{result}` be :math:`{\val'}^\ast`.
+  a. If it succeeds with :ref:`values <syntax-val>` :math:`{\val'}^\ast` as results, then let :math:`\X{result}` be :math:`{\val'}^\ast`.
 
-  * Else it has trapped, hence let :math:`\X{result}` be :math:`\ERROR`.
+  b. Else it has trapped, hence let :math:`\X{result}` be :math:`\ERROR`.
 
-* Return the new store paired with :math:`\X{result}`.
+3. Return the new store paired with :math:`\X{result}`.
 
 .. math::
    ~ \\
@@ -267,6 +267,23 @@ Functions
 
 .. note::
    The store may be modified even in case of an error.
+
+
+.. _embed-type-func:
+
+:math:`\F{type\_func}(\store, \funcaddr) : \functype`
+.....................................................
+
+1. Assert: :math:`\store.\SFUNCS[\funcaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVFUNC~\funcaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~\functype`.
+
+3. Return :math:`\functype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_func}(S, a) &=& \X{ft} && (\iff S \vdashexternval \EVFUNC~a : \ETFUNC~\X{ft}) \\
+   \end{array}
 
 
 .. index:: table, table address, store, table instance, table type, element, function address
@@ -280,9 +297,9 @@ Tables
 :math:`\F{alloc\_table}(\store, \tabletype) : (\store, \tableaddr)`
 ...................................................................
 
-* Let :math:`\tableaddr` be the result of :ref:`allocating a table <alloc-table>` in :math:`\store` with :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
+1. Let :math:`\tableaddr` be the result of :ref:`allocating a table <alloc-table>` in :math:`\store` with :ref:`table type <syntax-tabletype>` :math:`\tabletype`.
 
-* Return the new store paired with :math:`\tableaddr`.
+2. Return the new store paired with :math:`\tableaddr`.
 
 .. math::
    \begin{array}{lclll}
@@ -295,17 +312,17 @@ Tables
 :math:`\F{read\_table}(\store, \tableaddr, i) : \funcaddr ~|~ \error`
 .....................................................................
 
-* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
 
-* Assert: :math:`i` is a non-negative integer.
+2. Assert: :math:`i` is a non-negative integer.
 
-* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+3. Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
 
-* If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+4. If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
 
-* If :math:`\X{ti}.\TIELEM[i]` contains a :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`, then return :math:`\X{fa}`.
+5. If :math:`\X{ti}.\TIELEM[i]` contains a :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`, then return :math:`\X{fa}`.
 
-* Else :math:`\X{ti}.\TIELEM[i]` is empty, hence return :math:`\ERROR`.
+6. Else :math:`\X{ti}.\TIELEM[i]` is empty, hence return :math:`\ERROR`.
 
 .. math::
    \begin{array}{lclll}
@@ -319,17 +336,17 @@ Tables
 :math:`\F{write\_table}(\store, \tableaddr, i, \funcaddr) : \store ~|~ \error`
 ..............................................................................
 
-* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
 
-* Assert: :math:`i` is a non-negative integer.
+2. Assert: :math:`i` is a non-negative integer.
 
-* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+3. Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
 
-* If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+4. If :math:`i` is larger than or equal to the length if :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
 
-* Replace :math:`\X{ti}.\TIELEM[i]` with the :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`.
+5. Replace :math:`\X{ti}.\TIELEM[i]` with the :ref:`function address <syntax-funcaddr>` :math:`\X{fa}`.
 
-* Return the updated store.
+6. Return the updated store.
 
 .. math::
    \begin{array}{lclll}
@@ -343,27 +360,39 @@ Tables
 :math:`\F{grow\_table}(\store, \tableaddr, n) : \store ~|~ \error`
 ..................................................................
 
-* Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
 
-* Assert: :math:`n` is a non-negative integer.
+2. Assert: :math:`n` is a non-negative integer.
 
-* Let :math:`\X{ti}` be the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]`.
+3. Try :ref:`growing <grow-table>` the :ref:`table instance <syntax-tableinst>` :math:`\store.\STABLES[\tableaddr]` by :math:`n` elements:
 
-* If :math:`\X{ti}.\TIMAX` is non-empty and smaller than :math:`n` added to the length of :math:`\X{ti}.\TIELEM`, then return :math:`\ERROR`.
+   a. If it succeeds, return the updated store.
 
-* Append :math:`n` empty elements to :math:`\X{ti}.\TIELEM`.
+   b. Else, return :math:`\ERROR`.
 
-* Return the updated store.
+.. math::
+   ~ \\
+   \begin{array}{lclll}
+   \F{grow\_table}(S, a, n) &=& S' &&
+     (\iff S' = S \with \STABLES[a] = \growtable(S.\STABLES[a], n)) \\
+   \F{grow\_table}(S, a, n) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-type-table:
+
+:math:`\F{type\_table}(\store, \tableaddr) : \tabletype`
+........................................................
+
+1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVTABLE~\tableaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~\tabletype`.
+
+3. Return :math:`\tabletype`.
 
 .. math::
    \begin{array}{lclll}
-   \F{grow\_table}(S, a, n) &=& S' && (
-     \begin{array}[t]{@{}r@{~}l@{}}
-     \iff & \X{ti} = S.\STABLES[a] \\
-     \wedge & (\X{ti}.\TIMAX = \epsilon \vee |\X{ti}.\TIELEM| + n \leq \X{ti}.\TIMAX) \\
-     \wedge & S' = S \with \STABLES[a].\TIELEM = \X{ti}.\TIELEM~(\epsilon)^n) \\
-     \end{array} \\
-   \F{grow\_table}(S, a, n) &=& \ERROR && (\otherwise) \\
+   \F{type\_table}(S, a) &=& \X{tt} && (\iff S \vdashexternval \EVTABLE~a : \ETTABLE~\X{tt}) \\
    \end{array}
 
 
@@ -378,9 +407,9 @@ Memories
 :math:`\F{alloc\_mem}(\store, \memtype) : (\store, \memaddr)`
 ................................................................
 
-* Let :math:`\memaddr` be the result of :ref:`allocating a memory <alloc-mem>` in :math:`\store` with :ref:`memory type <syntax-memtype>` :math:`\memtype`.
+1. Let :math:`\memaddr` be the result of :ref:`allocating a memory <alloc-mem>` in :math:`\store` with :ref:`memory type <syntax-memtype>` :math:`\memtype`.
 
-* Return the new store paired with :math:`\memaddr`.
+2. Return the new store paired with :math:`\memaddr`.
 
 .. math::
    \begin{array}{lclll}
@@ -393,15 +422,15 @@ Memories
 :math:`\F{read\_mem}(\store, \memaddr, i) : \byte ~|~ \error`
 .............................................................
 
-* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
 
-* Assert: :math:`i` is a non-negative integer.
+2. Assert: :math:`i` is a non-negative integer.
 
-* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+3. Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
 
-* If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
+4. If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
 
-* Else, return the  :ref:`byte <syntax-byte>` :math:`\X{mi}.\MIDATA[i]`.
+5. Else, return the  :ref:`byte <syntax-byte>` :math:`\X{mi}.\MIDATA[i]`.
 
 .. math::
    \begin{array}{lclll}
@@ -415,17 +444,17 @@ Memories
 :math:`\F{write\_mem}(\store, \memaddr, i, \byte) : \store ~|~ \error`
 ......................................................................
 
-* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
 
-* Assert: :math:`i` is a non-negative integer.
+2. Assert: :math:`i` is a non-negative integer.
 
-* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+3. Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
 
-* If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
+4. If :math:`i` is larger than or equal to the length if :math:`\X{mi}.\MIDATA`, then return :math:`\ERROR`.
 
-* Replace :math:`\X{mi}.\MIDATA[i]` with :math:`\byte`.
+5. Replace :math:`\X{mi}.\MIDATA[i]` with :math:`\byte`.
 
-* Return the updated store.
+6. Return the updated store.
 
 .. math::
    \begin{array}{lclll}
@@ -439,28 +468,39 @@ Memories
 :math:`\F{grow\_mem}(\store, \memaddr, n) : \store ~|~ \error`
 ..............................................................
 
-* Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
 
-* Assert: :math:`n` is a non-negative integer.
+2. Assert: :math:`n` is a non-negative integer.
 
-* Let :math:`\X{mi}` be the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]`.
+3. Try :ref:`growing <grow-mem>` the :ref:`memory instance <syntax-meminst>` :math:`\store.\SMEMS[\memaddr]` by :math:`n` :ref:`pages <page-size>`:
 
-* If :math:`\X{mi}.\MIMAX` is non-empty and smaller than :math:`n` added to the length of :math:`\X{mi}.\MIDATA` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`, then return :math:`\ERROR`.
+   a. If it succeeds, return the updated store.
 
-* Append :math:`n` times the :ref:`page size <page-size>` :math:`64\,\F{Ki}` zero :ref:`bytes <syntax-byte>` to :math:`\X{mi}.\MIDATA`.
-
-* Return the updated store.
+   b. Else, return :math:`\ERROR`.
 
 .. math::
    ~ \\
    \begin{array}{lclll}
-   \F{grow\_mem}(S, a, n) &=& S' && (
-     \begin{array}[t]{@{}r@{~}l@{}}
-     \iff & \X{mi} = S.\SMEMS[a] \\
-     \wedge & (\X{mi}.\MIMAX = \epsilon \vee |\X{mi}.\MIDATA|/64\,\F{Ki} + n \leq \X{mi}.\TIMAX) \\
-     \wedge & S' = S \with \SMEMS[a].\MIDATA = \X{mi}.\MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}}) \\
-     \end{array} \\
+   \F{grow\_mem}(S, a, n) &=& S' &&
+     (\iff S' = S \with \SMEMS[a] = \growmem(S.\SMEMS[a], n)) \\
    \F{grow\_mem}(S, a, n) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-type-mem:
+
+:math:`\F{type\_mem}(\store, \memaddr) : \memtype`
+..................................................
+
+1. Assert: :math:`\store.\SMEMS[\memaddr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVMEM~\memaddr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETMEM~\memtype`.
+
+3. Return :math:`\memtype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_mem}(S, a) &=& \X{mt} && (\iff S \vdashexternval \EVMEM~a : \ETMEM~\X{mt}) \\
    \end{array}
 
 
@@ -476,9 +516,9 @@ Globals
 :math:`\F{alloc\_global}(\store, \globaltype, \val) : (\store, \globaladdr)`
 ............................................................................
 
-* Let :math:`\globaladdr` be the result of :ref:`allocating a global <alloc-global>` in :math:`\store` with :ref:`global type <syntax-globaltype>` :math:`\globaltype` and initialization value :math:`\val`.
+1. Let :math:`\globaladdr` be the result of :ref:`allocating a global <alloc-global>` in :math:`\store` with :ref:`global type <syntax-globaltype>` :math:`\globaltype` and initialization value :math:`\val`.
 
-* Return the new store paired with :math:`\globaladdr`.
+2. Return the new store paired with :math:`\globaladdr`.
 
 .. math::
    \begin{array}{lclll}
@@ -491,11 +531,11 @@ Globals
 :math:`\F{read\_global}(\store, \globaladdr) : \val`
 ....................................................
 
-* Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
+1. Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
 
-* Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
+2. Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
 
-* Return the :ref:`value <syntax-val>` :math:`\X{gi}.\GIVALUE`.
+3. Return the :ref:`value <syntax-val>` :math:`\X{gi}.\GIVALUE`.
 
 .. math::
    \begin{array}{lclll}
@@ -508,19 +548,36 @@ Globals
 :math:`\F{write\_global}(\store, \globaladdr, \val) : \store ~|~ \error`
 ........................................................................
 
-* Assert: :math:`\store.\SGLOBALS[a]` exists.
+1. Assert: :math:`\store.\SGLOBALS[a]` exists.
 
-* Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
+2. Let :math:`\X{gi}` be the :ref:`global instance <syntax-globalinst>` :math:`\store.\SGLOBALS[\globaladdr]`.
 
-* If :math:`\X{gi}.\GIMUT` is not :math:`\MVAR`, then return :math:`\ERROR`.
+3. If :math:`\X{gi}.\GIMUT` is not :math:`\MVAR`, then return :math:`\ERROR`.
 
-* Replace :math:`\X{gi}.\GIVALUE` with the :ref:`value <syntax-val>` :math:`\val`.
+4. Replace :math:`\X{gi}.\GIVALUE` with the :ref:`value <syntax-val>` :math:`\val`.
 
-* Return the updated store.
+5. Return the updated store.
 
 .. math::
    ~ \\
    \begin{array}{lclll}
    \F{write\_global}(S, a, v) &=& S' && (\iff S.\SGLOBALS[a].\GIMUT = \MVAR \wedge S' = S \with \SGLOBALS[a].\GIVALUE = v) \\
    \F{write\_global}(S, a, v) &=& \ERROR && (\otherwise) \\
+   \end{array}
+
+
+.. _embed-type-global:
+
+:math:`\F{type\_global}(\store, \globaladdr) : \globaltype`
+...........................................................
+
+1. Assert: :math:`\store.\SGLOBALS[\globaladdr]` exists.
+
+2. Assert: the :ref:`external value <syntax-externval>` :math:`\EVGLOBAL~\globaladdr` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~\globaltype`.
+
+3. Return :math:`\globaltype`.
+
+.. math::
+   \begin{array}{lclll}
+   \F{type\_global}(S, a) &=& \X{gt} && (\iff S \vdashexternval \EVGLOBAL~a : \ETGLOBAL~\X{gt}) \\
    \end{array}

--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -28,11 +28,11 @@ Construct                                        Judgement
 :ref:`Element segment <valid-elem>`              :math:`C \vdashelem \elem \ok`
 :ref:`Data segment <valid-data>`                 :math:`C \vdashdata \data \ok`
 :ref:`Start function <valid-start>`              :math:`C \vdashstart \start \ok`
-:ref:`Export <valid-export>`                     :math:`C \vdashexport \export : \name`
-:ref:`Export description <valid-exportdesc>`     :math:`C \vdashexportdesc \exportdesc \ok`
+:ref:`Export <valid-export>`                     :math:`C \vdashexport \export : \externtype`
+:ref:`Export description <valid-exportdesc>`     :math:`C \vdashexportdesc \exportdesc : \externtype`
 :ref:`Import <valid-import>`                     :math:`C \vdashimport \import : \externtype`
 :ref:`Import description <valid-importdesc>`     :math:`C \vdashimportdesc \importdesc : \externtype`
-:ref:`Module <valid-module>`                     :math:`\vdashmodule \module : \externtype^\ast`
+:ref:`Module <valid-module>`                     :math:`\vdashmodule \module : \externtype^\ast \to \externtype^\ast`
 ===============================================  ===============================================================================
 
 

--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -47,7 +47,7 @@ Construct                                        Judgement
 :ref:`Value <valid-val>`                         :math:`\vdashval \val : \valtype`
 :ref:`Result <valid-result>`                     :math:`\vdashresult \result : \resulttype`
 :ref:`External value <valid-externval>`          :math:`S \vdashexternval \externval : \externtype`
-:ref:`Function instance <valid-funcinst>`        :math:`S \vdashfuncinst \funcinst : \resulttype`
+:ref:`Function instance <valid-funcinst>`        :math:`S \vdashfuncinst \funcinst : \functype`
 :ref:`Table instance <valid-tableinst>`          :math:`S \vdashtableinst \tableinst : \tabletype`
 :ref:`Memory instance <valid-meminst>`           :math:`S \vdashmeminst \meminst : \memtype`
 :ref:`Global instance <valid-globalinst>`        :math:`S \vdashglobalinst \globalinst : \globaltype`
@@ -55,7 +55,7 @@ Construct                                        Judgement
 :ref:`Module instance <valid-moduleinst>`        :math:`S \vdashmoduleinst \moduleinst : C`
 :ref:`Store <valid-store>`                       :math:`\vdashstore \store \ok`
 :ref:`Configuration <valid-config>`              :math:`\vdashconfig \config \ok`
-:ref:`Thread <valid-thread>`                     :math:`S;\resulttype^? \vdashthread \thread : \resulttype^?`
+:ref:`Thread <valid-thread>`                     :math:`S;\resulttype^? \vdashthread \thread : \resulttype`
 :ref:`Frame <valid-frame>`                       :math:`S \vdashframe \frame : C`
 ===============================================  ===============================================================================
 

--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -47,7 +47,6 @@ Construct                                        Judgement
 :ref:`Value <valid-val>`                         :math:`\vdashval \val : \valtype`
 :ref:`Result <valid-result>`                     :math:`\vdashresult \result : \resulttype`
 :ref:`External value <valid-externval>`          :math:`S \vdashexternval \externval : \externtype`
-:ref:`Module instruction <valid-moduleinstr>`    :math:`S \vdashmoduleinstr \moduleinstr \ok`
 :ref:`Function instance <valid-funcinst>`        :math:`S \vdashfuncinst \funcinst : \resulttype`
 :ref:`Table instance <valid-tableinst>`          :math:`S \vdashtableinst \tableinst : \tabletype`
 :ref:`Memory instance <valid-meminst>`           :math:`S \vdashmeminst \meminst : \memtype`
@@ -105,5 +104,4 @@ Construct                                        Judgement
 ===============================================  ===============================================================================
 :ref:`Instruction <exec-instr>`                  :math:`S;F;\instr \stepto S';F';{\instr'}^\ast`
 :ref:`Expression <exec-expr>`                    :math:`S;F;\expr \stepto^\ast S';F';\val^\ast`
-:ref:`Module instruction <exec-moduleinstr>`     :math:`S;\moduleinstr \stepto S';{\moduleinstr'}^\ast`
 ===============================================  ===============================================================================

--- a/document/core/appendix/index.rst
+++ b/document/core/appendix/index.rst
@@ -6,6 +6,7 @@ Appendix
 .. toctree::
    :maxdepth: 2
 
+   embedding
    implementation
    custom
    properties

--- a/document/core/appendix/index.rst
+++ b/document/core/appendix/index.rst
@@ -8,6 +8,6 @@ Appendix
 
    embedding
    implementation
+   algorithm
    custom
    properties
-   algorithm

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -17,7 +17,7 @@ The :ref:`type system <type-system>` of WebAssembly is *sound*, implying both *t
 Soundness also is instrumental in ensuring additional properties, most notably, *encapsulation* of function and module scopes: no :ref:`locals <syntax-local>` can be accessed outside their own function and no :ref:`module <syntax-module>` components can be accessed outside their own module unless they are explicitly :ref:`exported <syntax-export>` or :ref:`imported <syntax-import>`.
 
 The typing rules defining WebAssembly :ref:`validation <valid>` only cover the *static* components of a WebAssembly program.
-In order to state and prove soundness precisely, the typing rules must be extended to the *dynamic* components of the abstract :ref:`runtime <syntax-runtime>`, that is, the :ref:`store <syntax-store>`, :ref:`configurations <syntax-config>`, and :ref:`administrative instructions <syntax-instr-admin>` as well as :ref:`module instructions <valid-moduleinstr>`. [#cite-pldi2017]_
+In order to state and prove soundness precisely, the typing rules must be extended to the *dynamic* components of the abstract :ref:`runtime <syntax-runtime>`, that is, the :ref:`store <syntax-store>`, :ref:`configurations <syntax-config>`, and :ref:`administrative instructions <syntax-instr-admin>`. [#cite-pldi2017]_
 
 
 .. index:: value, value type, result, result type, trap
@@ -98,7 +98,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
 * Each :ref:`memory instance <syntax-meminst>` :math:`\meminst_i` in :math:`S.\SMEMS` must be :ref:`valid <valid-meminst>` with some :ref:`memory type <syntax-memtype>` :math:`\memtype_i`.
 
-* Each :ref:`global instance <syntax-globalinst>` :math:`\globalinst_i` in :math:`S.\SGLOBALS` must be :ref:`valid <valid-globalinst>` with some optional  :ref:`global type <syntax-globaltype>` :math:`\globaltype_i^?`.
+* Each :ref:`global instance <syntax-globalinst>` :math:`\globalinst_i` in :math:`S.\SGLOBALS` must be :ref:`valid <valid-globalinst>` with some  :ref:`global type <syntax-globaltype>` :math:`\globaltype_i`.
 
 * Then the store is valid.
 
@@ -112,7 +112,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
      \\
      (S \vdashmeminst \meminst : \memtype)^\ast
      \qquad
-     (S \vdashglobalinst \globalinst : \globaltype^?)^\ast
+     (S \vdashglobalinst \globalinst : \globaltype)^\ast
      \\
      S = \{
        \SFUNCS~\funcinst^\ast,
@@ -354,13 +354,9 @@ Configuration Validity
 To relate the WebAssembly :ref:`type system <valid>` to its :ref:`execution semantics <exec>`, the :ref:`typing rules for instructions <valid-instr>` must be extended to :ref:`configurations <syntax-config>` :math:`S;T`,
 which relates the :ref:`store <syntax-store>` to execution :ref:`threads <syntax-thread>`.
 
-Threads may either be regular threads executing sequences of :ref:`instructions <syntax-instr>`, or module threads executing :ref:`module instructions <syntax-moduleinstr>` that represent an ongoing module instantiation.
-Regular threads are classified by their :ref:`result type <syntax-resulttype>`.
-Module threads on the other hand have no result, not even an empty one.
-Consequently, threads and configurations are cumutavily classified by an *optional* result type, where :math:`\epsilon` classifies the thread as a module computation.
-
+Configurations and threads are classified by their :ref:`result type <syntax-resulttype>`.
 In addition to the store :math:`S`, threads are typed under a *return type* :math:`\resulttype^?`, which controls whether and with which type a |return| instruction is allowed.
-This type is :math:`\epsilon`, except for instruction sequences inside an administrative |FRAME| instruction.
+This type is absent (:math:`\epsilon`) except for instruction sequences inside an administrative |FRAME| instruction.
 
 Finally, :ref:`frames <syntax-frame>` are classified with *frame contexts*, which extend the :ref:`module contexts <module-context>` of a frame's associated :ref:`module instance <syntax-moduleinst>` with the :ref:`locals <syntax-local>` that the frame contains.
 
@@ -373,17 +369,17 @@ Finally, :ref:`frames <syntax-frame>` are classified with *frame contexts*, whic
 * The :ref:`store <syntax-store>` :math:`S` must be :ref:`valid <valid-store>`.
 
 * Under no allowed return type,
-  the :ref:`thread <syntax-thread>` :math:`T` must be :ref:`valid <valid-thread>` with some optional :ref:`result type <syntax-resulttype>` :math:`[t^?]^?`.
+  the :ref:`thread <syntax-thread>` :math:`T` must be :ref:`valid <valid-thread>` with some :ref:`result type <syntax-resulttype>` :math:`[t^?]`.
 
-* Then the configuration is valid with the optional :ref:`result type <syntax-resulttype>` :math:`[t^?]^?`.
+* Then the configuration is valid with the :ref:`result type <syntax-resulttype>` :math:`[t^?]`.
 
 .. math::
    \frac{
      \vdashstore S \ok
      \qquad
-     S; \epsilon \vdashthread T : [t^?]^?
+     S; \epsilon \vdashthread T : [t^?]
    }{
-     \vdashconfig S; T : [t^?]^?
+     \vdashconfig S; T : [t^?]
    }
 
 
@@ -411,25 +407,6 @@ Finally, :ref:`frames <syntax-frame>` are classified with *frame contexts*, whic
      S; C,\CRETURN~\resulttype^? \vdashinstrseq \instr^\ast : [] \to [t^?]
    }{
      S; \resulttype^? \vdashthread F; \instr^\ast : [t^?]
-   }
-
-
-.. index:: thread, module instruction
-
-:ref:`Threads <syntax-thread>` :math:`\moduleinstr^\ast`
-........................................................
-
-* The current allowed return type must be empty.
-
-* Each :ref:`module instruction <syntax-moduleinstr>` :math:`\moduleinstr_i` in :math:`\moduleinstr^\ast` must be :ref:`valid <valid-moduleinstr>`.
-
-* Then the thread is valid with no :ref:`result type <syntax-resulttype>`.
-
-.. math::
-   \frac{
-     (S \vdashmoduleinstr \moduleinstr \ok)^\ast
-   }{
-     S; \epsilon \vdashthread \moduleinstr^\ast : \epsilon
    }
 
 
@@ -467,7 +444,7 @@ Administrative Instructions
 
 Typing rules for :ref:`administrative instructions <syntax-instr-admin>` are specified as follows.
 In addition to the :ref:`context <context>` :math:`C`, typing of these instructions is defined under a given :ref:`store <syntax-store>` :math:`S`.
-To that end, all previous typing judgements :math:`C \vdash \X{prop}` are generalized to include the store, as in :math:`S; C \vdash \X{prop}`, by implicitly adding :math:`S` to all rules -- :math:`S` is never modified by the pre-existing rules, but it is accessed in the new rules for :ref:`administrative instructions <valid-instr-admin>` and  :ref:`module instructions <valid-moduleinstr>` given below.
+To that end, all previous typing judgements :math:`C \vdash \X{prop}` are generalized to include the store, as in :math:`S; C \vdash \X{prop}`, by implicitly adding :math:`S` to all rules -- :math:`S` is never modified by the pre-existing rules, but it is accessed in the extra rules for :ref:`administrative instructions <valid-instr-admin>` given below.
 
 
 .. index:: trap
@@ -498,6 +475,54 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
      S \vdashexternval \EVFUNC~\funcaddr : \ETFUNC~[t_1^\ast] \to [t_2^\ast]
    }{
      S; C \vdashadmininstr \INVOKE~\funcaddr : [t_1^\ast] \to [t_2^\ast]
+   }
+
+
+.. index:: element, table, table address, module instance, function index
+
+:math:`\INITELEM~\tableaddr~o~x^n`
+..................................
+
+* The :ref:`external table value <syntax-externval>` :math:`\EVTABLE~\tableaddr` must be :ref:`valid <valid-externval-table>` with some :ref:`external table type <syntax-externtype>` :math:`\ETTABLE~\limits~\ANYFUNC`.
+
+* The index :math:`o + n` must be smaller than or equal to :math:`\limits.\LMIN`.
+
+* The :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst` must be :ref:`valid <valid-moduleinst>` with some :ref:`context <context>` :math:`C`.
+
+* Each :ref:`function index <syntax-funcidx>` :math:`x_i` in :math:`x^n` must be defined in the context :math:`C`.
+
+* Then the instruction is valid.
+
+.. math::
+   \frac{
+     S \vdashexternval \EVTABLE~\tableaddr : \ETTABLE~\limits~\ANYFUNC
+     \qquad
+     o + n \leq \limits.\LMIN
+     \qquad
+     (C.\CFUNCS[x] = \functype)^n
+   }{
+     S; C \vdashadmininstr \INITELEM~\tableaddr~o~x^n \ok
+   }
+
+
+.. index:: data, memory, memory address, byte
+
+:math:`\INITDATA~\memaddr~o~b^n`
+................................
+
+* The :ref:`external memory value <syntax-externval>` :math:`\EVMEM~\memaddr` must be :ref:`valid <valid-externval-mem>` with some :ref:`external memory type <syntax-externtype>` :math:`\ETMEM~\limits`.
+
+* The index :math:`o + n` must be smaller than or equal to :math:`\limits.\LMIN` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
+
+* Then the instruction is valid.
+
+.. math::
+   \frac{
+     S \vdashexternval \EVMEM~\memaddr : \ETMEM~\limits
+     \qquad
+     o + n \leq \limits.\LMIN \cdot 64\,\F{Ki}
+   }{
+     S; C \vdashadmininstr \INITDATA~\memaddr~o~b^n \ok
    }
 
 
@@ -541,104 +566,6 @@ To that end, all previous typing judgements :math:`C \vdash \X{prop}` are genera
    }{
      S; C \vdashadmininstr \FRAME_n\{F\}~\instr^\ast~\END : [] \to [t^n]
    }
-
-
-.. index:: module instruction, store
-.. _valid-moduleinstr:
-
-Module Instructions
-~~~~~~~~~~~~~~~~~~~
-
-Typing rules for :ref:`module instructions <valid-moduleinstr>` are specified as follows.
-Unlike regular instructions, module instructions do not use the operand stack, and consequently, are not classified by a type.
-
-
-.. index:: instantiation, external value, external type
-
-:math:`\INSTANTIATE~\module~\externval^\ast`
-............................................
-
-* Each :ref:`external value <syntax-externval>` :math:`\externval_i` in :math:`\externval^\ast` must be :ref:`valid <valid-externval>` with some :ref:`external type <syntax-externtype>` :math:`\externtype_i`.
-
-* Then the module instruction is valid.
-
-.. math::
-   \frac{
-     (S \vdashexternval \externval : \externtype)^\ast
-   }{
-     S \vdashmoduleinstr \INSTANTIATE~\module~\externval^\ast \ok
-   }
-
-
-.. index:: element, table, table address, module instance, function index
-
-:math:`\INITELEM~\tableaddr~o~\moduleinst~x^n`
-..............................................
-
-* The :ref:`external table value <syntax-externval>` :math:`\EVTABLE~\tableaddr` must be :ref:`valid <valid-externval-table>` with some :ref:`external table type <syntax-externtype>` :math:`\ETTABLE~\limits~\ANYFUNC`.
-
-* The index :math:`o + n` must be smaller than or equal to :math:`\limits.\LMIN`.
-
-* The :ref:`module instance <syntax-moduleinst>` :math:`\moduleinst` must be :ref:`valid <valid-moduleinst>` with some :ref:`context <context>` :math:`C`.
-
-* Each :ref:`function index <syntax-funcidx>` :math:`x_i` in :math:`x^n` must be defined in the context :math:`C`.
-
-* Then the module instruction is valid.
-
-.. math::
-   \frac{
-     \begin{array}{@{}rl@{}}
-     S \vdashexternval \EVTABLE~\tableaddr : \ETTABLE~\limits~\ANYFUNC
-     \qquad&
-     o + n \leq \limits.\LMIN
-     \\
-     S \vdashmoduleinst \moduleinst : C
-     \qquad&
-     (C.\CFUNCS[x] = \functype)^n
-     \end{array}
-   }{
-     S \vdashmoduleinstr \INITELEM~\tableaddr~o~\moduleinst~x^n \ok
-   }
-
-
-.. index:: data, memory, memory address, byte
-
-:math:`\INITDATA~\memaddr~o~b^n`
-................................
-
-* The :ref:`external memory value <syntax-externval>` :math:`\EVMEM~\memaddr` must be :ref:`valid <valid-externval-mem>` with some :ref:`external memory type <syntax-externtype>` :math:`\ETMEM~\limits`.
-
-* The index :math:`o + n` must be smaller than or equal to :math:`\limits.\LMIN` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
-
-* Then the module instruction is valid.
-
-.. math::
-   \frac{
-     S \vdashexternval \EVMEM~\memaddr : \ETMEM~\limits
-     \qquad
-     o + n \leq \limits.\LMIN \cdot 64\,\F{Ki}
-   }{
-     S \vdashmoduleinstr \INITDATA~\memaddr~o~b^n \ok
-   }
-
-
-.. index:: instruction, context
-
-:math:`\instr`
-..............
-
-* Under an empty :ref:`context <context>`,
-  the :ref:`instruction <syntax-instr>` :math:`\instr` must be valid with type :math:`[] \to []`.
-
-* Then the instruction is valid as a module instruction.
-
-.. math::
-   \frac{
-     S; \{\} \vdashinstr \instr : [] \to []
-   }{
-     S \vdashmoduleinstr \instr \ok
-   }
-
 
 
 .. index:: ! store extension, store
@@ -785,16 +712,16 @@ Given the definition of :ref:`valid configurations <valid-config>`,
 the standard soundness theorems hold.
 
 **Theorem (Preservation).**
-If the :ref:`configuration <syntax-config>` :math:`S;T` is :ref:`valid <valid-config>` with optional :ref:`result type <syntax-resulttype>` :math:`[t^\ast]^?` (i.e., :math:`\vdashconfig S;T : [t^\ast]^?`),
+If the :ref:`configuration <syntax-config>` :math:`S;T` is :ref:`valid <valid-config>` with :ref:`result type <syntax-resulttype>` :math:`[t^\ast]` (i.e., :math:`\vdashconfig S;T : [t^\ast]`),
 and steps to :math:`S';T'` (i.e., :math:`S;T \stepto S';T'`),
-then :math:`S';T'` is a valid configuration with the same optional resulttype (i.e., :math:`\vdashconfig S';T' : [t^\ast]^?`).
+then :math:`S';T'` is a valid configuration with the same resulttype (i.e., :math:`\vdashconfig S';T' : [t^\ast]`).
 Furthermore, :math:`S'` is an :ref:`extension <extend-store>` of :math:`S` (i.e., :math:`\vdashstoreextends S \extendsto S'`).
 
-A *terminal* :ref:`thread <syntax-thread>` is either an empty sequence of :ref:`module instructions <syntax-moduleinstr>`, a |TRAP| instruction, or a sequence :math:`\val^\ast` of :ref:`values <syntax-val>` (paired with a :ref:`frame <syntax-frame>`).
+A *terminal* :ref:`thread <syntax-thread>` is one whose sequence of :ref:`instructions <syntax-instr>` is a :ref:`result <syntax-result>`.
 A terminal configuration is a configuration whose thread is terminal.
 
 **Theorem (Progress).**
-If the :ref:`configuration <syntax-config>` :math:`S;T` is :ref:`valid <valid-config>` (i.e., :math:`\vdashconfig S;T : [t^\ast]^?` with some optional :ref:`result type <syntax-resulttype>` :math:`[t^\ast]^?`),
+If the :ref:`configuration <syntax-config>` :math:`S;T` is :ref:`valid <valid-config>` (i.e., :math:`\vdashconfig S;T : [t^\ast]` with some :ref:`result type <syntax-resulttype>` :math:`[t^\ast]`),
 then either it is terminal,
 or it can step to some configuration :math:`S';T'` (i.e., :math:`S;T \stepto S';T'`).
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -432,7 +432,7 @@ Memory Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     (\iff & \X{ea} = i + \memarg.\OFFSET \\
      \wedge & \X{ea} + |t|/8 \leq |S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA| \\
      \wedge & \bytes_t(c) = S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA[\X{ea} \slice |t|/8])
      \end{array}
@@ -443,7 +443,7 @@ Memory Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     (\iff & \X{ea} = i + \memarg.\OFFSET \\
      \wedge & \X{ea} + N/8 \leq |S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA| \\
      \wedge & \bytes_{\iN}(n) = S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA[\X{ea} \slice N/8])
      \end{array}
@@ -510,7 +510,7 @@ Memory Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     (\iff & \X{ea} = i + \memarg.\OFFSET \\
      \wedge & \X{ea} + |t|/8 \leq |S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA| \\
      \wedge & S' = S \with \SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA[\X{ea} \slice |t|/8] = \bytes_t(c)
      \end{array}
@@ -520,7 +520,7 @@ Memory Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & \X{ea} = i + \memarg.\OFFSET \\
+     (\iff & \X{ea} = i + \memarg.\OFFSET \\
      \wedge & \X{ea} + N/8 \leq |S.\SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA| \\
      \wedge & S' = S \with \SMEMS[F.\AMODULE.\MIMEMS[0]].\MIDATA[\X{ea} \slice N/8] = \bytes_{\iN}(\wrap_{|t|,N}(c))
      \end{array}
@@ -583,21 +583,13 @@ Memory Instructions
 
 8. Pop the value :math:`\I32.\CONST~n` from the stack.
 
-9. If :math:`\X{mem}.\MIMAX` is not empty and :math:`\X{sz} + n` is larger than :math:`\X{mem}.\MIMAX`, then:
+9. Either, try :ref:`growing <grow-mem>` :math:`\X{mem}` by :math:`n` :ref:`pages <page-size>`:
 
-  a. Push the value :math:`\I32.\CONST~(-1)` to the stack.
+   a. If it succeeds, push the value :math:`\I32.\CONST~\X{sz}` to the stack.
 
-10. Else, either:
+   b. Else, push the value :math:`\I32.\CONST~(-1)` to the stack.
 
-    a. Let :math:`\X{len}` be :math:`n` multiplied with the :ref:`page size <page-size>`.
-
-    b. Append :math:`\X{len}` bytes with value :math:`\hex{00}` to :math:`S.\SMEMS[a]`.
-
-    c. Push the value :math:`\I32.\CONST~\X{sz}` to the stack.
-
-11. Or:
-
-    a. Push the value :math:`\I32.\CONST~(-1)` to the stack.
+10. Or, push the value :math:`\I32.\CONST~(-1)` to the stack.
 
 .. math::
    ~\\[-1ex]
@@ -607,10 +599,8 @@ Memory Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & F.\AMODULE.\MIMEMS[0] = a \\
-     \wedge & |S.\SMEMS[a].\MIDATA| = \X{sz}\cdot64\,\F{Ki} \\
-     \wedge & (\X{sz} + n \leq S.\SMEMS[a].\MIMAX \vee S.\SMEMS[a].\MIMAX = \epsilon) \\
-     \wedge & S' = S \with \SMEMS[a].\MIDATA = S.\SMEMS[a].\MIDATA~(\hex{00})^{n\cdot64\,\F{Ki}}) \\
+     (\iff & F.\AMODULE.\MIMEMS[0] = a \\
+     \wedge & S' = S \with \SMEMS[a] = \growmem(S.\SMEMS[a], n)) \\
      \end{array}
    \\[1ex]
    \begin{array}{lcl@{\qquad}l}
@@ -624,7 +614,7 @@ Memory Instructions
    or fail, returning :math:`{-1}`.
    Failure *must* occur if the referenced memory instance has a maximum size defined that would be exceeded.
    However, failure *can* occur in other cases as well.
-   In practice, the choice depends on the resources available to the :ref:`embedder <embedder>`.
+   In practice, the choice depends on the :ref:`resources <impl-exec>` available to the :ref:`embedder <embedder>`.
 
 
 .. index:: control instructions, structured control, label, block, branch, result type, label index, function index, type index, vector, address, table address, table instance, store, frame
@@ -930,7 +920,7 @@ Control Instructions
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & S.\STABLES[F.\AMODULE.\MITABLES[0]].\TIELEM[i] = a \\
+     (\iff & S.\STABLES[F.\AMODULE.\MITABLES[0]].\TIELEM[i] = a \\
      \wedge & S.\SFUNCS[a] = f \\
      \wedge & F.\AMODULE.\MITYPES[x] = f.\FITYPE)
      \end{array}
@@ -1044,7 +1034,7 @@ Invocation of :ref:`function address <syntax-funcaddr>` :math:`a`
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & S.\SFUNCS[a] = f \\
+     (\iff & S.\SFUNCS[a] = f \\
      \wedge & f.\FITYPE = [t_1^n] \to [t_2^m] \\
      \wedge & f.\FICODE = \{ \FTYPE~x, \FLOCALS~t^k, \FBODY~\instr^\ast~\END \} \\
      \wedge & F = \{ \AMODULE~f.\FIMODULE, ~\ALOCALS~\val^n~(t.\CONST~0)^k \})
@@ -1105,7 +1095,7 @@ Furthermore, the resulting store must be :ref:`valid <valid-store>`, i.e., all d
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\mbox{if} & S.\SFUNCS[a] = \{ \FITYPE~[t_1^n] \to [t_2^m], \FIHOSTCODE~\X{hf} \} \\
+     (\iff & S.\SFUNCS[a] = \{ \FITYPE~[t_1^n] \to [t_2^m], \FIHOSTCODE~\X{hf} \} \\
      \wedge & \X{hf}(S; \val^n) = S'; \result) \\
      \end{array} \\
    \end{array}

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -636,7 +636,7 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      (\INVOKE~\funcaddr)^? \\
      \end{array} \\
    &(\iff
-     & \vdashmodule \module : \externtype^n \\
+     & \vdashmodule \module : \externtype^n \to {\externtype'}^\ast \\
      &\wedge& (\vdashexternval \externval : \externtype')^n \\
      &\wedge& (\vdashexterntypematch \externtype' \matches \externtype)^n \\[1ex]
      &\wedge& \module.\MGLOBALS = \global^k \\
@@ -729,7 +729,7 @@ The values :math:`\val_{\F{res}}^m` are returned as the results of the invocatio
 .. math::
    ~\\[-1ex]
    \begin{array}{@{}lcl}
-   \invoke(S, \funcaddr, \val^n) &=& \result \\
+   \invoke(S, \funcaddr, \val^n) &=& S', \result \\
      &(\iff & S.\SFUNCS[\funcaddr].\FITYPE = [t_1^n] \to [t_2^m] \\
      &\wedge& \val^n = (t_1.\CONST~c)^n \\
      &\wedge& S; \val^n~(\INVOKE~\funcaddr) \stepto^\ast S'; \result) \\

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -684,10 +684,10 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      &\wedge& \module.\MDATA = \data^\ast \\
      &\wedge& \module.\MSTART = \start^? \\[1ex]
      &\wedge& S', \moduleinst = \F{allocmodule}(S, \module, \externval^n, v^\ast) \\
-     &\wedge& F' = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
-     &\wedge& (S'; F'; \global.\GINIT \stepto^\ast S'; F'; v)^\ast \\
-     &\wedge& (S'; F'; \elem.\EOFFSET \stepto^\ast S'; F'; \I32.\CONST~\X{eo})^\ast \\
-     &\wedge& (S'; F'; \data.\DOFFSET \stepto^\ast S'; F'; \I32.\CONST~\X{do})^\ast \\[1ex]
+     &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
+     &\wedge& (S'; F; \global.\GINIT \stepto^\ast S'; F; v)^\ast \\
+     &\wedge& (S'; F; \elem.\EOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{eo})^\ast \\
+     &\wedge& (S'; F; \data.\DOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{do})^\ast \\[1ex]
      &\wedge& (\X{eo} + |\elem.\EINIT| \leq |S'.\STABLES[\tableaddr].\TIELEM|)^\ast \\
      &\wedge& (\X{do} + |\data.\DINIT| \leq |S'.\SMEMS[\memaddr].\MIDATA|)^\ast
      )

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -371,6 +371,46 @@ New instances of :ref:`functions <syntax-funcinst>`, :ref:`tables <syntax-tablei
    \end{array}
 
 
+.. index:: table, table instance, table address, grow, limits
+.. _grow-table:
+
+Growing :ref:`tables <syntax-tableinst>`
+........................................
+
+1. Let :math:`\tableinst` be the :ref:`table instance <syntax-tableinst>` to grow and :math:`n` the number of elements by which to grow it.
+
+2. If :math:`\tableinst.\TIMAX` is not empty and smaller than :math:`n` added to the length of :math:`\tableinst.\TIELEM`, then fail.
+
+3. Append :math:`n` empty elements to :math:`\tableinst.\TIELEM`.
+
+.. math::
+   \begin{array}{rllll}
+   \growtable(\tableinst, n) &=& \tableinst \with \TIELEM = \tableinst.\TIELEM~(\epsilon)^n \\
+     && (\iff \tableinst.\TIMAX = \epsilon \vee |\tableinst.\TIELEM| + n \leq \tableinst.\TIMAX) \\
+   \end{array}
+
+
+.. index:: memory, memory instance, memory address, grow, limits
+.. _grow-mem:
+
+Growing :ref:`memories <syntax-meminst>`
+........................................
+
+1. Let :math:`\meminst` be the :ref:`memory instance <syntax-meminst>` to grow and :math:`n` the number of :ref:`pages <page-size>` by which to grow it.
+
+2. If :math:`\meminst.\MIMAX` is not empty and smaller than :math:`n` added to the length of :math:`\meminst.\MIDATA` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`, then fail.
+
+3. Let :math:`\X{len}` be :math:`n` times the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
+
+4. Append :math:`\X{len}` :ref:`bytes <syntax-byte>` with value :math:`\hex{00}` to :math:`\meminst.\MIDATA`.
+
+.. math::
+   \begin{array}{rllll}
+   \growmem(\meminst, n) &=& \meminst \with \MIDATA = \meminst.\MIDATA~(\hex{00})^{n \cdot 64\,\F{Ki}} \\
+     && (\iff \meminst.\MIMAX = \epsilon \vee |\meminst.\MIDATA| + n \cdot 64\,\F{Ki} \leq \meminst.\MIMAX \cdot 64\,\F{Ki}) \\
+   \end{array}
+
+
 .. index:: module, module instance, function instance, table instance, memory instance, global instance, export instance, function address, table address, memory address, global address, function index, table index, memory index, global index, type, function, table, memory, global, import, export, external value, external type, matching
 .. _alloc-module:
 

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -398,9 +398,9 @@ Growing :ref:`memories <syntax-meminst>`
 
 1. Let :math:`\meminst` be the :ref:`memory instance <syntax-meminst>` to grow and :math:`n` the number of :ref:`pages <page-size>` by which to grow it.
 
-2. If :math:`\meminst.\MIMAX` is not empty and smaller than :math:`n` added to the length of :math:`\meminst.\MIDATA` divided by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`, then fail.
+2. Let :math:`\X{len}` be :math:`n` multiplied by the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
 
-3. Let :math:`\X{len}` be :math:`n` times the :ref:`page size <page-size>` :math:`64\,\F{Ki}`.
+3. If :math:`\meminst.\MIMAX` is not empty and its value multiplied by the :ref:`page size <page-size>` :math:`64\,\F{Ki}` is smaller than :math:`\X{len}` added to the length of :math:`\meminst.\MIDATA`, then fail.
 
 4. Append :math:`\X{len}` :ref:`bytes <syntax-byte>` with value :math:`\hex{00}` to :math:`\meminst.\MIDATA`.
 

--- a/document/core/text/lexical.rst
+++ b/document/core/text/lexical.rst
@@ -8,6 +8,7 @@ Lexical Format
 .. index:: ! character, Unicode, ASCII, code point, ! source text
    pair: text format; character
 .. _source:
+.. _text-source:
 .. _text-char:
 
 Characters
@@ -18,6 +19,8 @@ Characters are assumed to be represented as valid |Unicode|_ (Section 2.4) *code
 
 .. math::
    \begin{array}{llll}
+   \production{source} & \Tsource &::=&
+     \Tchar^\ast \\
    \production{character} & \Tchar &::=&
      \unicode{00} ~|~ \dots ~|~ \unicode{D7FF} ~|~ \unicode{E000} ~|~ \dots ~|~ \unicode{10FFFF} \\
    \end{array}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -860,10 +860,8 @@
 
 .. |TRAP| mathdef:: \xref{exec/runtime}{syntax-trap}{\K{trap}}
 .. |INVOKE| mathdef:: \xref{exec/runtime}{syntax-invoke}{\K{invoke}}
-.. |INSTANTIATE| mathdef:: \xref{exec/runtime}{syntax-instantiate}{\K{instantiate}}
 .. |INITELEM| mathdef:: \xref{exec/runtime}{syntax-init_elem}{\K{init\_elem}}
 .. |INITDATA| mathdef:: \xref{exec/runtime}{syntax-init_data}{\K{init\_data}}
-.. |DO| mathdef:: \xref{exec/runtime}{syntax-do}{\K{do}}
 
 
 .. Values & Results, non-terminals
@@ -873,8 +871,6 @@
 
 
 .. Administrative Instructions, non-terminals
-
-.. |moduleinstr| mathdef:: \xref{exec/runtime}{syntax-moduleinstr}{\X{moduleinstr}}
 
 .. |XB| mathdef:: \xref{exec/runtime}{syntax-ctxt-block}{B}
 
@@ -970,6 +966,7 @@
 
 .. Other meta functions
 
+.. |instantiate| mathdef:: \xref{exec/modules}{exec-instantiation}{\F{instantiate}}
 .. |invoke| mathdef:: \xref{exec/modules}{exec-invocation}{\F{invoke}}
 
 
@@ -987,7 +984,6 @@
 .. Judgements
 
 .. |vdashadmininstr| mathdef:: \xref{appendix/properties}{valid-instr-admin}{\vdash}
-.. |vdashmoduleinstr| mathdef:: \xref{appendix/properties}{valid-moduleinstr}{\vdash}
 
 .. |vdashval| mathdef:: \xref{appendix/properties}{valid-val}{\vdash}
 .. |vdashresult| mathdef:: \xref{appendix/properties}{valid-result}{\vdash}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -531,6 +531,7 @@
 
 .. Lexical grammar, non-terminals
 
+.. |Tsource| mathdef:: \xref{text/lexical}{text-source}{\T{source}}
 .. |Tchar| mathdef:: \xref{text/lexical}{text-char}{\T{char}}
 .. |Tspace| mathdef:: \xref{text/lexical}{text-space}{\T{space}}
 .. |Tformat| mathdef:: \xref{text/lexical}{text-format}{\T{format}}
@@ -1024,3 +1025,10 @@
 .. |Bmodulenamesubsec| mathdef:: \xref{appendix/custom}{binary-modulenamesec}{\B{modulenamesubsec}}
 .. |Bfuncnamesubsec| mathdef:: \xref{appendix/custom}{binary-funcnamesec}{\B{funcnamesubsec}}
 .. |Blocalnamesubsec| mathdef:: \xref{appendix/custom}{binary-localnamesec}{\B{localnamesubsec}}
+
+
+.. Embedding
+.. ---------
+
+.. |error| mathdef:: \xref{appendix/embedding}{embed-error}{\X{error}}
+.. |ERROR| mathdef:: \xref{appendix/embedding}{embed-error}{\K{error}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -760,6 +760,9 @@
 .. |allocglobal| mathdef:: \xref{exec/modules}{alloc-global}{\F{allocglobal}}
 .. |allocmodule| mathdef:: \xref{exec/modules}{alloc-module}{\F{allocmodule}}
 
+.. |growtable| mathdef:: \xref{exec/modules}{grow-table}{\F{growtable}}
+.. |growmem| mathdef:: \xref{exec/modules}{grow-mem}{\F{growmem}}
+
 
 .. Addresses, non-terminals
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -253,22 +253,21 @@ Start function declarations :math:`\start` are not classified by any type.
 Exports
 ~~~~~~~
 
-Exports :math:`\export` are classified by their export :ref:`name <syntax-name>`.
-Export descriptions :math:`\exportdesc` are not classified by any type.
+Exports :math:`\export` and export descriptions :math:`\exportdesc` are classified by their their :ref:`external type <syntax-externtype>`.
 
 
 :math:`\{ \ENAME~\name, \EDESC~\exportdesc \}`
 ..............................................
 
-* The export description :math:`\exportdesc` must be valid with type :math:`\externtype`.
+* The export description :math:`\exportdesc` must be valid with :ref:`external type <syntax-externtype>` :math:`\externtype`.
 
-* Then the export is valid with name :math:`\name`.
+* Then the export is valid with :ref:`external type <syntax-externtype>` :math:`\externtype`.
 
 .. math::
    \frac{
-     C \vdashexportdesc \exportdesc \ok
+     C \vdashexportdesc \exportdesc : \externtype
    }{
-     C \vdashexport \{ \ENAME~\name, \EDESC~\exportdesc \} : \name
+     C \vdashexport \{ \ENAME~\name, \EDESC~\exportdesc \} : \externtype
    }
 
 
@@ -277,13 +276,13 @@ Export descriptions :math:`\exportdesc` are not classified by any type.
 
 * The function :math:`C.\CFUNCS[x]` must be defined in the context.
 
-* Then the export description is valid.
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETFUNC~C.\CFUNCS[x]`.
 
 .. math::
    \frac{
      C.\CFUNCS[x] = \functype
    }{
-     C \vdashexportdesc \EDFUNC~x \ok
+     C \vdashexportdesc \EDFUNC~x : \ETFUNC~\functype
    }
 
 
@@ -292,13 +291,13 @@ Export descriptions :math:`\exportdesc` are not classified by any type.
 
 * The table :math:`C.\CTABLES[x]` must be defined in the context.
 
-* Then the export description is valid.
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETTABLE~C.\CTABLES[x]`.
 
 .. math::
    \frac{
      C.\CTABLES[x] = \tabletype
    }{
-     C \vdashexportdesc \EDTABLE~x \ok
+     C \vdashexportdesc \EDTABLE~x : \ETTABLE~\tabletype
    }
 
 
@@ -307,13 +306,13 @@ Export descriptions :math:`\exportdesc` are not classified by any type.
 
 * The memory :math:`C.\CMEMS[x]` must be defined in the context.
 
-* Then the export description is valid.
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETMEM~C.\CMEMS[x]`.
 
 .. math::
    \frac{
      C.\CMEMS[x] = \memtype
    }{
-     C \vdashexportdesc \EDMEM~x \ok
+     C \vdashexportdesc \EDMEM~x : \ETMEM~\memtype
    }
 
 
@@ -326,13 +325,13 @@ Export descriptions :math:`\exportdesc` are not classified by any type.
 
 * The mutability :math:`\mut` must be |MCONST|.
 
-* Then the export description is valid.
+* Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~C.\CGLOBALS[x]`.
 
 .. math::
    \frac{
      C.\CGLOBALS[x] = \MCONST~t
    }{
-     C \vdashexportdesc \EDGLOBAL~x \ok
+     C \vdashexportdesc \EDGLOBAL~x : \ETGLOBAL~(\MCONST~t)
    }
 
 
@@ -435,6 +434,8 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
 Modules
 ~~~~~~~
 
+Modules are classified by their mapping from the :ref:`external types <syntax-externtype>` of their :ref:`imports <syntax-import>` to those of their :ref:`exports <syntax-export>`.
+
 A module is entirely *closed*,
 that is, its components can only refer to definitions that appear in the module itself.
 Consequently, no initial :ref:`context <context>` is required.
@@ -498,17 +499,19 @@ Instead, the context :math:`C` for validation of the module's content is constru
     the segment :math:`\import_i` must be :ref:`valid <valid-import>` with an :ref:`external type <syntax-externtype>` :math:`\externtype_i`.
 
   * For each :math:`\export_i` in :math:`\module.\MEXPORTS`,
-    the segment :math:`\import_i` must be :ref:`valid <valid-export>` with a :ref:`name <syntax-name>` :math:`\name_i`.
+    the segment :math:`\import_i` must be :ref:`valid <valid-export>` with :ref:`external type <syntax-externtype> :math:`\externtype'_i`.
 
 * The length of :math:`C.\CTABLES` must not be larger than :math:`1`.
 
 * The length of :math:`C.\CMEMS` must not be larger than :math:`1`.
 
-* All export names :math:`\name_i` must be different.
+* All export names :math:`\export_i.\ENAME` must be different.
 
 * Let :math:`\externtype^\ast` be the concatenation of :ref:`external types <syntax-externtype>` :math:`\externtype_i` of the imports, in index order.
 
-* Then the module is valid with :ref:`external types <syntax-externtype>` :math:`\externtype^\ast`.
+* Let :math:`{\externtype'}^\ast` be the concatenation of :ref:`external types <syntax-externtype>` :math:`\externtype'_i` of the exports, in index order.
+
+* Then the module is valid with :ref:`external types <syntax-externtype>` :math:`\externtype^\ast \to {\externtype'}^\ast`.
 
 .. math::
    \frac{
@@ -531,7 +534,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \quad
      (C \vdashimport \import : \X{it})^\ast
      \quad
-     (C \vdashexport \export : \X{name})^\ast
+     (C \vdashexport \export : \X{et})^\ast
      \\
      \X{ift}^\ast = \etfuncs(\X{it}^\ast)
      \qquad
@@ -549,7 +552,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \qquad
      |C.\CMEMS| \leq 1
      \qquad
-     \name^\ast ~\F{disjoint}
+     (\export.\ENAME)^\ast ~\F{disjoint}
      \end{array}
    }{
      \vdashmodule \{
@@ -563,7 +566,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
          \MDATA~\data^\ast,
          \MSTART~\start^?,
          \MIMPORTS~\import^\ast,
-         \MEXPORTS~\export^\ast \} : \X{it}^\ast \\
+         \MEXPORTS~\export^\ast \} : \X{it}^\ast \to \X{et}^\ast \\
        \end{array}
    }
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -499,7 +499,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
     the segment :math:`\import_i` must be :ref:`valid <valid-import>` with an :ref:`external type <syntax-externtype>` :math:`\externtype_i`.
 
   * For each :math:`\export_i` in :math:`\module.\MEXPORTS`,
-    the segment :math:`\import_i` must be :ref:`valid <valid-export>` with :ref:`external type <syntax-externtype> :math:`\externtype'_i`.
+    the segment :math:`\import_i` must be :ref:`valid <valid-export>` with :ref:`external type <syntax-externtype>` :math:`\externtype'_i`.
 
 * The length of :math:`C.\CTABLES` must not be larger than :math:`1`.
 


### PR DESCRIPTION
This PR adds an appendix defining an "embedder interface", i.e., entry points that other specs like the JS API can reference to define the operations that they provide to a host environment. The intention is that this interface is complete in the sense that no other parts of the core spec (except pieces of the abstract syntax, like types and values) need to be directly referenced from an embedder spec.

Preview at: https://webassembly.github.io/spec/appendix/embedding.html