### PR TITLE
Mention suggested MIME type in Binary Format | Conventions

### DIFF
--- a/document/core/binary/conventions.rst
+++ b/document/core/binary/conventions.rst
@@ -20,7 +20,8 @@ Except for a few exceptions, the binary grammar closely mirrors the grammar of t
    Implementations of decoders must support all possible alternatives;
    implementations of encoders can pick any allowed encoding.
 
-The recommended extension for files containing WebAssembly modules in binary format is ":math:`\T{.wasm}`".
+The recommended extension for files containing WebAssembly modules in binary format is ":math:`\T{.wasm}`"
+and the recommended Media Type is ":math:`\T{application/wasm}`".
 
 .. [#compression]
    Additional encoding layers -- for example, introducing compression -- may be defined on top of the basic representation defined here.

--- a/document/core/binary/conventions.rst
+++ b/document/core/binary/conventions.rst
@@ -21,7 +21,7 @@ Except for a few exceptions, the binary grammar closely mirrors the grammar of t
    implementations of encoders can pick any allowed encoding.
 
 The recommended extension for files containing WebAssembly modules in binary format is ":math:`\T{.wasm}`"
-and the recommended Media Type is ":math:`\T{application/wasm}`".
+and the recommended |MediaType|_ is ":math:`\T{application/wasm}`".
 
 .. [#compression]
    Additional encoding layers -- for example, introducing compression -- may be defined on top of the basic representation defined here.

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -29,6 +29,8 @@
 .. |SExpressions| replace:: S-expressions
 .. _SExpressions: https://en.wikipedia.org/wiki/S-expression
 
+.. |MediaType| replace:: Media Type
+.. _MediaType: https://www.iana.org/assignments/media-types/media-types.xhtml
 
 .. Literature
 .. ----------


### PR DESCRIPTION
As discussed in #583.  Reading https://www.iana.org/assignments/media-types/media-types.xhtml it seems like the more modern name is "Media Type".