### PR TITLE
[test] Wrap the default imports in a proxy to avoid TypeErrors

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -22,12 +22,12 @@ let harness =
   "  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),\n" ^
   "  memory: new WebAssembly.Memory({initial: 1, maximum: 2})\n" ^
   "};\n" ^
-  "let spectest_handler = {\n" ^
+  "let handler = {\n" ^
   "  get(target, prop) {\n" ^
   "    return (prop in target) ?  target[prop] : {};\n" ^
   "  }\n" ^
   "};\n" ^
-  "let registry = new Proxy({spectest}, spectest_handler);\n" ^
+  "let registry = new Proxy({spectest}, handler);\n" ^
   "\n" ^
   "function register(name, instance) {\n" ^
   "  registry[name] = instance.exports;\n" ^

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -10,20 +10,24 @@ let harness =
   "'use strict';\n" ^
   "\n" ^
   "let spectest = {\n" ^
-  "  print: console.log.bind(console)," ^
-  "  print_i32: console.log.bind(console)," ^
-  "  print_i32_f32: console.log.bind(console)," ^
-  "  print_f64_f64: console.log.bind(console)," ^
-  "  print_f32: console.log.bind(console)," ^
-  "  print_f64: console.log.bind(console)," ^
-  "  global_i32: 666," ^
-  "  global_f32: 666," ^
-  "  global_f64: 666," ^
-  "  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'})," ^
-  "  memory: new WebAssembly.Memory({initial: 1, maximum: 2})" ^
+  "  print: console.log.bind(console),\n" ^
+  "  print_i32: console.log.bind(console),\n" ^
+  "  print_i32_f32: console.log.bind(console),\n" ^
+  "  print_f64_f64: console.log.bind(console),\n" ^
+  "  print_f32: console.log.bind(console),\n" ^
+  "  print_f64: console.log.bind(console),\n" ^
+  "  global_i32: 666,\n" ^
+  "  global_f32: 666,\n" ^
+  "  global_f64: 666,\n" ^
+  "  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),\n" ^
+  "  memory: new WebAssembly.Memory({initial: 1, maximum: 2})\n" ^
   "};\n" ^
-  "\n" ^
-  "let registry = {spectest};\n" ^
+  "let spectest_handler = {\n" ^
+  "  get(target, prop) {\n" ^
+  "    return (prop in target) ?  target[prop] : {};\n" ^
+  "  }\n" ^
+  "};\n" ^
+  "let registry = new Proxy({spectest}, spectest_handler);\n" ^
   "\n" ^
   "function register(name, instance) {\n" ^
   "  registry[name] = instance.exports;\n" ^


### PR DESCRIPTION
This PR fixes the problem discussed in https://github.com/WebAssembly/spec/issues/684. We wrap the default imports in the core spec tests to avoid TypeErrors, because in the core WebAssembly spec TypeErrors have no place.

Drive-by change: add newlines I forgot in the last PR.