### PR TITLE
Fix build issue

### DIFF
--- a/document/travis-deploy.sh
+++ b/document/travis-deploy.sh
@@ -77,4 +77,3 @@ git commit -m "Deploy to GitHub Pages: ${SHA}"
 
 # Now that we're all set up, we can push.
 git push $SSH_REPO $TARGET_BRANCH
-bash


### PR DESCRIPTION
There was an errant call to "bash" at the end of the Travis CI deploy
script, leading deploys to stall and appear to be failing. This patch
removes the line.