### PR TITLE
[spec] Clean up instantiation and expression evaluation.

### DIFF
--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -102,6 +102,6 @@ Execution
 ===============================================  ===============================================================================
 Construct                                        Judgement
 ===============================================  ===============================================================================
-:ref:`Instruction <exec-instr>`                  :math:`S;F;\instr \stepto S';F';{\instr'}^\ast`
-:ref:`Expression <exec-expr>`                    :math:`S;F;\expr \stepto^\ast S';F';\val^\ast`
+:ref:`Instruction <exec-instr>`                  :math:`S;F;\instr^\ast \stepto S';F';{\instr'}^\ast`
+:ref:`Expression <exec-expr>`                    :math:`S;F;\expr \stepto  S';F';\expr'`
 ===============================================  ===============================================================================

--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -7,7 +7,7 @@ Soundness
 The :ref:`type system <type-system>` of WebAssembly is *sound*, implying both *type safety* and *memory safety* with respect to the WebAssembly semantics. For example:
 
 * All types declared and derived during validation are respected at run time;
-  e.g., every :ref:`local <syntax-local>` or :ref:`global <syntax-global>` variable will only contain type-correct values, every :ref:`instruction <syntax-instr>` will only be applied to operands of the expected type, and every :ref:`function <syntax-func>` :ref:`invocation <exec-invocation>` always evaluates to a result of the right type.
+  e.g., every :ref:`local <syntax-local>` or :ref:`global <syntax-global>` variable will only contain type-correct values, every :ref:`instruction <syntax-instr>` will only be applied to operands of the expected type, and every :ref:`function <syntax-func>` :ref:`invocation <exec-invocation>` always evaluates to a result of the right type (if it does not :ref:`trap <trap>`).
 
 * No memory location will be read or written except those explicitly defined by the program, i.e., as a :ref:`local <syntax-local>`, a :ref:`global <syntax-global>`, an element in a :ref:`table <syntax-table>`, or a location within a linear :ref:`memory <syntax-mem>`.
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1140,5 +1140,6 @@ An :ref:`expression <syntax-expr>` is executed relative to a :ref:`current <exec
    }
 
 .. note::
-   This formal reduction rule is used during :ref:`instantiation <exec-instantiation>` to execute :ref:`global <syntax-global>` initializer expressions as well as :ref:`element <syntax-elem>` and :ref:`data <syntax-data>` segment offset expressions.
-   Expressions constituting :ref:`function <syntax-func>` bodies, by contrast, are executed during function :ref:`invocation <exec-invoke>`.
+   By iterating this reduction rule, we can *evaluate* some expressions to values.
+   This is always possible, for example, with :ref:`constant expressions <valid-constant>`.
+   Expressions constituting :ref:`function <syntax-func>` bodies, by contrast, need not terminate with a value are executed during function :ref:`invocation <exec-invoke>`.

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1126,11 +1126,17 @@ All these notions are made precise in the :ref:`Appendix <soundness>`.
 Expressions
 ~~~~~~~~~~~
 
-An :ref:`expression <syntax-expr>` is executed relative to a :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>` pointing to its containing :ref:`module instance <syntax-moduleinst>`.
+An :ref:`expression <syntax-expr>` is *evaluated* relative to a :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>` pointing to its containing :ref:`module instance <syntax-moduleinst>`.
 
 1. Jump to the start of the instruction sequence :math:`\instr^\ast` of the expression.
 
 2. Execute the instruction sequence.
+
+3. Assert: due to :ref:`validation <valid-expr>`, the top of the stack contains a :ref:`value <syntax-val>`.
+
+4. Pop the :ref:`value <syntax-val>` :math:`\val` from the stack.
+
+The value :math:`\val` is the result of the evaluation.
 
 .. math::
    \frac{
@@ -1140,6 +1146,5 @@ An :ref:`expression <syntax-expr>` is executed relative to a :ref:`current <exec
    }
 
 .. note::
