### PR TITLE
[test] Fix default imports in the multi-stage tests

### DIFF
--- a/test/harness/index.js
+++ b/test/harness/index.js
@@ -76,21 +76,25 @@ function reinitializeRegistry() {
     if (typeof WebAssembly === 'undefined')
         return;
 
-    registry = {
-        spectest: {
-            print: console.log.bind(console),
-            print_i32: console.log.bind(console),
-            print_i32_f32: console.log.bind(console),
-            print_f64_f64: console.log.bind(console),
-            print_f32: console.log.bind(console),
-            print_f64: console.log.bind(console),
-            global_i32: 666,
-            global_f32: 666,
-            global_f64: 666,
-            table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
-            memory: new WebAssembly.Memory({initial: 1, maximum: 2})
-        }
+    let spectest = {
+        print: console.log.bind(console),
+        print_i32: console.log.bind(console),
+        print_i32_f32: console.log.bind(console),
+        print_f64_f64: console.log.bind(console),
+        print_f32: console.log.bind(console),
+        print_f64: console.log.bind(console),
+        global_i32: 666,
+        global_f32: 666,
+        global_f64: 666,
+        table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
+        memory: new WebAssembly.Memory({initial: 1, maximum: 2})
     };
+    let handler = {
+        get(target, prop) {
+        return (prop in target) ?  target[prop] : {};
+      }
+    };
+    registry = new Proxy({spectest}, handler);
 }
 
 reinitializeRegistry();


### PR DESCRIPTION
This is the same change I did already for the core spec tests (#685), but this time for the multi-stage testing.
Original message:
This PR fixes the problem discussed in #684. We wrap the default imports in the core spec tests to avoid TypeErrors, because in the core WebAssembly spec TypeErrors have no place.