### PR TITLE
[spec] Editorial changes

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -596,8 +596,8 @@ dictionary TableDescriptor {
 [LegacyNamespace=WebAssembly, Constructor(TableDescriptor descriptor), Exposed=(Window,Worker,Worklet)]
 interface Table {
   unsigned long grow([EnforceRange] unsigned long delta);
-  Function? get([EnforceRange] unsigned long delta);
-  void set([EnforceRange] unsigned long delta, Function? value);
+  Function? get([EnforceRange] unsigned long index);
+  void set([EnforceRange] unsigned long index, Function? value);
   readonly attribute unsigned long length;
 };
 </pre>
@@ -846,3 +846,9 @@ same class of exception is thrown as for out of memory conditions in JavaScript.
 The particular exception here is implementation-defined in both cases.
 
 Note: ECMAScript doesn't specify any sort of behavior on out-of-memory conditions; implementations have been observed to throw OOMError and to crash. Either is valid here.
+
+<h2 id="appendix-changes">Appendix A: Changes from previous versions</h2>
+
+The WebAssembly JS interface was previously documented in <a href="https://github.com/WebAssembly/design/blob/149ce422f3f4c7bcdec9bba9d489d9b28cb726ce/JS.md">JS.md</a> in the WebAssembly design repository. The notation used in that version was loosely based on the ECMAScript specification [[ECMASCRIPT]], whereas this specification is based on WebIDL [[WEBIDL]]. In the transition, there were a couple of small, normative, observable changes in behavior. This section documents them.
+- Methods were previously unenumerable properties of objects, keeping with ECMAScript conventions; in this specification, the methods are enumerable, keeping with WebIDL conventions.
+- Appropriate integer values were previously through a <a href="https://github.com/WebAssembly/design/blob/149ce422f3f4c7bcdec9bba9d489d9b28cb726ce/JS.md#tononwrappinguint32">ToNonWrappingUint32</a> abstract operation; in this specification, they are enforced through the WebIDL type <code>[EnforceRange] unsigned long</code>. The major difference in semantics is that the latter type will throw a TypeError on NaN and things which convert to NaN under the [=ToNumber=] operation (e.g., undefined, strings that don't parse as numbers). In some places, such values are declared as <code>optional</code> to similar effect; in other places, this is not possible within WebIDL conventions.

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -162,16 +162,7 @@ spec:ecmascript; type:exception; for:ECMAScript; text:RangeError
 spec:ecmascript; type:interface; for:ECMAScript; text:ArrayBuffer
 </pre>
 
-Issue: This document is an early draft, porting <a href="https://github.com/WebAssembly/design/blob/master/JS.md">the official JS/WebAssembly interface specification</a> to WebIDL and Bikeshed. It should currently not be used as the WebAssembly specification.
-
 This API is, initially, the only API for accessing WebAssembly [[WEBASSEMBLY]] from the web platform, through a bridge to explicitly construct modules from ECMAScript [[ECMASCRIPT]].
-
-Issue: In future versions, WebAssembly may
-be loaded and run directly from an HTML `<script type='module'>` tag—and
-any other Web API that loads ES6 modules via URL—as part of
-[ES6 Module integration](https://github.com/WebAssembly/design/issues/1087).)
-
-Note: WebAssembly JS API declaration file for TypeScript can be found [here](https://github.com/01alchemist/webassembly-types/blob/master/webassembly.d.ts) which enable autocompletion and make TypeScript compiler happy.
 
 <h2 id="sample">Sample API Usage</h2>
 


### PR DESCRIPTION
- Remove warning that the JS API spec isn't the real spec
- Add appendix listing (known) differences from the previous JS.md spec
- Fix a couple misnamed parameters