### PR TITLE
[spec] Normative: Support [Serializable] for WebAssembly.Module

### DIFF
--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -147,13 +147,7 @@ The [=serialization steps=], given |value|, |serialized| and |forStorage|, are:
 
     1. Set |serialized|.\[[Bytes]] to |value|.\[[Bytes]].
 
-    1. Set |serialized|.\[[AgentCluster]] to the [=current Realm=]'s corresponding [=agent cluster=].
-
 The [=deserialization steps=], given |serialized| and |value|, are:
-
-    1. If |targetRealm|'s corresponding [=agent cluster=] is not
-        |serialized|.\[[AgentCluster]], then throw a
-        "<a exception>DataCloneError</a>" {{DOMException}}.
 
     1. Let |bytes| be |serialized|.\[[Bytes]].
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -137,7 +137,7 @@ Note: This algorithm accepts a {{Response}} object, or a
 
 <h2 id="serialization">Serialization</h2>
 
-On the Web, {{Module}} has the <code>[<a extended-attribute>Serializable</a>]</code> extended attribute.
+Web user agents must augment the {{Module}} interface with the <code>[<a extended-attribute>Serializable</a>]</code> extended attribute.
 
 The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -32,6 +32,12 @@ Prepare For TR: true
     "title": "WebAssembly JS Integration Specification",
     "publisher": "W3C WebAssembly Community Group",
     "status": "Draft"
+  },
+  "SECURECONTEXTS": {
+    "href": "https://w3c.github.io/webappsec-secure-contexts/",
+    "title": "Secure Contexts",
+    "publisher": "WebAppSec WG",
+    "status": "Candidate Recommendation"
   }
 }
 </pre>
@@ -42,6 +48,9 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: interface
         text: ArrayBuffer; url: sec-arraybuffer-objects
+    type: dfn
+        text: agent cluster; url: sec-agent-clusters
+        text: current Realm; url: current-realm
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     text: function index; url: syntax/modules.html#syntax-funcidx
     text: name section; url: appendix/custom.html?highlight=name%20section#binary-namesec
@@ -61,6 +70,7 @@ urlPrefix: https://webassembly.github.io/spec/js-api/; spec: WASMJS
         text: Exported Function; url: #exported-function
 url:https://html.spec.whatwg.org/#cors-same-origin;text:CORS-same-origin;type:dfn;spec:HTML
 url:https://fetch.spec.whatwg.org/#concept-body-consume-body;text:consume body;type:dfn;spec:FETCH
+url:https://w3c.github.io/webappsec-secure-contexts/#environment-settings-object-contextually-secure; text:contextually secure; type: dfn; spec: SECURECONTEXTS
 </pre>
 
 <pre class='link-defaults'>
@@ -124,6 +134,42 @@ Note: This algorithm accepts a {{Response}} object, or a
          1. [=Reject=] |returnValue| with |reason|.
      1. Return |returnValue|.
 </div>
+
+<h2 id="serialization">Serialization</h2>
+
+On the Web, {{Module}} has the <code>[<a extended-attribute>Serializable</a>]</code> extended attribute.
+
+The [=serialization steps=], given |value|, |serialized| and |forStorage|, are:
+
+    1. If |forStorage| is true and the [=relevant settings object=]
+        of |value| is not [=contextually secure=], throw a
+        "<a exception>DataCloneError</a>" {{DOMException}}
+
+    1. Set |serialized|.\[[Bytes]] to |value|.\[[Bytes]].
+
+    1. Set |serialized|.\[[AgentCluster]] to the [=current Realm=]'s corresponding [=agent cluster=].
+
+The [=deserialization steps=], given |serialized| and |value|, are:
+
+    1. If |targetRealm|'s corresponding [=agent cluster=] is not
+        |serialized|.\[[AgentCluster]], then throw a
+        "<a exception>DataCloneError</a>" {{DOMException}}.
+
+    1. Let |bytes| be |serialized|.\[[Bytes]].
+
+    1. Set |value|.\[[Bytes]] to |bytes|.
+
+    1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
+
+The semantics of a structured serialization is as-if the binary source, from which the
+{{Module}} was compiled, is serialized, then deserialized, and recompiled into the target realm.
+Engines should attempt to share/reuse internal compiled code when performing
+a structured serialization, although in corner cases like CPU upgrade or browser
+update, this might not be possible and full recompilation may be necessary.
+
+Given the above engine optimizations, structured serialization provides developers
+explicit control over both compiled-code caching and cross-window/worker code
+sharing.
 
 <h2 id="conventions">Developer-Facing Display Conventions</h2>
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -147,11 +147,19 @@ The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
     1. Set |serialized|.\[[Bytes]] to the [=sub-serialization=] of |value|.\[[Bytes]].
 
+    1. If |forStorage| is *false*, set |serialized|.\[[AgentCluster]] to the
+       [=current Realm=]'s corresponding [=agent cluster=].
+
 The [=deserialization steps=], given |serialized| and |value|, are:
 
     1. Let |bytes| be the [=sub-deserialization=] of |serialized|.\[[Bytes]].
 
     1. Set |value|.\[[Bytes]] to |bytes|.
