### PR TITLE
[spec] Editorial: Fix cross-references to core spec

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -16,8 +16,8 @@ Prepare For TR: true
 <pre class='biblio'>
 {
   "WEBASSEMBLY": {
-    "href": "https://webassembly.github.io/spec/",
-    "title": "WebAssembly Specification",
+    "href": "https://webassembly.github.io/spec/core/",
+    "title": "WebAssembly Core Specification",
     "publisher": "W3C WebAssembly Community Group",
     "status": "Draft"
   }
@@ -84,7 +84,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: the Number value; url: sec-ecmascript-language-types-number-type
         text: NumberToRawBytes; url: sec-numbertorawbytes
         text: Built-in Function Objects; url: sec-built-in-function-objects
-urlPrefix: https://webassembly.github.io/spec/core/multipage/; spec: WebAssembly; type: dfn
+urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -22,8 +22,8 @@ Prepare For TR: true
     "status": "Current Editor's Draft"
   },
   "WEBASSEMBLY": {
-    "href": "https://webassembly.github.io/spec/",
-    "title": "WebAssembly Specification",
+    "href": "https://webassembly.github.io/spec/core/",
+    "title": "WebAssembly Core Specification",
     "publisher": "W3C WebAssembly Community Group",
     "status": "Draft"
   },
@@ -42,7 +42,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: interface
         text: ArrayBuffer; url: sec-arraybuffer-objects
-urlPrefix: https://webassembly.github.io/spec/core/multipage/; spec: WebAssembly; type: dfn
+urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     text: function index; url: syntax/modules.html#syntax-funcidx
     text: "name" section; url: appendix/custom.html?highlight=name%20section#binary-namesec
 urlPrefix: https://webassembly.github.io/spec/js-api/; spec: WASMJS


### PR DESCRIPTION
In particular, the spec moved and redirects don't seem to be in place;
this patch fixes the links.