-   By iterating this reduction rule, we can *evaluate* some expressions to values.
-   This is always possible, for example, with :ref:`constant expressions <valid-constant>`.
-   Expressions constituting :ref:`function <syntax-func>` bodies, by contrast, need not terminate with a value are executed during function :ref:`invocation <exec-invoke>`.
+   Evaluation iterates this reduction rule until reaching a value.
+   Expressions constituting :ref:`function <syntax-func>` bodies need not terminate with a value are executed during function :ref:`invocation <exec-invoke>`.

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1147,4 +1147,4 @@ The value :math:`\val` is the result of the evaluation.
 
 .. note::
    Evaluation iterates this reduction rule until reaching a value.
-   Expressions constituting :ref:`function <syntax-func>` bodies need not terminate with a value are executed during function :ref:`invocation <exec-invoke>`.
+   Expressions constituting :ref:`function <syntax-func>` bodies are executed during function :ref:`invocation <exec-invoke>`.

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1126,21 +1126,19 @@ All these notions are made precise in the :ref:`Appendix <soundness>`.
 Expressions
 ~~~~~~~~~~~
 
-An :ref:`expression <syntax-expr>` is *evaluated* relative to a :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>` pointing to its containing :ref:`module instance <syntax-moduleinst>`.
+An :ref:`expression <syntax-expr>` is executed relative to a :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>` pointing to its containing :ref:`module instance <syntax-moduleinst>`.
 
 1. Jump to the start of the instruction sequence :math:`\instr^\ast` of the expression.
 
-2. Execute of the instruction sequence.
-
-3. Assert: due to :ref:`validation <valid-expr>`, the top of the stack contains a :ref:`value <syntax-val>`.
-
-4. Pop the the :ref:`value <syntax-val>` :math:`\val` from the stack.
-
-The value :math:`\val` is the result of the evaluation.
+2. Execute the instruction sequence.
 
 .. math::
    \frac{
-     S; F; \instr^\ast \stepto^\ast S'; F'; v
+     S; F; \instr^\ast \stepto S'; F'; \instr'^\ast
    }{
-     S; F; \instr^\ast~\END \stepto^\ast S'; F'; v
+     S; F; \instr^\ast~\END \stepto S'; F'; \instr'^\ast~\END
    }
+
+.. note::
+   This formal reduction rule is used during :ref:`instantiation <exec-instantiation>` to execute :ref:`global <syntax-global>` initializer expressions as well as :ref:`element <syntax-elem>` and :ref:`data <syntax-data>` segment offset expressions.
+   Expressions constituting :ref:`function <syntax-func>` bodies, by contrast, are executed during function :ref:`invocation <exec-invoke>`.

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -563,85 +563,95 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 4. For each :ref:`external value <syntax-externval>` :math:`\externval_i` in :math:`\externval^n` and :ref:`external type <syntax-externtype>` :math:`\externtype'_i` in :math:`\externtype_{\F{im}}^n`, do:
 
-   a. Assert: :math:`\externval_i` is :ref:`valid <valid-externval>` with :ref:`external type <syntax-externtype>` :math:`\externtype_i` in store :math:`S`.
+   a. If :math:`\externval_i` is not :ref:`valid <valid-externval>` with an :ref:`external type <syntax-externtype>` :math:`\externtype_i` in store :math:`S`, then:
+
+      i. Fail.
 
    b. If :math:`\externtype_i` does not :ref:`match <match-externtype>` :math:`\externtype'_i`, then:
 
       i. Fail.
 
-5. Let :math:`\moduleinst_{\F{im}}` be the auxiliary module instance :math:`\{\MIGLOBALS~\evglobals(\externval^\ast)\}` that only consists of the imported globals.
+.. _exec-initvals:
 
-6. Let :math:`F` be the :ref:`frame <syntax-frame>` :math:`\{ \AMODULE~\moduleinst_{\F{im}}, \ALOCALS~\epsilon \}`.
+5. Let :math:`\val^\ast` be the vector of :ref:`global <syntax-global>` initialization :ref:`values <syntax-val>` determined by :math:`\module` and :math:`\externval^n`. These may be calculated as follows.
 
