### PR TITLE
[test] Remove redundant kExprReturn

### DIFF
--- a/test/html/indexeddb.js
+++ b/test/html/indexeddb.js
@@ -65,8 +65,7 @@
                 .addBody([
                     kExprI32Const,
                     42,
-                    kExprReturn,
-                    kExprEnd
+                    kExprReturn
                 ])
                 .exportFunc();
             let source = builder.toBuffer();


### PR DESCRIPTION
The .addBody function of the WasmModuleBuilder automatically adds kExprEnd at the end of a function. Therefore the explicit addition of kExprEnd produces invalid wasm code. If you want to add kExprEnd explicitly, you have to use .addBodyWithEnd.