### PR TITLE
[test] Sync default imports of the interpreter with the test harness

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -10,11 +10,17 @@ let harness =
   "'use strict';\n" ^
   "\n" ^
   "let spectest = {\n" ^
-  "  print: print || ((...xs) => console.log(...xs)),\n" ^
-  "  global: 666,\n" ^
-  "  table: " ^
-  "new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'})," ^
-  "  memory: new WebAssembly.Memory({initial: 1, maximum: 2})," ^
+  "  print: console.log.bind(console)," ^
+  "  print_i32: console.log.bind(console)," ^
+  "  print_i32_f32: console.log.bind(console)," ^
+  "  print_f64_f64: console.log.bind(console)," ^
+  "  print_f32: console.log.bind(console)," ^
+  "  print_f64: console.log.bind(console)," ^
+  "  global_i32: 666," ^
+  "  global_f32: 666," ^
+  "  global_f64: 666," ^
+  "  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'})," ^
+  "  memory: new WebAssembly.Memory({initial: 1, maximum: 2})" ^
   "};\n" ^
   "\n" ^
   "let registry = {spectest};\n" ^


### PR DESCRIPTION
This PR gets the JS  tests generated by the spec interpreter in sync again with the changes done in https://github.com/WebAssembly/spec/pull/652.