-7. Push the frame :math:`F` to the stack.
+   a. Let :math:`\moduleinst_{\F{im}}` be the auxiliary module :ref:`instance <syntax-moduleinst>` :math:`\{\MIGLOBALS~\evglobals(\externval^n)\}` that only consists of the imported globals.
 
-8. Let :math:`\globalidx_{\F{new}}` be the :ref:`global index <syntax-globalidx>` that corresponds to the number of global :ref:`imports <syntax-import>` in :math:`\module.\MIMPORTS` (i.e., the index of the first non-imported global).
+   b. Let :math:`F_{\F{im}}` be the auxiliary :ref:`frame <syntax-frame>` :math:`\{ \AMODULE~\moduleinst_{\F{im}}, \ALOCALS~\epsilon \}`.
 
-9. For each :ref:`global <syntax-global>` :math:`\global_i` in :math:`\module.\MGLOBALS`, do:
+   c. Push the frame :math:`F_{\F{im}}` to the stack.
 
-   a. Let :math:`\val_i` be the result of :ref:`evaluating <exec-expr>` the initializer expression :math:`\global_i.\GINIT`.
+   d. For each :ref:`global <syntax-global>` :math:`\global_i` in :math:`\module.\MGLOBALS`, do:
 
-   b. Let :math:`\globalidx_i` be the :ref:`global index <syntax-globalidx>` :math:`\globalidx_{\F{new}} + i`.
+      i. :ref:`Execute <exec-expr>` the initializer expression :math:`\global_i.\GINIT`.
 
-   c. Assert: due to :ref:`validation <valid-global>`, :math:`\moduleinst.\MIGLOBALS[\globalidx_i]` exists.
+      ii. Assert: due to :ref:`validation <valid-global>`, an expression :math:`\val_i~\END` is now on the top of the stack.
 
-   d. Let :math:`\globaladdr_i` be the :ref:`global address <syntax-globaladdr>` :math:`\moduleinst.\MIGLOBALS[\globalidx_i]`.
+      iii. Pop the expression from the stack.
 
-   e. Assert: due to :ref:`validation <valid-global>`, :math:`S.\SGLOBALS[\globaladdr_i]` exists.
+   e. Assert: due to :ref:`validation <valid-module>`, the frame :math:`F_{\F{im}}` is now on the top of the stack.
 
-   f. Let :math:`\globalinst_i` be the :ref:`global instance <syntax-globalinst>` :math:`S.\SGLOBALS[\globaladdr_i]`.
+   f. Pop the frame from the stack.
 
-10. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
+6. Let :math:`\moduleinst` be a new module instance :ref:`allocated <alloc-module>` from :math:`\module` in store :math:`S` with imports :math:`\externval^n` and global initializer values :math:`\val^\ast`, and let :math:`S'` be the extended store produced by module allocation.
 
-    a. Let :math:`\X{eoval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\elem_i.\EOFFSET`.
+7. Let :math:`F` be the :ref:`frame <syntax-frame>` :math:`\{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \}`.
 
-    b. Assert: due to :ref:`validation <valid-elem>`, :math:`\X{eoval}_i` is of the form :math:`\I32.\CONST~\X{eo}_i`.
+8. Push the frame :math:`F` to the stack.
 
-    c. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
+9. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
 
-    d. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
+	a. :ref:`Execute <exec-expr>` the expression :math:`\elem_i.\EOFFSET`.
 
-    e. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
+    b. Assert: due to :ref:`validation <valid-elem>`, an expression :math:`\I32.\CONST~\X{eo}_i~\END` is now on the top of the stack.
 
-    f. Assert: due to :ref:`validation <valid-elem>`, :math:`S.\STABLES[\tableaddr_i]` exists.
+    c. Pop the expression from the stack.
 
