### PR TITLE
[interpreter] Fix local decoding

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -572,9 +572,9 @@ let start_section s =
 (* Code section *)
 
 let local s =
-  let n = len32 s in
+  let n = vu32 s in
   let t = value_type s in
-  Lib.List.make n t
+  Lib.List32.make n t
 
 let code _ s =
   let locals = List.flatten (vec local s) in

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -45,12 +45,13 @@ end
 
 module List =
 struct
-  let rec make n x =
-    if n = 0 then [] else x :: make (n - 1) x
+  let rec make n x = make' n x []
+  and make' n x xs =
+    if n = 0 then xs else make' (n - 1) x (x::xs)
 
-  let rec table n f = table' 0 n f
-  and table' i n f =
-    if i = n then [] else f i :: table' (i + 1) n f
+  let rec table n f = table' n f []
+  and table' n f xs =
+    if n = 0 then xs else table' (n - 1) f (f (n - 1) :: xs)
 
   let rec take n xs =
     match n, xs with
@@ -93,6 +94,10 @@ end
 
 module List32 =
 struct
+  let rec make n x = make' n x []
+  and make' n x xs =
+    if n = 0l then xs else make' (Int32.sub n 1l) x (x::xs)
+
   let rec length xs = length' xs 0l
   and length' xs n =
     match xs with

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -22,6 +22,7 @@ end
 
 module List32 :
 sig
+  val make : int32 -> 'a -> 'a list
   val length : 'a list -> int32
   val nth : 'a list -> int32 -> 'a (* raises Failure *)
   val take : int32 -> 'a list -> 'a list (* raises Failure *)


### PR DESCRIPTION
Avoid bogus length check when decoding local count. Also, make some library functions tail-recursive to avoid stack overflow.