### PR TITLE
[spec] Cite mechanisation paper

### DIFF
--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -709,7 +709,7 @@ Theorems
 ~~~~~~~~
 
 Given the definition of :ref:`valid configurations <valid-config>`,
-the standard soundness theorems hold.
+the standard soundness theorems hold. [#cite-cpp2018]_
 
 **Theorem (Preservation).**
 If a :ref:`configuration <syntax-config>` :math:`S;T` is :ref:`valid <valid-config>` with :ref:`result type <syntax-resulttype>` :math:`[t^\ast]` (i.e., :math:`\vdashconfig S;T : [t^\ast]`),
@@ -739,3 +739,7 @@ Consequently, given a :ref:`valid store <valid-store>`, no computation defined b
 .. [#cite-pldi2017]
    The formalization and theorems are derived from the following article:
    Andreas Haas, Andreas Rossberg, Derek Schuff, Ben Titzer, Dan Gohman, Luke Wagner, Alon Zakai, JF Bastien, Michael Holman. |PLDI2017|_. Proceedings of the 38th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI 2017). ACM 2017.
+
+.. [#cite-cpp2018]
+   A machine-verified version of the formalization and soundness proof is described in the following article:
+   Conrad Watt. |CPP2018|_. Proceedings of the 7th ACM SIGPLAN Conference on Certified Programs and Proofs (CPP 2018). ACM 2018.

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -38,6 +38,9 @@
 .. |PLDI2017| replace:: Bringing the Web up to Speed with WebAssembly
 .. _PLDI2017: https://dl.acm.org/citation.cfm?doid=3062341.3062363
 
+.. |CPP2018| replace:: Mechanising and Verifying the WebAssembly Specification
+.. _CPP2018: https://dl.acm.org/citation.cfm?id=3167082
+
 .. |TAPL| replace:: Types and Programming Languages
 .. _TAPL: https://www.cis.upenn.edu/~bcpierce/tapl/
 


### PR DESCRIPTION
Cite Conrad Watt's CPP 2018 paper describing the Isabelle mechanisation of the soundness proof.