### PR TITLE
[test] Grow memory and verify that new allocated byte is zero

### DIFF
--- a/test/Todo.md
+++ b/test/Todo.md
@@ -4,8 +4,6 @@ have a link to an open issue/PR, or be obvious. Comments/corrections/additions
 welcome.
 
 Linear memory semantics:
- - test that newly allocated memory (program start and `memory.grow`) is zeroed
- - test that `memory.grow` does a full 32-bit unsigned check for page-size divisibility
  - test that load/store addreses are full int32 (or int64), and not OCaml int
  - test that when allocating 4GiB, accessing index -1 fails
  - test that too-big `memory.grow` fails appropriately

--- a/test/core/memory_grow.wast
+++ b/test/core/memory_grow.wast
@@ -58,3 +58,38 @@
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 10))
 (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
 (assert_return (invoke "grow" (i32.const 0x10000)) (i32.const -1))
+
+;; Test that newly allocated memory (program start and memory.grow) is zeroed
+
+(module
+  (memory 1)
+  (func (export "grow") (param i32) (result i32)
+    (memory.grow (get_local 0))
+  )
+  (func (export "check-memory-zero") (param i32 i32) (result i32)
+    (local i32)
+    (set_local 2 (i32.const 1))
+    (block
+      (loop
+        (set_local 2 (i32.load8_u (get_local 0)))
+        (br_if 1 (i32.ne (get_local 2) (i32.const 0)))
+        (br_if 1 (i32.ge_u (get_local 0) (get_local 1)))
+        (set_local 0 (i32.add (get_local 0) (i32.const 1)))
+        (br_if 0 (i32.le_u (get_local 0) (get_local 1)))
+      )
+    )
+    (get_local 2)
+  )
+)
+
+(assert_return (invoke "check-memory-zero" (i32.const 0) (i32.const 0xffff)) (i32.const 0))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "check-memory-zero" (i32.const 0x10000) (i32.const 0x1_ffff)) (i32.const 0))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 2))
+(assert_return (invoke "check-memory-zero" (i32.const 0x20000) (i32.const 0x2_ffff)) (i32.const 0))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 3))
+(assert_return (invoke "check-memory-zero" (i32.const 0x30000) (i32.const 0x3_ffff)) (i32.const 0))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 4))
+(assert_return (invoke "check-memory-zero" (i32.const 0x40000) (i32.const 0x4_ffff)) (i32.const 0))
+(assert_return (invoke "grow" (i32.const 1)) (i32.const 5))
+(assert_return (invoke "check-memory-zero" (i32.const 0x50000) (i32.const 0x5_ffff)) (i32.const 0))


### PR DESCRIPTION
 - Covers checkpoint at Todo.md:
   test that newly allocated memory (program start and memory.grow) is zeroed
 - rename resizing.wast to memory_grow.wast