### PR TITLE
[js-api] Fix various style issues and typos found by Mark Miller

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -286,22 +286,22 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 </div>
 
 <div algorithm>
-  To <dfn>asynchronously compile a WebAssembly module</dfn> from a {{BufferSource}} |bytes|, with the promise |promise|, using optional [=task source=] |taskSource|, perform the following steps:
+  To <dfn>asynchronously compile a WebAssembly module</dfn> from a {{BufferSource}} |bytes|, using optional [=task source=] |taskSource|, perform the following steps:
 
+    1. Let |promise| be [=a new promise=].
     1. In parallel, [=compile a WebAssembly module|compile the WebAssembly module=] |bytes| and store the result as |module|.
     1. When the above operation completes, [=queue a task=] to perform the following steps. If |taskSource| was provided, queue the task on that task source.
         1. If |module| is [=error=], reject |promise| with a {{CompileError}} exception.
         1. Otherwise,
             1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and let |moduleObject| be the result.
             1. [=Resolve=] |promise| with |moduleObject|.
+    1. Return |promise|.
 </div>
 
 <div algorithm>
     The <dfn method for="WebAssembly">compile(bytes)</dfn> method, when invoked, performs the following steps:
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
-    1. Let |promise| be [=a new promise=].
-    1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| with |promise|.
-    1. Return |promise|.
+    1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| and return the result.
 </div>
 
 <div algorithm="instantiate">
@@ -405,8 +405,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 <div algorithm>
   The <dfn method for="WebAssembly">instantiate(bytes, importObject)</dfn> method, when invoked, performs the following steps:
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
-    1. Let |promiseOfModule| be [=a new promise=].
-    1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| with |promiseOfModule|.
+    1. [=Asynchronously compile a WebAssembly module=] from |stableBytes| and let |promiseOfModule| be the result.
     1. [=Instantiate a promise of a module|Instantiate=] |promiseOfModule| with imports |importObject| and return the result.
 </div>
 
@@ -488,7 +487,7 @@ interface Module {
     1. For each [=custom section=] |customSection| in the binary format of |bytes|,
         1. Let |name| be the <code>name</code> of the custom section, [=UTF-8 decode without BOM or fail|decoded as UTF-8=].
         1. Assert: |name| is not failure (|moduleObject|.\[[Module]] is [=valid=]).
-        1. If |name| equals |secondName| as string values,
+        1. If |name| equals |sectionName| as string values,
             1. [=Append=] a new {{ArrayBuffer}} containing a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes| for the range matched by this [=customsec=] production.
     1. Return |customSections|.
 </div>
@@ -499,7 +498,7 @@ interface Module {
     1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
     1. [=Compile a WebAssembly module|Compile the WebAssembly module=] |stableBytes| and store the result as |module|.
     1. If |module| is [=error=], throw a {{CompileError}} exception.
-    1. [=Construct a WebAssembly module object=] from |module| and |bytes|, and return the result.
+    1. [=Construct a WebAssembly module object=] from |module| and |stableBytes|, and return the result.
 </div>
 
 <h3 id="instances">Instances</h3>
@@ -652,7 +651,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
         Note: The above exception may happen due to either insufficient memory or an invalid size parameter.
 
-    6. Set the [=surrounding agent=]'s [=associated store=] to |store|.
+    6. Set the [=surrounding agent=]'s [=associated store=] to |result|.
     1. [=Append=] null to the Table instance's \[[Values]] internal slot |d| times.
     1. Return |initialSize|.
 </div>
@@ -718,8 +717,8 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
     1. Set |function|.\[[FunctionAddress]] to |funcaddr|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |functype| be [=type_func=](|store|, |funcaddr|).
-    1. Let [|arguments|] → [|results|] be |functype|.
-    1. Let |arity| be the length of |arguments|.
+    1. Let [|paramTypes|] → [|resultTypes|] be |functype|.
+    1. Let |arity| be the length of |paramTypes|.
     1. Perform ! [=DefinePropertyOrThrow=](|function|, `"length"`, PropertyDescriptor {\[[Value]]: |arity|, \[[Writable]]: false, \[[Enumerable]]: false, \[[Configurable]]: true}).
     1. Let |name| be the [=name of the WebAssembly function=] |funcaddr|.
     1. Perform ! [=SetFunctionName=](|function|, |name|).
@@ -784,7 +783,7 @@ Assert: |w| is not of the form [=𝗂𝟨𝟦.𝖼𝗈𝗇𝗌𝗍=] |i64|.
 
 <!-- If the WebAssembly value is optional, then given `None`, return JavaScript value `undefined`. -->
 
-Note: Implementations may optionally replace the NaN payload with any other NaN payload at this point in the f32 or f64 cases; such a change would not be observable through [=NumberToRawBytes=].
+Note: Number values which are equal to NaN may have various observable NaN payloads; see [=NumberToRawBytes=].for details.
 </div>
 
 <div algorithm>

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -117,7 +117,7 @@ Note: This algorithm accepts a {{Response}} object, or a
         Note: Although it is specified here that the response is consumed entirely before compilation proceeds, that is purely for ease of specification; implementations are likely to instead perform processing in a streaming fashion. The different is unobservable, and thus the simpler model is specified. <!-- Using consume is a bit silly as it creates an ArrayBuffer but then we just want the underlying bytes. This is because of how streams is specced in terms of promises and JS objects whereas we want to operate more directly on the underlying concept. We can revisit this if things change in the Streams/Fetch specs. -->
 
         7. [=Upon fulfillment=] of |bodyPromise| with value |bodyArrayBuffer|:
-            1. [=Asynchronously compile a WebAssembly module|Asynchronously compile the WebAssembly module=] |bodyArrayBuffer| with |returnValue| using the [=networking task source=].
+            1. [=Asynchronously compile a WebAssembly module|Asynchronously compile the WebAssembly module=] |bodyArrayBuffer| using the [=networking task source=] and [=resolve=] |returnValue| with the result.
         1. [=Upon rejection=] of |bodyPromise| with reason |reason|:
             1. [=Reject=] |returnValue| with |reason|.
      1. [=Upon rejection=] of |source| with reason |reason|:


### PR DESCRIPTION
- Fix accidentally setting the wrong state from Table.grow
- secondName -> sectionName
- Fix note about NaN payloads
- Improve name of some types
- Make proper use of byte stability
- Create a promise from within "asynchronously compile..."

Fixes issues reported in #730 

cc @erights 