### PR TITLE
[spec] Make the `invoke` function return a full machine configuration

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -772,10 +772,5 @@ The values :math:`\val_{\F{res}}^m` are returned as the results of the invocatio
    \invoke(S, \funcaddr, \val^n) &=& S; F; \val^n~(\INVOKE~\funcaddr) \\
      &(\iff & S.\SFUNCS[\funcaddr].\FITYPE = [t_1^n] \to [t_2^m] \\
      &\wedge& \val^n = (t_1.\CONST~c)^n) \\
-     &\wedge& \moduleinst = \{~
-       \begin{array}[t]{@{}l@{}}
-       \MITYPES~\epsilon, \MIFUNCS~\epsilon, \MITABLES~\epsilon, \\
-       \MIMEMS~\epsilon, \MIGLOBALS~\epsilon, \MIEXPORTS~\epsilon ~\}
-       \end{array} \\
-     &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\
+     &\wedge& F = \{ \AMODULE~\{\}, \ALOCALS~\epsilon \} \\
    \end{array}

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -769,7 +769,13 @@ The values :math:`\val_{\F{res}}^m` are returned as the results of the invocatio
 .. math::
    ~\\[-1ex]
    \begin{array}{@{}lcl}
-   \invoke(S, \funcaddr, \val^n) &=& S; \val^n~(\INVOKE~\funcaddr) \\
+   \invoke(S, \funcaddr, \val^n) &=& S; F; \val^n~(\INVOKE~\funcaddr) \\
      &(\iff & S.\SFUNCS[\funcaddr].\FITYPE = [t_1^n] \to [t_2^m] \\
      &\wedge& \val^n = (t_1.\CONST~c)^n) \\
+     &\wedge& \moduleinst = \{~
+       \begin{array}[t]{@{}l@{}}
+       \MITYPES~\epsilon, \MIFUNCS~\epsilon, \MITABLES~\epsilon, \\
+       \MIMEMS~\epsilon, \MIGLOBALS~\epsilon, \MIEXPORTS~\epsilon ~\}
+       \end{array} \\
+     &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\
    \end{array}


### PR DESCRIPTION
The old rule returned a frameless configuration, which did not match
how `invoke` is used. (The `invoke_func` function in the appendix
simply starts reducing from whatever `invoke` returns.)

Any frame will do.