### PR TITLE
Remove two checkpoints about linear memory semantics in Todo.md

### DIFF
--- a/test/Todo.md
+++ b/test/Todo.md
@@ -4,8 +4,6 @@ have a link to an open issue/PR, or be obvious. Comments/corrections/additions
 welcome.
 
 Linear memory semantics:
- - test that newly allocated memory (program start and `memory.grow`) is zeroed
- - test that `memory.grow` does a full 32-bit unsigned check for page-size divisibility
  - test that load/store addreses are full int32 (or int64), and not OCaml int
  - test that when allocating 4GiB, accessing index -1 fails
  - test that too-big `memory.grow` fails appropriately


### PR DESCRIPTION
According to [comment](https://github.com/WebAssembly/spec/pull/784#issuecomment-384210795), remove the following checkpoint:
- test that newly allocated memory (program start and memory.grow) is zeroed
-    test that memory.grow does a full 32-bit unsigned check for page-size divisibility