### PR TITLE
Remove redundant kExprEnd in test

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -817,8 +817,7 @@ const complexTableReExportingModuleBinary = (() => {
         .addFunction('h', kSig_i_v)
         .addBody([
             kExprI32Const,
-            46,
-            kExprEnd
+            46
         ]).index;
 
     builder.setFunctionTableLength(3);


### PR DESCRIPTION
The addBody function of the WasmModuleBuilder automatically adds kExprEnd at the end of a function. Explicitly adding kExprEnd at the end of a function therefore causes the generated code to be incorrect WebAssembly code. This PR removes such an explicit kExprEnd.