### PR TITLE
Test that exported functions have no prototype

### DIFF
--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -408,6 +408,7 @@ test(() => {
     assert_equals(f.length, 0);
     assert_equals('name' in f, true);
     assert_equals(Function.prototype.call.call(f), 42);
+    assert_equals('prototype' in f, false);
     assertThrows(() => new f(), TypeError);
 }, "Exported WebAssembly functions");
 


### PR DESCRIPTION
According to the spec, exported functions should not have a [[Construct]] method, hence they should not have a prototype.