### PR TITLE
Rename spectest imports to avoid depending on overloading.

### DIFF
--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -34,8 +34,10 @@ let lookup name t =
   match Utf8.encode name, t with
   | "print", _ -> ExternFunc (func print (FuncType ([], [])))
   | "print_i32", _ -> ExternFunc (func print (FuncType ([I32Type], [])))
-  | "print_i32_f32", _ -> ExternFunc (func print (FuncType ([I32Type; F32Type], [])))
-  | "print_f64_f64", _ -> ExternFunc (func print (FuncType ([F64Type; F64Type], [])))
+  | "print_i32_f32", _ ->
+    ExternFunc (func print (FuncType ([I32Type; F32Type], [])))
+  | "print_f64_f64", _ ->
+    ExternFunc (func print (FuncType ([F64Type; F64Type], [])))
   | "print_f32", _ -> ExternFunc (func print (FuncType ([F32Type], [])))
   | "print_f64", _ -> ExternFunc (func print (FuncType ([F64Type], [])))
   | "global_i32", _ -> ExternGlobal (global (GlobalType (I32Type, Immutable)))

--- a/interpreter/host/spectest.ml
+++ b/interpreter/host/spectest.ml
@@ -32,11 +32,15 @@ let print (FuncType (_, out)) vs =
 
 let lookup name t =
   match Utf8.encode name, t with
-  | "print", ExternFuncType t -> ExternFunc (func print t)
-  | "print", _ ->
-    let t = FuncType ([], []) in ExternFunc (func print t)
-  | "global", ExternGlobalType t -> ExternGlobal (global t)
-  | "global", _ -> ExternGlobal (global (GlobalType (I32Type, Immutable)))
+  | "print", _ -> ExternFunc (func print (FuncType ([], [])))
+  | "print_i32", _ -> ExternFunc (func print (FuncType ([I32Type], [])))
+  | "print_i32_f32", _ -> ExternFunc (func print (FuncType ([I32Type; F32Type], [])))
+  | "print_f64_f64", _ -> ExternFunc (func print (FuncType ([F64Type; F64Type], [])))
+  | "print_f32", _ -> ExternFunc (func print (FuncType ([F32Type], [])))
+  | "print_f64", _ -> ExternFunc (func print (FuncType ([F64Type], [])))
+  | "global_i32", _ -> ExternGlobal (global (GlobalType (I32Type, Immutable)))
+  | "global_f32", _ -> ExternGlobal (global (GlobalType (F32Type, Immutable)))
+  | "global_f64", _ -> ExternGlobal (global (GlobalType (F64Type, Immutable)))
   | "table", _ -> ExternTable table
   | "memory", _ -> ExternMemory memory
   | _ -> raise Not_found

--- a/test/core/func_ptrs.wast
+++ b/test/core/func_ptrs.wast
@@ -7,7 +7,7 @@
   (type $T (func (param i32) (result i32)))  ;; 5: i32 -> i32
   (type $U (func (param i32)))               ;; 6: i32 -> void
 
-  (func $print (import "spectest" "print") (type 6))
+  (func $print (import "spectest" "print_i32") (type 6))
 
   (func (type 0))
   (func (type $S))
@@ -46,7 +46,7 @@
 )
 
 (assert_invalid (module (func (type 42))) "unknown type")
