### PR TITLE
[js-api] Fix cross-reference to JS spec

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -578,7 +578,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |map| be the [=surrounding agent=]'s associated [=Memory object cache=].
     1. Assert: |map|[|memaddr|] [=map/exists=]
     1. Let |memory| be |map|[|memaddr|].
-    1. Perform ! [=ForceDetachArrayBuffer=](|memory|.\[[BufferObject]], "WebAssembly.Memory").
+    1. Perform ! [=DetachArrayBuffer=](|memory|.\[[BufferObject]], "WebAssembly.Memory").
     1. Let |block| be a [=Data Block=] which is [=identified with=] the underlying memory of |memaddr|.
     1. Let |buffer| be a new {{ArrayBuffer}} whose \[[ArrayBufferData]] is |block| and \[[ArrayBufferByteLength]] is set to the length of |block|.
     1. Set |memory|.\[[BufferObject]] to |buffer|.


### PR DESCRIPTION
Following up on #712