+
+    1. If |serialized| has an \[[AgentCluster]] field, and if |targetRealm|'s
+        corresponding [=agent cluster=] is not
+        |serialized|.\[[AgentCluster]], then throw a
+        "<a exception>DataCloneError</a>" {{DOMException}}.
 
     1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
 
@@ -164,6 +172,10 @@ Note: The semantics of a structured serialization is as-if the binary source, fr
 Given the above engine optimizations, structured serialization provides developers
 explicit control over both compiled-code caching and cross-window/worker code
 sharing.
+
+Note: The web platform does not permit cross-origin sharing of serialized Modules: in the
+case of |forStorage| being true, IndexedDB separates storage per origin; in the case of
+|forStorage| being false, agent clusters in HTML do not span multiple origins.
 
 <h2 id="conventions">Developer-Facing Display Conventions</h2>
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -145,11 +145,11 @@ The [=serialization steps=], given |value|, |serialized| and |forStorage|, are:
         of |value| is not [=contextually secure=], throw a
         "<a exception>DataCloneError</a>" {{DOMException}}
 
-    1. Set |serialized|.\[[Bytes]] to |value|.\[[Bytes]].
+    1. Set |serialized|.\[[Bytes]] to the [=sub-serialization=] of |value|.\[[Bytes]].
 
 The [=deserialization steps=], given |serialized| and |value|, are:
 
-    1. Let |bytes| be |serialized|.\[[Bytes]].
+    1. Let |bytes| be the [=sub-deserialization=] of |serialized|.\[[Bytes]].
 
     1. Set |value|.\[[Bytes]] to |bytes|.
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -141,13 +141,12 @@ Web user agents must augment the {{Module}} interface with the <code>[<a extende
 
 The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
-    1. If |forStorage| is true and the [=relevant settings object=]
-        of |value| is not [=contextually secure=], throw a
+    1. If |forStorage| is true, throw a
         "<a exception>DataCloneError</a>" {{DOMException}}
 
     1. Set |serialized|.\[[Bytes]] to the [=sub-serialization=] of |value|.\[[Bytes]].
 
-    1. If |forStorage| is *false*, set |serialized|.\[[AgentCluster]] to the
+    1. Set |serialized|.\[[AgentCluster]] to the
        [=current Realm=]'s corresponding [=agent cluster=].
 
 The [=deserialization steps=], given |serialized| and |value|, are:
@@ -156,8 +155,7 @@ The [=deserialization steps=], given |serialized| and |value|, are:
 
     1. Set |value|.\[[Bytes]] to |bytes|.
 
-    1. If |serialized| has an \[[AgentCluster]] field, and if |targetRealm|'s
-        corresponding [=agent cluster=] is not
+    1. If |targetRealm|'s corresponding [=agent cluster=] is not
         |serialized|.\[[AgentCluster]], then throw a
         "<a exception>DataCloneError</a>" {{DOMException}}.
 
@@ -172,10 +170,6 @@ Note: The semantics of a structured serialization is as-if the binary source, fr
 Given the above engine optimizations, structured serialization provides developers
 explicit control over both compiled-code caching and cross-window/worker code
 sharing.
-
-Note: The web platform does not permit cross-origin sharing of serialized Modules: in the
-case of |forStorage| being true, IndexedDB separates storage per origin; in the case of
-|forStorage| being false, agent clusters in HTML do not span multiple origins.
 
 <h2 id="conventions">Developer-Facing Display Conventions</h2>
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -139,7 +139,7 @@ Note: This algorithm accepts a {{Response}} object, or a
 
 On the Web, {{Module}} has the <code>[<a extended-attribute>Serializable</a>]</code> extended attribute.
 
-The [=serialization steps=], given |value|, |serialized| and |forStorage|, are:
+The [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
     1. If |forStorage| is true and the [=relevant settings object=]
         of |value| is not [=contextually secure=], throw a
@@ -155,12 +155,12 @@ The [=deserialization steps=], given |serialized| and |value|, are:
 
     1. [=Compile a WebAssembly module=] from |bytes| and set |value|.\[[Module]] to the result.
 
-The semantics of a structured serialization is as-if the binary source, from which the
-{{Module}} was compiled, is serialized, then deserialized, and recompiled into the target realm.
 Engines should attempt to share/reuse internal compiled code when performing
 a structured serialization, although in corner cases like CPU upgrade or browser
 update, this might not be possible and full recompilation may be necessary.
 
+Note: The semantics of a structured serialization is as-if the binary source, from which the
+{{Module}} was compiled, is serialized, then deserialized, and recompiled into the target realm.
 Given the above engine optimizations, structured serialization provides developers
 explicit control over both compiled-code caching and cross-window/worker code
 sharing.


### PR DESCRIPTION
This patchset adds support to WebAssembly.Module to be used in HTML serialization, including from `postMessage` and IndexedDB. The change is based on @flagxor 's [earlier PR](https://github.com/WebAssembly/design/pull/1074), with the following changes:
- Rather than actually including the Module in the serialization, this PR includes only the binary data, as the Module cannot be referenced across agents (which each have their own separate store).
- The same-agent-cluster limitation is removed, as it is nonsensical in the context of *forStorage* serialization, for example IndexedDB, which is permitted by this specification.
- The Memory aspects are omitted in this PR; those will be pursued in a separate PR in the threads repository.
- The bytes of the module are explicit sub-serialized/deserialized