### PR TITLE
Add type-br_if-after-unreachable test.

### DIFF
--- a/test/core/unreached-invalid.wast
+++ b/test/core/unreached-invalid.wast
@@ -697,3 +697,13 @@
   ))
   "type mismatch"
 )
+(assert_invalid 
+  (module
+    (func $type-br_if-after-unreachable (result i64)
+      unreachable
+      br_if 0
+      i64.extend_u/i32
+    )
+  )
+ "type mismatch"
+)


### PR DESCRIPTION
This code is working as:

1. `unreachable`: makes the stack polymorphic.
2. `br_if`: Pops condition (always i32) and block's "label" values (in this case i64). Since stack is polymorphic and is empty this values might be represented as `Unknown` in validation algorithm. Then the "label" values are pushed on back on the stack.
3. `i64.extend_u/32`. Pops i32 value and extends it to i64 and pushes it on the stack.

Because `br_if` (2) can be viewed as a kind of tee (pop the value and push it back), it might be implemented in way that it pushes the value with type that was popped from the stack rather than pushing the value with type specified by the block. 

The problem with this approach is the stack value might be `Unknown` and the type pushed after it will be `Unknown`, and in (3) value would be not an i64 but `Unknown` thus this will lead to successful validation.
