### PR TITLE
[spec] Fix evaluation contexts and structural rules

### DIFF
--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -576,12 +576,12 @@ Finally, the following definition of *evaluation context* and associated structu
    S; F_0; \FRAME_n\{F\}~\instr^\ast~\END &\stepto& S'; F_0; \FRAME_n\{F'\}~\instr'^\ast~\END
    \end{array}
    \\ \qquad
-     (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
+     (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\[1ex]
    \begin{array}{lcl@{\qquad}l}
    S; F; E[\TRAP] &\stepto& S; F; \TRAP
-   \end{array}
-   \\ \qquad
-     (\iff E \neq [\_] \wedge E \neq \epsilon~[\_]~\epsilon) \\
+     &(\iff E \neq [\_]) \\
+   S; F; \FRAME_n\{F'\}~\TRAP~\END &\stepto& S; F; \TRAP
+   \end{array} \\
    \end{array}
 
 Reduction terminates when a thread's instruction sequence has been reduced to a :ref:`result <syntax-result>`,
@@ -599,3 +599,7 @@ that is, either a sequence of :ref:`values <syntax-val>` or to a |TRAP|.
       E = (\F64.\CONST~x_1)~[\_]~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL
 
    Moreover, this is the *only* possible choice of evaluation context where the contents of the hole matches the left-hand side of a reduction rule.
+
+.. note::
+   The restriction on evaluation contexts rules out contexts like :math:`[\_]` and :math:`\epsilon~[\_]~\epsilon` for which :math:`E[\TRAP] = \TRAP`.
+

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -573,10 +573,10 @@ Finally, the following definition of *evaluation context* and associated structu
    \\ \qquad
      (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
    \begin{array}{lcl@{\qquad}l}
-   S; F_0; \FRAME_n\{F\}~\instr^\ast~\END &\stepto& S'; F_0; \FRAME_n\{F'\}~\instr'^\ast~\END
+   S; F; \FRAME_n\{F'\}~\instr^\ast~\END &\stepto& S'; F; \FRAME_n\{F''\}~\instr'^\ast~\END
    \end{array}
    \\ \qquad
-     (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\[1ex]
+     (\iff S; F'; \instr^\ast \stepto S'; F''; {\instr'}^\ast) \\[1ex]
    \begin{array}{lcl@{\qquad}l}
    S; F; E[\TRAP] &\stepto& S; F; \TRAP
      &(\iff E \neq [\_]) \\
@@ -588,18 +588,16 @@ Reduction terminates when a thread's instruction sequence has been reduced to a 
 that is, either a sequence of :ref:`values <syntax-val>` or to a |TRAP|.
 
 .. note::
-   For example, the following instruction sequence,
+   The restriction on evaluation contexts rules out contexts like :math:`[\_]` and :math:`\epsilon~[\_]~\epsilon` for which :math:`E[\TRAP] = \TRAP`.
+
+   For an example of reduction under evaluation contexts, consider the following instruction sequence.
 
    .. math::
        (\F64.\CONST~x_1)~(\F64.\CONST~x_2)~\F64.\NEG~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL
 
-   can be decomposed into :math:`E[(\F64.\CONST~x_2)~\F64.\NEG]` where
+   This can be decomposed into :math:`E[(\F64.\CONST~x_2)~\F64.\NEG]` where
 
    .. math::
       E = (\F64.\CONST~x_1)~[\_]~(\F64.\CONST~x_3)~\F64.\ADD~\F64.\MUL
 
    Moreover, this is the *only* possible choice of evaluation context where the contents of the hole matches the left-hand side of a reduction rule.
-
-.. note::
-   The restriction on evaluation contexts rules out contexts like :math:`[\_]` and :math:`\epsilon~[\_]~\epsilon` for which :math:`E[\TRAP] = \TRAP`.
-

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -562,16 +562,26 @@ Finally, the following definition of *evaluation context* and associated structu
    \production{(evaluation contexts)} & E &::=&
      [\_] ~|~
      \val^\ast~E~\instr^\ast ~|~
-     \LABEL_n\{\instr^\ast\}~E~\END ~|~
-     \FRAME_n\{\frame\}~E~\END \\
+     \LABEL_n\{\instr^\ast\}~E~\END \\
    \end{array}
 
 .. math::
+   \begin{array}{l}
    \begin{array}{lcl@{\qquad}l}
    S; F; E[\instr^\ast] &\stepto& S'; F'; E[{\instr'}^\ast]
-     & (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
+   \end{array}
+   \\ \qquad
+     (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
+   \begin{array}{lcl@{\qquad}l}
+   S; F_0; \FRAME_n\{F\}~\instr^\ast~\END &\stepto& S'; F_0; \FRAME_n\{F'\}~\instr'^\ast~\END
+   \end{array}
+   \\ \qquad
+     (\iff S; F; \instr^\ast \stepto S'; F'; {\instr'}^\ast) \\
+   \begin{array}{lcl@{\qquad}l}
    S; F; E[\TRAP] &\stepto& S; F; \TRAP
-     & (\iff E \neq [\_]) \\
+   \end{array}
+   \\ \qquad
+     (\iff E \neq [\_] \wedge E \neq \epsilon~[\_]~\epsilon) \\
    \end{array}
 
 Reduction terminates when a thread's instruction sequence has been reduced to a :ref:`result <syntax-result>`,


### PR DESCRIPTION
Replace frame instructions in evaluation contexts with a
context-sensitive structural rule.

Clarify the side-condition in the trap propagation rule.