-    g. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\tableaddr_i]`.
+    d. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
 
-    h. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
+    e. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
 
-    i. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
+    f. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
 
-       i. Fail.
+    g. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
 
-11. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
+    h. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
 
-    a. Let :math:`\X{doval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
+    i. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
 
-    b. Assert: due to :ref:`validation <valid-data>`, :math:`\X{doval}_i` is of the form :math:`\I32.\CONST~\X{do}_i`.
-
-    c. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
-
-    d. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
-
-    e. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
-
-    f. Assert: due to :ref:`validation <valid-data>`, :math:`S.\SMEMS[\memaddr_i]` exists.
-
-    g. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S.\SMEMS[\memaddr_i]`.
-
-    h. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
-
-    i. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
+    j. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
 
        i. Fail.
 
-12. Assert: due to :ref:`validation <valid-module>`, the frame :math:`F` is now on the top of the stack.
+10. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
 
-13. Pop the frame from the stack.
+    a. :ref:`Execute <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
 
-14. Let :math:`\moduleinst` be a new module instance :ref:`allocated <alloc-module>` from :math:`\module` in store :math:`S` with imports :math:`\externval^\ast` and global initializer values :math:`\val^\ast`.
+    b. Assert: due to :ref:`validation <valid-data>`, an expression :math:`\I32.\CONST~\X{do}_i~\END` is now on the top of the stack.
 
-15. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
+    c. Pop the expression from the stack.
+
+    d. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
+
+    e. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
+
+    f. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
+
+    g. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
+
+    h. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
+
+    i. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
+
+    j. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
+
+       i. Fail.
+
+11. Assert: due to :ref:`validation <valid-module>`, the frame :math:`F` is now on the top of the stack.
+
+12. Pop the frame from the stack.
+
+13. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
 
     a. For each :ref:`function index <syntax-funcidx>` :math:`\funcidx_{ij}` in :math:`\elem_i.\EINIT` (starting with :math:`j = 0`), do:
 
@@ -651,13 +661,13 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
        iii. Replace :math:`\tableinst_i.\TIELEM[\X{eo}_i + j]` with :math:`\funcaddr_{ij}`.
 
-16. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
+14. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
 
     a. For each :ref:`byte <syntax-byte>` :math:`b_{ij}` in :math:`\data_i.\DINIT` (starting with :math:`j = 0`), do:
 
        i. Replace :math:`\meminst_i.\MIDATA[\X{do}_i + j]` with :math:`b_{ij}`.
 
-17. If the :ref:`start function <syntax-start>` :math:`\module.\MSTART` is not empty, then:
+15. If the :ref:`start function <syntax-start>` :math:`\module.\MSTART` is not empty, then:
 
     a. Assert: due to :ref:`validation <valid-start>`, :math:`\moduleinst.\MIFUNCS[\module.\MSTART.\SFUNC]` exists.
 
@@ -679,25 +689,21 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      & \vdashmodule \module : \externtype_{\F{im}}^n \to \externtype_{\F{ex}}^\ast \\
      &\wedge& (S \vdashexternval \externval : \externtype)^n \\
      &\wedge& (\vdashexterntypematch \externtype \matches \externtype_{\F{im}})^n \\[1ex]
-     &\wedge& \module.\MGLOBALS = \global^k \\
+     &\wedge& \module.\MGLOBALS = \global^\ast \\
      &\wedge& \module.\MELEM = \elem^\ast \\
      &\wedge& \module.\MDATA = \data^\ast \\
      &\wedge& \module.\MSTART = \start^? \\[1ex]
-     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^n, v^\ast) \\
+     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^n, \val^\ast) \\
      &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