-(assert_invalid (module (import "spectest" "print" (func (type 43)))) "unknown type")
+(assert_invalid (module (import "spectest" "print_i32" (func (type 43)))) "unknown type")
 
 (module
   (type $T (func (param) (result i32)))

--- a/test/core/globals.wast
+++ b/test/core/globals.wast
@@ -122,7 +122,7 @@
 )
 
 (module
-  (import "spectest" "global" (global i32))
+  (import "spectest" "global_i32" (global i32))
 )
 (assert_malformed
   (module binary
@@ -130,7 +130,7 @@
     "\02\94\80\80\80\00"             ;; import section
       "\01"                          ;; length 1
       "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
-      "\06\67\6c\6f\62\61\6c"        ;; "global"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
       "\03"                          ;; GlobalImport
       "\7f"                          ;; i32
       "\02"                          ;; invalid mutability
@@ -143,7 +143,7 @@
     "\02\94\80\80\80\00"             ;; import section
       "\01"                          ;; length 1
       "\08\73\70\65\63\74\65\73\74"  ;; "spectest"
-      "\06\67\6c\6f\62\61\6c"        ;; "global"
+      "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
       "\03"                          ;; GlobalImport
       "\7f"                          ;; i32
       "\ff"                          ;; invalid mutability

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -556,3 +556,28 @@
   (module quote "(memory 0) (import \"\" \"\" (memory 1 2))")
   "import after memory"
 )
+
+;; This module is required to validate, regardless of whether it can be
+;; linked. Overloading is not possible in wasm itself, but it is possible
+;; in modules from which wasm can import.
+(assert_unlinkable
+  (module
+    (import "not wasm" "overloaded" (func))
+    (import "not wasm" "overloaded" (func (param i32)))
+    (import "not wasm" "overloaded" (func (param i32 i32)))
+    (import "not wasm" "overloaded" (func (param i64)))
+    (import "not wasm" "overloaded" (func (param f32)))
+    (import "not wasm" "overloaded" (func (param f64)))
+    (import "not wasm" "overloaded" (func (result i32)))
+    (import "not wasm" "overloaded" (func (result i64)))
+    (import "not wasm" "overloaded" (func (result f32)))
+    (import "not wasm" "overloaded" (func (result f64)))
+    (import "not wasm" "overloaded" (global i32))
+    (import "not wasm" "overloaded" (global i64))
+    (import "not wasm" "overloaded" (global f32))
+    (import "not wasm" "overloaded" (global f64))
+    (import "not wasm" "overloaded" (table 0 anyfunc))
+    (import "not wasm" "overloaded" (memory 0))
+  )
+  "unknown import"
+)

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -27,28 +27,28 @@
   (type $func_f32 (func (param f32)))
   (type $func_f64 (func (param f64)))
 
-  (import "spectest" "print" (func (param i32)))
+  (import "spectest" "print_i32" (func (param i32)))
   ;; JavaScript can't handle i64 yet.
-  ;; (func (import "spectest" "print") (param i64))
-  (import "spectest" "print" (func $print_i32 (param i32)))
+  ;; (func (import "spectest" "print_i64") (param i64))
+  (import "spectest" "print_i32" (func $print_i32 (param i32)))
   ;; JavaScript can't handle i64 yet.
-  ;; (import "spectest" "print" (func $print_i64 (param i64)))
-  (import "spectest" "print" (func $print_f32 (param f32)))
-  (import "spectest" "print" (func $print_f64 (param f64)))
-  (import "spectest" "print" (func $print_i32_f32 (param i32 f32)))
-  (import "spectest" "print" (func $print_f64_f64 (param f64 f64)))
-  (func $print_i32-2 (import "spectest" "print") (param i32))
-  (func $print_f64-2 (import "spectest" "print") (param f64))
+  ;; (import "spectest" "print_i64" (func $print_i64 (param i64)))
+  (import "spectest" "print_f32" (func $print_f32 (param f32)))
+  (import "spectest" "print_f64" (func $print_f64 (param f64)))
+  (import "spectest" "print_i32_f32" (func $print_i32_f32 (param i32 f32)))
+  (import "spectest" "print_f64_f64" (func $print_f64_f64 (param f64 f64)))
+  (func $print_i32-2 (import "spectest" "print_i32") (param i32))
+  (func $print_f64-2 (import "spectest" "print_f64") (param f64))
   (import "test" "func-i64->i64" (func $i64->i64 (param i64) (result i64)))
 
-  (func (export "p1") (import "spectest" "print") (param i32))
-  (func $p (export "p2") (import "spectest" "print") (param i32))
-  (func (export "p3") (export "p4") (import "spectest" "print") (param i32))
-  (func (export "p5") (import "spectest" "print") (type 0))
-  (func (export "p6") (import "spectest" "print") (type 0) (param i32) (result))
+  (func (export "p1") (import "spectest" "print_i32") (param i32))
+  (func $p (export "p2") (import "spectest" "print_i32") (param i32))
+  (func (export "p3") (export "p4") (import "spectest" "print_i32") (param i32))
+  (func (export "p5") (import "spectest" "print_i32") (type 0))
+  (func (export "p6") (import "spectest" "print_i32") (type 0) (param i32) (result))
 
-  (import "spectest" "print" (func (type $forward)))
-  (func (import "spectest" "print") (type $forward))
+  (import "spectest" "print_i32" (func (type $forward)))
+  (func (import "spectest" "print_i32") (type $forward))
   (type $forward (func (param i32)))
 
   (table anyfunc (elem $print_i32 $print_f64))
@@ -182,7 +182,7 @@
   "incompatible import type"
 )
 (assert_unlinkable
-  (module (import "spectest" "global" (func)))
+  (module (import "spectest" "global_i32" (func)))
   "incompatible import type"
 )
 (assert_unlinkable
@@ -198,16 +198,16 @@
 ;; Globals
 
 (module
-  (import "spectest" "global" (global i32))
-  (global (import "spectest" "global") i32)
+  (import "spectest" "global_i32" (global i32))
+  (global (import "spectest" "global_i32") i32)
 
-  (import "spectest" "global" (global $x i32))
-  (global $y (import "spectest" "global") i32)
+  (import "spectest" "global_i32" (global $x i32))
+  (global $y (import "spectest" "global_i32") i32)
 
   ;; JavaScript can't handle i64 yet.
-  ;; (import "spectest" "global" (global i64))
-  (import "spectest" "global" (global f32))
-  (import "spectest" "global" (global f64))
+  ;; (import "spectest" "global_i64" (global i64))
+  (import "spectest" "global_f32" (global f32))
+  (import "spectest" "global_f64" (global f64))
 
   (func (export "get-0") (result i32) (get_global 0))
   (func (export "get-1") (result i32) (get_global 1))
@@ -245,7 +245,7 @@
   "incompatible import type"
 )
 (assert_unlinkable
-  (module (import "spectest" "print" (global i32)))
+  (module (import "spectest" "print_i32" (global i32)))
   "incompatible import type"
 )
 (assert_unlinkable
@@ -362,7 +362,7 @@
   "incompatible import type"
 )
 (assert_unlinkable
-  (module (import "spectest" "print" (table 10 anyfunc)))
+  (module (import "spectest" "print_i32" (table 10 anyfunc)))
   "incompatible import type"
 )
 
@@ -455,11 +455,11 @@
   "incompatible import type"
 )
 (assert_unlinkable
-  (module (import "spectest" "print" (memory 1)))
+  (module (import "spectest" "print_i32" (memory 1)))
   "incompatible import type"
 )
 (assert_unlinkable
-  (module (import "spectest" "global" (memory 1)))
+  (module (import "spectest" "global_i32" (memory 1)))
   "incompatible import type"
 )
 (assert_unlinkable

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -20,7 +20,7 @@
 (assert_return (invoke $Nf "call Mf.call") (i32.const 2))
 
 (module
-  (import "spectest" "print" (func $f (param i32)))
+  (import "spectest" "print_i32" (func $f (param i32)))
   (export "print" (func $f))
 )
 (register "reexport_f")
@@ -289,7 +289,7 @@
 
 (assert_unlinkable
   (module
-    (func $host (import "spectest" "print"))
+    (func $host (import "spectest" "print_hello"))
     (memory (import "Mm" "mem") 1)
     (table (import "Mm" "tab") 0 anyfunc)  ;; does not exist
     (data (i32.const 0) "abc")

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -289,7 +289,7 @@
 
 (assert_unlinkable
   (module
-    (func $host (import "spectest" "print_hello"))
+    (func $host (import "spectest" "print"))
     (memory (import "Mm" "mem") 1)
     (table (import "Mm" "tab") 0 anyfunc)  ;; does not exist
     (data (i32.const 0) "abc")

--- a/test/core/memory.wast
+++ b/test/core/memory.wast
@@ -10,8 +10,8 @@
 (module (memory 1 2)
   (data (i32.const 0) "a") (data (i32.const 1) "b") (data (i32.const 2) "c")
 )
-(module (global (import "spectest" "global") i32) (memory 1) (data (get_global 0) "a"))
-(module (global $g (import "spectest" "global") i32) (memory 1) (data (get_global $g) "a"))
+(module (global (import "spectest" "global_i32") i32) (memory 1) (data (get_global 0) "a"))
+(module (global $g (import "spectest" "global_i32") i32) (memory 1) (data (get_global $g) "a"))
 ;; Use of internal globals in constant expressions is not allowed in MVP.
 ;; (module (memory 1) (data (get_global 0) "a") (global i32 (i32.const 0)))
 ;; (module (memory 1) (data (get_global $g) "a") (global $g i32 (i32.const 0)))
@@ -112,7 +112,7 @@
 ;)
 (assert_unlinkable
   (module
-    (global (import "spectest" "global") i32)
+    (global (import "spectest" "global_i32") i32)
     (memory 0) (data (get_global 0) "a")
   )
   "data segment does not fit"

--- a/test/core/names.wast
+++ b/test/core/names.wast
@@ -1075,8 +1075,8 @@
 (module
   ;; Test that we can use indices instead of names to reference imports,
   ;; exports, functions and parameters.
-  (import "spectest" "print" (func (param i32)))
-  (func (import "spectest" "print") (param i32))
+  (import "spectest" "print_i32" (func (param i32)))
+  (func (import "spectest" "print_i32") (param i32))
   (func (param i32) (param i32)
     (call 0 (get_local 0))
     (call 1 (get_local 1))

--- a/test/core/start.wast
+++ b/test/core/start.wast
@@ -78,19 +78,19 @@
 (assert_return (invoke "get") (i32.const 70))
 
 (module
-  (func $print_i32 (import "spectest" "print") (param i32))
+  (func $print_i32 (import "spectest" "print_i32") (param i32))
   (func $main (call $print_i32 (i32.const 1)))
   (start 1)
 )
 
 (module
-  (func $print_i32 (import "spectest" "print") (param i32))
+  (func $print_i32 (import "spectest" "print_i32") (param i32))
   (func $main (call $print_i32 (i32.const 2)))
   (start $main)
 )
 
 (module
-  (func $print (import "spectest" "print"))
+  (func $print (import "spectest" "print_hello"))
   (start $print)
 )
 

--- a/test/core/start.wast
+++ b/test/core/start.wast
@@ -90,7 +90,7 @@
 )
 
 (module
-  (func $print (import "spectest" "print_hello"))
+  (func $print (import "spectest" "print"))
   (start $print)
 )
 

--- a/test/harness/index.js
+++ b/test/harness/index.js
@@ -79,7 +79,14 @@ function reinitializeRegistry() {
     registry = {
         spectest: {
             print: console.log.bind(console),
-            global: 666,
+            print_i32: console.log.bind(console),
+            print_i32_f32: console.log.bind(console),
+            print_f64_f64: console.log.bind(console),
+            print_f32: console.log.bind(console),
+            print_f64: console.log.bind(console),
+            global_i32: 666,
+            global_f32: 666,
+            global_f64: 666,
             table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
             memory: new WebAssembly.Memory({initial: 1, maximum: 2})
         }


### PR DESCRIPTION
This just updates the testsuite, and does not update the interpreter.