### PR TITLE
[spec] Normative: Permit work in parallel during instantiation

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -592,6 +592,8 @@ interface Module {
     1. If |module| is [=error=], throw a {{CompileError}} exception.
     1. Set **this**.\[[Module]] to |module|.
     1. Set **this**.\[[Bytes]] to |stableBytes|.
+
+Note: Some implementations enforce a size limitation on |bytes|. Use of this API is discouraged, in favor of asynchronous APIs.
 </div>
 
 <h3 id="instances">Instances</h3>
@@ -610,6 +612,8 @@ interface Instance {
     1. [=Read the imports=] of |module| with imports |importObject|, and let |imports| be the result.
     1. [=Instantiate the core of a WebAssembly module=] |module| with |imports|, and let |instance| be the result.
     1. [=initialize an instance object|Initialize=] **this** from |module| and |instance|.
+
+Note: The use of this synchronous API is discouraged, as some implementations sometimes do long-running compilation work when instantiating.
 </div>
 
 <div algorithm>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -462,13 +462,15 @@ The verification of WebAssembly type requirements is deferred to the
     1. Let |module| be |moduleObject|.\[[Module]].
     1. [=Read the imports=] of |module| with imports |importObject|, and let |imports| be the result.
         If this operation throws an exception, catch it, [=reject=] |promise| with the exception, and return |promise|.
-    1. [=Queue a task=] to perform the following steps:
-        1.  [=Instantiate the core of a WebAssembly module=] |module| with |imports|, and let |instance| be the result.
-            If this throws an exception, catch it, [=reject=] |promise| with the exception, and terminate these substeps.
-        1.  Let |instanceObject| be a [=/new=] {{Instance}}.
-        1.  [=initialize an instance object|Initialize=] |instanceObject| from |module| and |instance|.
-            If this throws an exception, catch it, [=reject=] |promise| with the exception, and terminate these substeps.
-        1. [=Resolve=] |promise| with |instanceObject|.
+    1. Run the following steps [=in parallel=]:
+        1. [=Queue a task=] to perform the following steps:
+            Note: Implementation-specific work may be performed here.
+            1.  [=Instantiate the core of a WebAssembly module=] |module| with |imports|, and let |instance| be the result.
+                If this throws an exception, catch it, [=reject=] |promise| with the exception, and terminate these substeps.
+            1.  Let |instanceObject| be a [=/new=] {{Instance}}.
+            1.  [=initialize an instance object|Initialize=] |instanceObject| from |module| and |instance|.
+                If this throws an exception, catch it, [=reject=] |promise| with the exception, and terminate these substeps.
+            1. [=Resolve=] |promise| with |instanceObject|.
     1. Return |promise|.
 </div>
 
@@ -487,14 +489,15 @@ The verification of WebAssembly type requirements is deferred to the
 
     1. Let |promise| be [=a new promise=].
     1. [=Upon fulfillment=] of |promiseOfModule| with value |module|:
-        1. [=synchronously instantiate a WebAssembly module|Synchronously instantiate the WebAssembly module=] |module| importing |importObject|, and let |instance| be the result.  If this throws an exception, catch it, [=reject=] |promise| with the exception, and abort these substeps.
-        1. Let |result| be the {{WebAssemblyInstantiatedSource}} value «[ "{{WebAssemblyInstantiatedSource/module}}" → |module|, "{{WebAssemblyInstantiatedSource/instance}}" → |instance| ]».
-        1. [=Resolve=] |promise| with |result|.
+        1. [=asynchronously instantiate a WebAssembly module|Instantiate the WebAssembly module=] |module| importing |importObject|, and let |innerPromise| be the result.
+        1. [=Upon fulfillment=] of |innerPromise| with value |instance|.
+            1. Let |result| be the {{WebAssemblyInstantiatedSource}} value «[ "{{WebAssemblyInstantiatedSource/module}}" → |module|, "{{WebAssemblyInstantiatedSource/instance}}" → |instance| ]».
+            1. [=Resolve=] |promise| with |result|.
+        1. [=Upon rejection=] of |innerPromise| with reason |reason|:
+            1. [=Reject=] |promise| with |reason|.
     1. [=Upon rejection=] of |promiseOfModule| with reason |reason|:
         1. [=Reject=] |promise| with |reason|.
     1. Return |promise|.
-
-    Note: It would be valid to perform certain parts of the instantiation [=in parallel=], but several parts need to happen in the event loop, including JavaScript operations to access the |importObject| and execution of the start function.
 </div>
 
 <div algorithm>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -473,7 +473,7 @@ The verification of WebAssembly type requirements is deferred to the
 </div>
 
 <div algorithm="instantiate">
-  To <dfn>instantiate a WebAssembly module</dfn> from a {{Module}} |moduleObject| and imports |importObject|, perform the following steps:
+  To <dfn>synchronously instantiate a WebAssembly module</dfn> from a {{Module}} |moduleObject| and imports |importObject|, perform the following steps:
     1. Let |module| be |moduleObject|.\[[Module]].
     1. [=Read the imports=] of |module| with imports |importObject|, and let |imports| be the result.
     1. [=Instantiate the core of a WebAssembly module=] |module| with |imports|, and let |instance| be the result.
@@ -487,7 +487,7 @@ The verification of WebAssembly type requirements is deferred to the
 
     1. Let |promise| be [=a new promise=].
     1. [=Upon fulfillment=] of |promiseOfModule| with value |module|:
-        1. [=instantiate a WebAssembly module|Instantiate the WebAssembly module=] |module| importing |importObject|, and let |instance| be the result.  If this throws an exception, catch it, [=reject=] |promise| with the exception, and abort these substeps.
+        1. [=synchronously instantiate a WebAssembly module|Synchronously instantiate the WebAssembly module=] |module| importing |importObject|, and let |instance| be the result.  If this throws an exception, catch it, [=reject=] |promise| with the exception, and abort these substeps.
         1. Let |result| be the {{WebAssemblyInstantiatedSource}} value «[ "{{WebAssemblyInstantiatedSource/module}}" → |module|, "{{WebAssemblyInstantiatedSource/instance}}" → |instance| ]».
         1. [=Resolve=] |promise| with |result|.
     1. [=Upon rejection=] of |promiseOfModule| with reason |reason|:


### PR DESCRIPTION
On JSC, some compilation work takes place the first time that a
Module is instantiated. If the module is instantiated in an
asynchronous way, the work happens off the main thread. This patch
loosens the specification of WebAssembly module instantiation
to permit this specific type of delay.

Based on skimming the code (but not running tests), I believe that
the new specification matches 3/4 of the implementations I examined.
The one which might not fit is V8, which defers reading properties
of the import object to a microtask queue item at the beginning
of WebAssembly.instantiate(Module), unlike the others, which read it
synchronously.

The previous specification didn't match any implementations, as it
specified to queue an HTML task at the beginning of the
WebAssembly.instantiate(Module) method, which no implementation
actually did to my knowledge. Punting to a queue there doesn't really
serve any purpose and was simply an error in drafting the previous
specification.

Closes #741
See also https://github.com/webpack/webpack/issues/6433