-     &\wedge& (S'; F; \global.\GINIT \stepto^\ast S'; F; v)^\ast \\
-     &\wedge& (S'; F; \elem.\EOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{eo})^\ast \\
-     &\wedge& (S'; F; \data.\DOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{do})^\ast \\[1ex]
+     &\wedge& (S'; F; \global.\GINIT \stepto^\ast S'; F; \val~\END)^\ast \\
+     &\wedge& (S'; F; \elem.\EOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{eo}~\END)^\ast \\
+     &\wedge& (S'; F; \data.\DOFFSET \stepto^\ast S'; F; \I32.\CONST~\X{do}~\END)^\ast \\[1ex]
      &\wedge& (\X{eo} + |\elem.\EINIT| \leq |S'.\STABLES[\tableaddr].\TIELEM|)^\ast \\
      &\wedge& (\X{do} + |\data.\DINIT| \leq |S'.\SMEMS[\memaddr].\MIDATA|)^\ast
    \\[1ex]
-     &\wedge& \globaladdr^\ast = \moduleinst.\MIGLOBALS[|\moduleinst.\MIGLOBALS|-k \slice k] \\
      &\wedge& (\tableaddr = \moduleinst.\MITABLES[\elem.\ETABLE])^\ast \\
      &\wedge& (\memaddr = \moduleinst.\MIMEMS[\data.\DMEM])^\ast \\
      &\wedge& (\funcaddr = \moduleinst.\MIFUNCS[\start.\SFUNC])^?)
-   \\[1ex]
-   \instantiate(S, \module, \externval^n) &=& S; \{\AMODULE~\{\}, \ALOCALS~\epsilon\}; \TRAP
-     \qquad (\otherwise)
    \\[2ex]
    S; F; \INITELEM~a~i~\epsilon &\stepto&
      S; F; \epsilon \\
@@ -713,11 +719,15 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
    \end{array}
 
 .. note::
+   Module :ref:`allocation <alloc-module>` and the :ref:`execution <exec-expr>` of :ref:`global <syntax-global>` initializers are mutually recursive because the global initialization :ref:`values <syntax-val>`  :math:`\val^\ast` are passed to the module allocator but depend on the store :math:`S'` and module instance :math:`\moduleinst` returned by allocation.
+   However, this recursion is just a specification device.
+   Due to :ref:`validation <valid-module>`, the initialization values can easily :ref:`be determined <exec-initvals>` from a simple pre-pass that executes global initializers in the initial store.
+
    All failure conditions are checked before any observable mutation of the store takes place.
    Store mutation is not atomic;
    it happens in individual steps that may be interleaved with other threads.
 
-   Evaluation of :ref:`constant expressions <valid-constant>` does not affect the store.
+   :ref:`Execution <exec-expr>` of :ref:`constant expressions <valid-constant>` does not affect the store.
 
 
 .. index:: ! invocation, module, module instance, function, export, function address, function instance, function type, value, stack, trap, store

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -583,15 +583,11 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
    d. For each :ref:`global <syntax-global>` :math:`\global_i` in :math:`\module.\MGLOBALS`, do:
 
-      i. :ref:`Execute <exec-expr>` the initializer expression :math:`\global_i.\GINIT`.
-
-      ii. Assert: due to :ref:`validation <valid-global>`, an expression :math:`\val_i~\END` is now on the top of the stack.
-
-      iii. Pop the expression from the stack.
+      i. Let :math:`\val_i` be the result of :ref:`evaluating <exec-expr>` the initializer expression :math:`\global_i.\GINIT`.
 
    e. Assert: due to :ref:`validation <valid-module>`, the frame :math:`F_{\F{im}}` is now on the top of the stack.
 
-   f. Pop the frame from the stack.
+   f. Pop the frame :math:`F_{\F{im}}` from the stack.
 
 6. Let :math:`\moduleinst` be a new module instance :ref:`allocated <alloc-module>` from :math:`\module` in store :math:`S` with imports :math:`\externval^n` and global initializer values :math:`\val^\ast`, and let :math:`S'` be the extended store produced by module allocation.
 
@@ -601,49 +597,45 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 9. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
 
-	a. :ref:`Execute <exec-expr>` the expression :math:`\elem_i.\EOFFSET`.
+    a. Let :math:`\X{eoval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\elem_i.\EOFFSET`.
 
-    b. Assert: due to :ref:`validation <valid-elem>`, an expression :math:`\I32.\CONST~\X{eo}_i~\END` is now on the top of the stack.
+    b. Assert: due to :ref:`validation <valid-elem>`, :math:`\X{eoval}_i` is of the form :math:`\I32.\CONST~\X{eo}_i`.
 
-    c. Pop the expression from the stack.
+    c. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
 
-    d. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
+    d. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
 
-    e. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
+    e. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
 
-    f. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
+    f. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
 
-    g. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
+    g. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
 
-    h. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
+    h. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
 
-    i. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
-
-    j. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
+    i. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
 
        i. Fail.
 
 10. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
 
-    a. :ref:`Execute <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
+    a. Let :math:`\X{doval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
 
-    b. Assert: due to :ref:`validation <valid-data>`, an expression :math:`\I32.\CONST~\X{do}_i~\END` is now on the top of the stack.
+    b. Assert: due to :ref:`validation <valid-data>`, :math:`\X{doval}_i` is of the form :math:`\I32.\CONST~\X{do}_i`.
 
-    c. Pop the expression from the stack.
+    c. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
 
-    d. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
+    d. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
 
-    e. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
+    e. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
 
-    f. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
+    f. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
 
-    g. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
+    g. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
 
-    h. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
+    h. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
 
-    i. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
-
-    j. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
+    i. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
 
        i. Fail.
 
@@ -719,15 +711,15 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
    \end{array}
 
 .. note::
-   Module :ref:`allocation <alloc-module>` and the :ref:`execution <exec-expr>` of :ref:`global <syntax-global>` initializers are mutually recursive because the global initialization :ref:`values <syntax-val>`  :math:`\val^\ast` are passed to the module allocator but depend on the store :math:`S'` and module instance :math:`\moduleinst` returned by allocation.
+   Module :ref:`allocation <alloc-module>` and the :ref:`evaluation <exec-expr>` of :ref:`global <syntax-global>` initializers are mutually recursive because the global initialization :ref:`values <syntax-val>` :math:`\val^\ast` are passed to the module allocator but depend on the store :math:`S'` and module instance :math:`\moduleinst` returned by allocation.
    However, this recursion is just a specification device.
-   Due to :ref:`validation <valid-module>`, the initialization values can easily :ref:`be determined <exec-initvals>` from a simple pre-pass that executes global initializers in the initial store.
+   Due to :ref:`validation <valid-module>`, the initialization values can easily :ref:`be determined <exec-initvals>` from a simple pre-pass that evaluates global initializers in the initial store.
 
    All failure conditions are checked before any observable mutation of the store takes place.
    Store mutation is not atomic;
    it happens in individual steps that may be interleaved with other threads.
 
-   :ref:`Execution <exec-expr>` of :ref:`constant expressions <valid-constant>` does not affect the store.
+   :ref:`Evaluation <exec-expr>` of :ref:`constant expressions <valid-constant>` does not affect the store.
 
 
 .. index:: ! invocation, module, module instance, function, export, function address, function instance, function type, value, stack, trap, store


### PR DESCRIPTION
Change expression evaluation to reduction. The use of `\stepto^\ast` in the evaluation rule's conclusion had been confusing, being syntax rather than the usual RTC operator.

Fix an incidental typo in `_index-rules`. The instruction reduction judgment lacked an `^\ast`.

Remove unused details from the rules for `\instantiate`. Neither `\globaladdr^\ast` nor `k` was used.

Make `\instantiate` prose and rules agree on when to trap by dropping the generic "otherwise" rule that trapped. The rules no longer relate inputs to outputs where the prose specified "Fail". (Aside: nothing had to change in the embedding, where instantiation is used.)

Make `\instantiate` check, rather than assume, validity of inputs.

Update `\instantiate` prose to use `allocmodule`.

Note the mutual recursion between instantiation's module allocation and execution of global initializers. (Left a sketch of the pre-pass needed to break the recursion in prose step (5) because it's easy to miss or forget that global initializers depend only on imported globals.)

Prefer `\val` to `v` in the rule for `\instantiate`.