### PR TITLE
 [spec] Use typeuse syntax for call_indirect

### DIFF
--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -87,7 +87,7 @@ The same label identifier may optionally be repeated after the corresponding :ma
 All other control instruction are represented verbatim.
 
 .. math::
-   \begin{array}{llclll}
+   \begin{array}{llcllll}
    \production{plain instruction} & \Tplaininstr_I &::=&
      \text{unreachable} &\Rightarrow& \UNREACHABLE \\ &&|&
      \text{nop} &\Rightarrow& \NOP \\ &&|&
@@ -97,8 +97,12 @@ All other control instruction are represented verbatim.
        &\Rightarrow& \BRTABLE~l^\ast~l_N \\ &&|&
      \text{return} &\Rightarrow& \RETURN \\ &&|&
      \text{call}~~x{:}\Tfuncidx_I &\Rightarrow& \CALL~x \\ &&|&
-     \text{call\_indirect}~~x{:}\Ttypeidx_I &\Rightarrow& \CALLINDIRECT~x \\
+     \text{call\_indirect}~~x,I'{:}\Ttypeuse_I &\Rightarrow& \CALLINDIRECT~x
+       & (\iff I' = \{\}) \\
    \end{array}
+
+.. note::
+   The side condition stating that the :ref:`identifier context <text-context>` :math:`I'` must be empty in the rule for |CALLINDIRECT| enforces that no identifier can be bound in any |Tparam| declaration appearing in the type annotation.
 
 
 Abbreviations


### PR DESCRIPTION
This is a late but small change/extension to the text format that I floated with some people.

Instead of a simple type index, the call signature for `call_indirect` is specified using the existing `typeuse` syntax used e.g. in function declarations:
```
call_indirect (type $t)
call_indirect (param i32 i32)
call_indirect (param i32 i64) (result i32)
```
That makes it consistent with how types are/will be referenced elsewhere (besides function declarations, e.g. in block signatures in the [multi-value proposal](https://github.com/WebAssembly/multi-value/)). Furthermore, as the example shows, it implies that you can write the call signature inline, like for functions and blocks.

The expansion rules are like for function declarations. However, inline types for call_indirect must not include parameter names.