### PR TITLE
[spec] read_table returns an optional function address

### DIFF
--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -327,7 +327,7 @@ Tables
 .. _embed-read-table:
 
 :math:`\F{read\_table}(\store, \tableaddr, i) : \funcaddr^? ~|~ \error`
-.....................................................................
+.......................................................................
 
 1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.
 

--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -326,7 +326,7 @@ Tables
 
 .. _embed-read-table:
 
-:math:`\F{read\_table}(\store, \tableaddr, i) : \funcaddr ~|~ \error`
+:math:`\F{read\_table}(\store, \tableaddr, i) : \funcaddr^? ~|~ \error`
 .....................................................................
 
 1. Assert: :math:`\store.\STABLES[\tableaddr]` exists.


### PR DESCRIPTION
The formal definition is correct, but the return type of the `read_table` embedding function in the prose misses the optional sign.