### PR TITLE
Merge mutable global proposal into spec

### DIFF
--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -311,9 +311,6 @@ Each export is labeled by a unique :ref:`name <syntax-name>`.
 Exportable definitions are :ref:`functions <syntax-func>`, :ref:`tables <syntax-table>`, :ref:`memories <syntax-mem>`, and :ref:`globals <syntax-global>`,
 which are referenced through a respective descriptor.
 
-.. note::
-   In the current version of WebAssembly, only *immutable* globals may be exported.
-
 
 Conventions
 ...........
@@ -362,8 +359,6 @@ Every import defines an index in the respective :ref:`index space <syntax-index>
 In each index space, the indices of imports go before the first index of any definition contained in the module itself.
 
 .. note::
-   In the current version of WebAssembly, only *immutable* globals may be imported.
-
    Unlike export names, import names are not necessarily unique.
    It is possible to import the same |IMODULE|/|INAME| pair multiple times;
    such imports may even have different type descriptions, including different kinds of entities.

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -325,7 +325,7 @@ Exports :math:`\export` and export descriptions :math:`\exportdesc` are classifi
 
 .. math::
    \frac{
-     C.\CGLOBALS[x] = \ETGLOBAL~\globaltype
+     C.\CGLOBALS[x] = \globaltype
    }{
      C \vdashexportdesc \EDGLOBAL~x : \ETGLOBAL~\globaltype
    }

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -321,17 +321,13 @@ Exports :math:`\export` and export descriptions :math:`\exportdesc` are classifi
 
 * The global :math:`C.\CGLOBALS[x]` must be defined in the context.
 
-* Let :math:`\mut~t` be the :ref:`global type <syntax-globaltype>` :math:`C.\CGLOBALS[x]`.
-
-* The mutability :math:`\mut` must be |MCONST|.
-
 * Then the export description is valid with :ref:`external type <syntax-externtype>` :math:`\ETGLOBAL~C.\CGLOBALS[x]`.
 
 .. math::
    \frac{
-     C.\CGLOBALS[x] = \MCONST~t
+     C.\CGLOBALS[x] = \ETGLOBAL~\globaltype
    }{
-     C \vdashexportdesc \EDGLOBAL~x : \ETGLOBAL~(\MCONST~t)
+     C \vdashexportdesc \EDGLOBAL~x : \ETGLOBAL~\globaltype
    }
 
 .. note::
@@ -417,15 +413,13 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
 
 * The global type :math:`\globaltype` must be :ref:`valid <valid-globaltype>`.
 
-* The mutability of :math:`\globaltype` must be |MCONST|.
-
 * Then the import description is valid with type :math:`\ETGLOBAL~\globaltype`.
 
 .. math::
    \frac{
-     \vdashglobaltype \MCONST~t \ok
+     \vdashglobaltype \globaltype \ok
    }{
-     C \vdashimportdesc \IDGLOBAL~\MCONST~t : \ETGLOBAL~\MCONST~t
+     C \vdashimportdesc \IDGLOBAL~\globaltype : \ETGLOBAL~\globaltype
    }
 
 .. note::

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -132,6 +132,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: table address; url: exec/runtime.html#syntax-tableaddr
     text: function address; url: exec/runtime.html#syntax-funcaddr
     text: memory address; url: exec/runtime.html#syntax-memaddr
+    text: global address; url: exec/runtime.html#syntax-globaladdr
     url: syntax/types.html#syntax-valtype
         text: 𝗂𝟥𝟤
         text: 𝗂𝟨𝟦
@@ -153,6 +154,9 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
         text: 𝗆𝖾𝗆
         text: 𝗀𝗅𝗈𝖻𝖺𝗅
     text: global type; url: syntax/types.html#syntax-globaltype
+    url: syntax/types.html#syntax-mut
+        text: var
+        text: const
     text: address; url: exec/runtime.html#addresses
     text: signed_32; url: exec/numerics.html#aux-signed
     text: grow_memory; url: exec/instructions.html#exec-grow-memory
@@ -225,6 +229,7 @@ Each [=agent=] is associated with the following [=ordered map=]s:
     * The <dfn>Memory object cache</dfn>, mapping [=memory address=]es to {{Memory}} objects.
     * The <dfn>Table object cache</dfn>, mapping [=table address=]es to {{Table}} objects.
     * The <dfn>Exported Function cache</dfn>, mapping [=function address=]es to [=Exported Function=] objects.
+    * The <dfn>Global object cache</dfn>, mapping [=global address=]es to {{Global}} objects.
 
 <h2 id="webassembly-namespace">The WebAssembly Namespace</h2>
 
@@ -326,13 +331,17 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
                 1. Let |index| be the number of external functions in |imports|. This value |index| is known as the <dfn>index of the host function</dfn> |funcaddr|.
             1. Let |externfunc| be the [=external value=] [=external value|𝖿𝗎𝗇𝖼=] |funcaddr|.
             1. [=Append=] |externfunc| to |imports|.
-        1. If |externtype| is of the form [=𝗀𝗅𝗈𝖻𝖺𝗅=] |globaltype|,
-            1. If |globaltype| is [=𝗂𝟨𝟦=] or [=Type=](|v|) is not [=Number=], throw a {{LinkError}} exception.
-            1. Let |value| be [=ToWebAssemblyValue=](|v|, |globaltype|.<em>[=global type|valtype=]</em>)
-            1. Assert: |globaltype|.<em>[=global type|mut=]</em> is [=global type|𝖼𝗈𝗇𝗌𝗍=], as verified by WebAssembly validation.
-            1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-            1. Let (|store|, |globaladdr|) be [=alloc_global=](|store|, |globaltype|, |value|).
-            1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
+        1. If |externtype| is of the form [=𝗀𝗅𝗈𝖻𝖺𝗅=] |mut| |valtype|,
+            1. If [=Type=](|v|) is [=Number=],
+                1. If |valtype| is [=𝗂𝟨𝟦=], throw a {{LinkError}} exception.
+                1. Let |value| be [=ToWebAssemblyValue=](|v|, |valtype|)
+                1. Let |store| be the [=surrounding agent=]'s [=associated store=].
+                1. Let (|store|, |globaladdr|) be [=alloc_global=](|store|, [=const=] |valtype|, |value|).
+                1. Set the [[surrounding agent=]'s [=associated store=] to |store|.
+            1. If |v| is a {{Global}} instance,
+                1. Let |globaladdr| be |v|.\[[Global]]
+            1. Otherwise,
+                1. Throw a {{LinkError}} exception.
             1. Let |externglobal| be [=external value|𝗀𝗅𝗈𝖻𝖺𝗅=] |globaladdr|.
             1. [=Append=] |externglobal| to |imports|.
         1. If |externtype| is of the form [=𝗆𝖾𝗆=] |memtype|,
@@ -365,11 +374,10 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
             1. Let |func| be the result of creating [=a new Exported Function=] from |funcaddr|.
             1. Let |value| be |func|.
         1. If |externtype| is of the form [=𝗀𝗅𝗈𝖻𝖺𝗅=] |globaltype|,
-            1. If |globaltype|.<em>[=global type|valtype=]</em> is [=𝗂𝟨𝟦=], throw a {{LinkError}} exception.
-            1. Assert: |globaltype|.<em>[=global type|mut=]</em> is [=global type|𝖼𝗈𝗇𝗌𝗍=], as verified by WebAssembly validation.
             1. Assert: |externval| is of the form [=external value|𝗀𝗅𝗈𝖻𝖺𝗅=] |globaladdr|.
             1. Let [=external value|𝗀𝗅𝗈𝖻𝖺𝗅=] |globaladdr| be |externval|.
-            1. Let |value| be [=ToJSValue=]([=read_global=](|store|, |globaladdr|)).
+            1. Let |global| be [=create a global object|a new Global object=] created from |globaladdr|.
+            1. Let |value| be |global|.
         1. If |externtype| is of the form [=𝗆𝖾𝗆=] |memtype|,
             1. Assert: |externval| is of the form [=external value|𝗆𝖾𝗆=] |memaddr|.
             1. Let [=external value|𝗆𝖾𝗆=] |memaddr| be |externval|.
@@ -702,6 +710,93 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
     1. Set |values|[|index|] to |value|.
     1. Return undefined.
+</div>
+
+<h3 id="globals">Globals</h3>
+
+<pre class="idl">
+dictionary GlobalDescriptor {
+  required USVString value;
+  boolean mutable = false;
+};
+
+[LegacyNamespace=WebAssembly, Constructor(GlobalDescriptor descriptor, unrestricted double value = 0), Exposed=(Window,Worker,Worklet)]
+interface Global {
+  unrestricted double valueOf();
+  attribute unrestricted double value;
+};
+</pre>
+
+<div>
+A {{Global}} object represents a single [=global instance=]
+which can be simultaneously referenced by multiple {{Instance}} objects. Each
+{{Global}} object has one internal slot:
+
+    * \[[Global]] : a [=global address=]
+</div>
+
+<div algorithm>
+    To <dfn>create a global object</dfn> from a [=global address=] |globaladdr|, perform the following steps:
+    1. Let |map| be the current [=agent=]'s associated [=Global object cache=].
+    1. If |map|[|globaladdr|] [=map/exists=],
+        1. Return |map|[|globaladdr|].
+    1. Let |global| be a new {{Global}} instance with \[[Global]] set to |globaladdr|.
+    1. [=map/Set=] |map|[|globaladdr|] to |global|.
+    1. Return |global|.
+</div>
+
+<div algorithm>
+    The algorithm <dfn>ToValueType</dfn>(|s|) performs the following steps:
+    1. If |s| equals "i32", return [=𝗂𝟥𝟤=].
+    1. If |s| equals "f32", return [=𝖿𝟥𝟤=].
+    1. If |s| equals "f64", return [=𝖿𝟨𝟦=].
+    1. Otherwise, throw a {{TypeError}} exception.
+</div>
+
+<div algorithm>
+    The <dfn constructor for="Global">Global(descriptor, v)</dfn> constructor, when invoked, performs the following steps:
+    1. Let |mutable| be |descriptor|["mutable"].
+    1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
+    1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
+    1. If |mutable| is true, let |globaltype| be [=var=] |valuetype|; otherwise, let |globaltype| be [=const=] |valuetype|.
+    1. Let |store| be the current agent's [=associated store=].
+    1. Let (|store|, |globaladdr|) be [=alloc_global=](|store|, |globaltype|, |value|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
+    1. Set the current agent's [=associated store=] to |store|.
+    1. [=Create a global object=] from the global address |globaladdr| and return the result.
+</div>
+
+<div algorithm>
+    The algorithm <dfn>GetGlobalValue</dfn>({{Global}} |global|) performs the following steps:
+    1. Let |store| be the current agent's [=associated store=].
+    1. Let |globaladdr| be |global|.\[[Global]].
+    1. Let |globaltype| be [=type_global=](|store|, |globaladdr|).
+    1. If |globaltype| is of the form |mut| [=𝗂𝟨𝟦=], throw a {{TypeError}}.
+    1. Let |value| be [=read_global=](|store|, |globaladdr|).
+    1. Return [=ToJSValue=](|value|).
+</div>
+
+<div algorithm>
+    The getter of the <dfn attribute for="Global">value</dfn> attribute of {{Global}}, when invoked, performs the following steps:
+    1. Let |global| be the {{Global}} instance.
+    1. Return [=GetGlobalValue=](|global|).
+
+    The setter of the value attribute of {{Global}}, when invoked with a value |v|, performs the following steps:
+    1. Let |global| be the {{Global}} instance.
+    1. Let |store| be the current agent's [=associated store=].
+    1. Let |globaladdr| be |global|.\[[Global]].
+    1. Let |globaltype| be [=type_global=](|store|, |globaladdr|), where |globaltype| is of the form |mut| |valuetype|.
+    1. If |mut| is [=const=], throw a {{TypeError}.
+    1. If |valuetype| is [=𝗂𝟨𝟦=], throw a {{TypeError}}.
+    1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
+    1. Let |store| be [=write_global=](|store|, |globaladdr|, |value|).
+    1. If |store| is [=error=], throw a {{RangeError}} exception.
+    1. Set the current agent's [=associated store=] to |store|.
+</div>
+
+<div algorithm>
+    The <dfn method for="Global">valueOf()</dfn> method, when invoked, performs the following steps:
+    1. Let |global| be the {{Global}} instance.
+    1. Return [=GetGlobalValue=](|global|).
 </div>
 
 <h3 id="exported-function-exotic-objects">Exported Functions</h3>

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -61,7 +61,8 @@ let harness =
   "}\n" ^
   "\n" ^
   "function get(instance, name) {\n" ^
-  "  return instance.exports[name];\n" ^
+  "  let v = instance.exports[name];\n" ^
+  "  return (v instanceof WebAssembly.Global) ? v.value : v;\n" ^
   "}\n" ^
   "\n" ^
   "function exports(name, instance) {\n" ^

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -428,9 +428,6 @@ let check_import (im : import) (c : context) : context =
     {c with memories = mt :: c.memories}
   | GlobalImport gt ->
     check_global_type gt idesc.at;
-    let GlobalType (_, mut) = gt in
-    require (mut = Immutable) idesc.at
-      "mutable globals cannot be imported (yet)";
     {c with globals = gt :: c.globals}
 
 module NameSet = Set.Make(struct type t = Ast.name let compare = compare end)
@@ -441,10 +438,7 @@ let check_export (c : context) (set : NameSet.t) (ex : export) : NameSet.t =
   | FuncExport x -> ignore (func c x)
   | TableExport x -> ignore (table c x)
   | MemoryExport x -> ignore (memory c x)
-  | GlobalExport x ->
-    let GlobalType (_, mut) = global c x in
-    require (mut = Immutable) edesc.at
-      "mutable globals cannot be exported (yet)"
+  | GlobalExport x -> ignore (global c x)
   );
   require (not (NameSet.mem name set)) ex.at "duplicate export name";
   NameSet.add name set

--- a/test/core/globals.wast
+++ b/test/core/globals.wast
@@ -51,25 +51,9 @@
   "global is immutable"
 )
 
-(assert_invalid
-  (module (import "m" "a" (global (mut i32))))
-  "mutable globals cannot be imported"
-)
-
-(assert_invalid
-  (module (global (import "m" "a") (mut i32)))
-  "mutable globals cannot be imported"
-)
-
-(assert_invalid
-  (module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
-  "mutable globals cannot be exported"
-)
-
-(assert_invalid
-  (module (global (export "a") (mut f32) (f32.const 0)))
-  "mutable globals cannot be exported"
-)
+;; mutable globals can be exported
+(module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
+(module (global (export "a") (mut f32) (f32.const 0)))
 
 (assert_invalid
   (module (global f32 (f32.neg (f32.const 0))))

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -39,16 +39,29 @@
 (module $Mg
   (global $glob (export "glob") i32 (i32.const 42))
   (func (export "get") (result i32) (get_global $glob))
+
+  ;; export mutable globals
+  (global $mut_glob (export "mut_glob") (mut i32) (i32.const 142))
+  (func (export "get_mut") (result i32) (get_global $mut_glob))
+  (func (export "set_mut") (param i32) (set_global $mut_glob (get_local 0)))
 )
 (register "Mg" $Mg)
 
 (module $Ng
   (global $x (import "Mg" "glob") i32)
+  (global $mut_glob (import "Mg" "mut_glob") (mut i32))
   (func $f (import "Mg" "get") (result i32))
+  (func $get_mut (import "Mg" "get_mut") (result i32))
+  (func $set_mut (import "Mg" "set_mut") (param i32))
+
   (export "Mg.glob" (global $x))
   (export "Mg.get" (func $f))
   (global $glob (export "glob") i32 (i32.const 43))
   (func (export "get") (result i32) (get_global $glob))
+
+  (export "Mg.mut_glob" (global $mut_glob))
+  (export "Mg.get_mut" (func $get_mut))
+  (export "Mg.set_mut" (func $set_mut))
 )
 
 (assert_return (get $Mg "glob") (i32.const 42))
@@ -58,6 +71,26 @@
 (assert_return (invoke $Ng "Mg.get") (i32.const 42))
 (assert_return (invoke $Ng "get") (i32.const 43))
 
+(assert_return (get $Mg "mut_glob") (i32.const 142))
+(assert_return (get $Ng "Mg.mut_glob") (i32.const 142))
+(assert_return (invoke $Mg "get_mut") (i32.const 142))
+(assert_return (invoke $Ng "Mg.get_mut") (i32.const 142))
+
+(assert_return (invoke $Mg "set_mut" (i32.const 241)))
+(assert_return (get $Mg "mut_glob") (i32.const 241))
+(assert_return (get $Ng "Mg.mut_glob") (i32.const 241))
+(assert_return (invoke $Mg "get_mut") (i32.const 241))
+(assert_return (invoke $Ng "Mg.get_mut") (i32.const 241))
+
+
+(assert_unlinkable
+  (module (import "Mg" "mut_glob" (global i32)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "Mg" "glob" (global (mut i32))))
+  "incompatible import type"
+)
 
 ;; Tables
 

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -225,9 +225,9 @@ class WasmModuleBuilder {
     return this.num_imported_funcs++;
   }
 
-  addImportedGlobal(module = "", name, type) {
+  addImportedGlobal(module = "", name, type, mutable = false) {
     let o = {module: module, name: name, kind: kExternalGlobal, type: type,
-             mutable: false}
+             mutable: mutable}
     this.imports.push(o);
     return this.num_imported_globals++;
   }

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -113,6 +113,16 @@ let mem1;
 let Table;
 let tbl1;
 let tableProto;
+let Global;
+let globalProto;
+let globalI32;
+let globalI64;
+let globalF32;
+let globalF64;
+let globalI32Mut;
+let globalI64Mut;
+let globalF32Mut;
+let globalF64Mut;
 
 let emptyModule;
 let exportingModule;
@@ -660,6 +670,275 @@ test(() => {
     assert_equals(tbl.length, 2);
     assertThrows(() => tbl.grow(1), Error);
 }, "'WebAssembly.Table.prototype.grow' method");
+
+test(() => {
+    const globalDesc = Object.getOwnPropertyDescriptor(WebAssembly, 'Global');
+    assert_equals(typeof globalDesc.value, "function");
+    assert_equals(globalDesc.writable, true);
+    assert_equals(globalDesc.enumerable, false);
+    assert_equals(globalDesc.configurable, true);
+    Global = WebAssembly.Global;
+}, "'WebAssembly.Global' data property");
+
+test(() => {
+    const globalDesc = Object.getOwnPropertyDescriptor(WebAssembly, 'Global');
+    assert_equals(Global, globalDesc.value);
+    assert_equals(Global.length, 1);
+    assert_equals(Global.name, "Global");
+    assertThrows(() => Global(), TypeError);
+    assertThrows(() => new Global(1), TypeError);
+    assertThrows(() => new Global({}), TypeError);
+    assertThrows(() => new Global({value: 'foo'}), TypeError);
+    assertThrows(() => new Global({value: 'i64'}), TypeError);
+    assert_equals(new Global({value:'i32'}) instanceof Global, true);
+    assert_equals(new Global({value:'f32'}) instanceof Global, true);
+    assert_equals(new Global({value:'f64'}) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}) instanceof Global, true);
+    assert_equals(new Global({value:'i32'}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32'}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64'}, 0xf64) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: false}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32', mutable: false}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: false}, 0xf64) instanceof Global, true);
+    assert_equals(new Global({value:'i32', mutable: true}, 0x132) instanceof Global, true);
+    assert_equals(new Global({value:'f32', mutable: true}, 0xf32) instanceof Global, true);
+    assert_equals(new Global({value:'f64', mutable: true}, 0xf64) instanceof Global, true);
+}, "'WebAssembly.Global' constructor function");
+
+test(() => {
+    const globalProtoDesc = Object.getOwnPropertyDescriptor(Global, 'prototype');
+    assert_equals(typeof globalProtoDesc.value, "object");
+    assert_equals(globalProtoDesc.writable, false);
+    assert_equals(globalProtoDesc.enumerable, false);
+    assert_equals(globalProtoDesc.configurable, false);
+}, "'WebAssembly.Global.prototype' data property");
+
+test(() => {
+    const globalProtoDesc = Object.getOwnPropertyDescriptor(Global, 'prototype');
+    globalProto = Global.prototype;
+    assert_equals(globalProto, globalProtoDesc.value);
+    assert_equals(String(globalProto), "[object WebAssembly.Global]");
+    assert_equals(Object.getPrototypeOf(globalProto), Object.prototype);
+}, "'WebAssembly.Global.prototype' object");
+
+test(() => {
+    globalI32 = new Global({value: 'i32'}, 0x132);
+    globalF32 = new Global({value: 'f32'}, 0xf32);
+    globalF64 = new Global({value: 'f64'}, 0xf64);
+    globalI32Mut = new Global({value: 'i32', mutable: true}, 0x132);
+    globalF32Mut = new Global({value: 'f32', mutable: true}, 0xf32);
+    globalF64Mut = new Global({value: 'f64', mutable: true}, 0xf64);
+    assert_equals(typeof globalI32, "object");
+    assert_equals(String(globalI32), "[object WebAssembly.Global]");
+    assert_equals(Object.getPrototypeOf(globalI32), globalProto);
+}, "'WebAssembly.Global' instance objects");
+
+test(() => {
+    let builder = new WasmModuleBuilder();
+    builder.addGlobal(kWasmI32).exportAs('i32');
+    builder.addGlobal(kWasmI64).exportAs('i64');
+    builder.addGlobal(kWasmF32).exportAs('f32');
+    builder.addGlobal(kWasmF64).exportAs('f64');
+    builder.addGlobal(kWasmI32, true).exportAs('i32mut');
+    builder.addGlobal(kWasmI64, true).exportAs('i64mut');
+    builder.addGlobal(kWasmF32, true).exportAs('f32mut');
+    builder.addGlobal(kWasmF64, true).exportAs('f64mut');
+    let module = new WebAssembly.Module(builder.toBuffer());
+    let instance = new WebAssembly.Instance(module);
+
+    assert_true(instance.exports.i32 instanceof WebAssembly.Global);
+    assert_true(instance.exports.i64 instanceof WebAssembly.Global);
+    assert_true(instance.exports.f32 instanceof WebAssembly.Global);
+    assert_true(instance.exports.f64 instanceof WebAssembly.Global);
+    assert_true(instance.exports.i32mut instanceof WebAssembly.Global);
+    assert_true(instance.exports.i64mut instanceof WebAssembly.Global);
+    assert_true(instance.exports.f32mut instanceof WebAssembly.Global);
+    assert_true(instance.exports.f64mut instanceof WebAssembly.Global);
+
+    // Can't set value of immutable globals.
+    assertThrows(() => instance.exports.i32.value = 0, TypeError);
+    assertThrows(() => instance.exports.i64.value = 0, TypeError);
+    assertThrows(() => instance.exports.f32.value = 0, TypeError);
+    assertThrows(() => instance.exports.f64.value = 0, TypeError);
+
+    instance.exports.i32mut.value = 13579;
+    instance.exports.f32mut.value = 24680;
+    instance.exports.f64mut.value = 124816;
+
+    globalI64 = instance.exports.i64;
+    globalI64Mut = instance.exports.i64mut;
+}, "Export 'WebAssembly.Global'");
+
+test(() => {
+    const lengthDesc = Object.getOwnPropertyDescriptor(globalProto, 'value');
+    assert_equals(typeof lengthDesc.get, "function");
+    assert_equals(typeof lengthDesc.set, "function");
+    assert_equals(lengthDesc.enumerable, false);
+    assert_equals(lengthDesc.configurable, true);
+}, "'WebAssembly.Global.prototype.value' accessor data property");
+
+test(() => {
+    const valueDesc = Object.getOwnPropertyDescriptor(globalProto, 'value');
+    const valueGetter = valueDesc.get;
+    assert_equals(valueGetter.length, 0);
+    assertThrows(() => valueGetter.call(), TypeError);
+    assertThrows(() => valueGetter.call({}), TypeError);
+
+    assert_equals(typeof valueGetter.call(globalI32), "number");
+    assertThrows(() => valueGetter.call(globalI64), TypeError);
+    assert_equals(typeof valueGetter.call(globalF32), "number");
+    assert_equals(typeof valueGetter.call(globalF64), "number");
+    assert_equals(typeof valueGetter.call(globalI32Mut), "number");
+    assertThrows(() => valueGetter.call(globalI64Mut), TypeError);
+    assert_equals(typeof valueGetter.call(globalF32Mut), "number");
+    assert_equals(typeof valueGetter.call(globalF64Mut), "number");
+
+    assert_equals(valueGetter.call(globalI32), 0x132);
+    assert_equals(valueGetter.call(globalF32), 0xf32);
+    assert_equals(valueGetter.call(globalF64), 0xf64);
+    assert_equals(valueGetter.call(globalI32Mut), 0x132);
+    assert_equals(valueGetter.call(globalF32Mut), 0xf32);
+    assert_equals(valueGetter.call(globalF64Mut), 0xf64);
+}, "'WebAssembly.Global.prototype.value' getter");
+
+test(() => {
+    const valueDesc = Object.getOwnPropertyDescriptor(globalProto, 'value');
+    const valueSetter = valueDesc.set;
+    assert_equals(valueSetter.length, 1);
+    assertThrows(() => valueSetter.call(), TypeError);
+    assertThrows(() => valueSetter.call({}), TypeError);
+
+    assertThrows(() => valueSetter.call(globalI32, 1234), TypeError);
+    assertThrows(() => valueSetter.call(globalI64, 1234), TypeError);
+    assertThrows(() => valueSetter.call(globalF32, 1234), TypeError);
+    assertThrows(() => valueSetter.call(globalF64, 1234), TypeError);
+
+    valueSetter.call(globalI32Mut, 1234);
+    assertThrows(() => valueSetter.call(globalI64Mut, 1234), TypeError);
+    valueSetter.call(globalF32Mut, 5678);
+    valueSetter.call(globalF64Mut, 9012);
+
+    assert_equals(globalI32Mut.value, 1234);
+    assert_equals(globalF32Mut.value, 5678);
+    assert_equals(globalF64Mut.value, 9012);
+}, "'WebAssembly.Global.prototype.value' setter");
+
+test(() => {
+    const valueOfDesc = Object.getOwnPropertyDescriptor(globalProto, 'valueOf');
+    assert_equals(typeof valueOfDesc.value, "function");
+    assert_equals(valueOfDesc.enumerable, false);
+    assert_equals(valueOfDesc.configurable, true);
+}, "'WebAssembly.Global.prototype.valueOf' data property");
+
+test(() => {
+    const valueOfDesc = Object.getOwnPropertyDescriptor(globalProto, 'valueOf');
+    const valueOf = valueOfDesc.value;
+    assert_equals(valueOf.length, 0);
+    assertThrows(() => valueOf.call(), TypeError);
+    assertThrows(() => valueOf.call({}), TypeError);
+
+    assert_equals(valueOf.call(globalI32), 0x132);
+    assertThrows(() => valueOf.call(globalI64), TypeError);
+    assert_equals(valueOf.call(globalF32), 0xf32);
+    assert_equals(valueOf.call(globalF64), 0xf64);
+    assert_equals(valueOf.call(globalI32Mut), 1234);
+    assertThrows(() => valueOf.call(globalI64Mut), TypeError);
+    assert_equals(valueOf.call(globalF32Mut), 5678);
+    assert_equals(valueOf.call(globalF64Mut), 9012);
+}, "'WebAssembly.Global.prototype.valueOf' method");
+
+test(() => {
+    assert_equals(new Global({value: 'i32'}).value, 0);
+    assert_equals(new Global({value: 'f32'}).value, 0);
+    assert_equals(new Global({value: 'f64'}).value, 0);
+}, "'WebAssembly.Global' default value is 0");
+
+test(() => {
+    let builder = new WasmModuleBuilder();
+    builder.addImportedGlobal('', 'i32', kWasmI32);
+    builder.addImportedGlobal('', 'i64', kWasmI64);
+    builder.addImportedGlobal('', 'f32', kWasmF32);
+    builder.addImportedGlobal('', 'f64', kWasmF64);
+    builder.addImportedGlobal('', 'i32mut', kWasmI32, true);
+    builder.addImportedGlobal('', 'i64mut', kWasmI64, true);
+    builder.addImportedGlobal('', 'f32mut', kWasmF32, true);
+    builder.addImportedGlobal('', 'f64mut', kWasmF64, true);
+    let module = new WebAssembly.Module(builder.toBuffer());
+    let instance = new WebAssembly.Instance(module, {
+        '': {
+          i32: globalI32,
+          i64: globalI64,
+          f32: globalF32,
+          f64: globalF64,
+          i32mut: globalI32Mut,
+          i64mut: globalI64Mut,
+          f32mut: globalF32Mut,
+          f64mut: globalF64Mut
+        }
+    });
+}, "Import 'WebAssembly.Global'");
+
+test(() => {
+    let assertInstanceError = (type, mutable, imports) => {
+      assertThrows(() => {
+        let builder = new WasmModuleBuilder();
+        builder.addImportedGlobal('', 'g', type, mutable);
+        let module = new WebAssembly.Module(builder.toBuffer());
+        let instance = new WebAssembly.Instance(module, imports);
+      }, LinkError);
+    };
+
+    const immutable = false, mutable = true;
+
+    // Type mismatch.
+    assertInstanceError(kWasmI32, immutable, {'': {g: globalI64}});
+    assertInstanceError(kWasmI32, immutable, {'': {g: globalF32}});
+    assertInstanceError(kWasmI32, immutable, {'': {g: globalF64}});
+    assertInstanceError(kWasmI64, immutable, {'': {g: globalI32}});
+    assertInstanceError(kWasmI64, immutable, {'': {g: globalF32}});
+    assertInstanceError(kWasmI64, immutable, {'': {g: globalF64}});
+    assertInstanceError(kWasmF32, immutable, {'': {g: globalI32}});
+    assertInstanceError(kWasmF32, immutable, {'': {g: globalI64}});
+    assertInstanceError(kWasmF32, immutable, {'': {g: globalF64}});
+    assertInstanceError(kWasmF64, immutable, {'': {g: globalI32}});
+    assertInstanceError(kWasmF64, immutable, {'': {g: globalI64}});
+    assertInstanceError(kWasmF64, immutable, {'': {g: globalF32}});
+
+    assertInstanceError(kWasmI32, mutable, {'': {g: globalI64Mut}});
+    assertInstanceError(kWasmI32, mutable, {'': {g: globalF32Mut}});
+    assertInstanceError(kWasmI32, mutable, {'': {g: globalF64Mut}});
+    assertInstanceError(kWasmI64, mutable, {'': {g: globalI32Mut}});
+    assertInstanceError(kWasmI64, mutable, {'': {g: globalF32Mut}});
+    assertInstanceError(kWasmI64, mutable, {'': {g: globalF64Mut}});
+    assertInstanceError(kWasmF32, mutable, {'': {g: globalI32Mut}});
+    assertInstanceError(kWasmF32, mutable, {'': {g: globalI64Mut}});
+    assertInstanceError(kWasmF32, mutable, {'': {g: globalF64Mut}});
+    assertInstanceError(kWasmF64, mutable, {'': {g: globalI32Mut}});
+    assertInstanceError(kWasmF64, mutable, {'': {g: globalI64Mut}});
+    assertInstanceError(kWasmF64, mutable, {'': {g: globalF32Mut}});
+
+    // Mutable mismatch.
+    assertInstanceError(kWasmI32, immutable, {'': {g: globalI32Mut}});
+    assertInstanceError(kWasmI64, immutable, {'': {g: globalI64Mut}});
+    assertInstanceError(kWasmF32, immutable, {'': {g: globalF32Mut}});
+    assertInstanceError(kWasmF64, immutable, {'': {g: globalF64Mut}});
+
+    assertInstanceError(kWasmI32, mutable, {'': {g: globalI32}});
+    assertInstanceError(kWasmI64, mutable, {'': {g: globalI64}});
+    assertInstanceError(kWasmF32, mutable, {'': {g: globalF32}});
+    assertInstanceError(kWasmF64, mutable, {'': {g: globalF64}});
+
+    // Can't import Number as mutable.
+    assertInstanceError(kWasmI32, mutable, {'': {g: 1}});
+    assertInstanceError(kWasmI64, mutable, {'': {g: 1}});
+    assertInstanceError(kWasmF32, mutable, {'': {g: 1}});
+    assertInstanceError(kWasmF64, mutable, {'': {g: 1}});
+}, "Import 'WebAssembly.Global' type mismatch");
 
 test(() => {
     assertThrows(() => WebAssembly.validate(), TypeError);


### PR DESCRIPTION
We discussed this in the June 6 Working Group meeting and decided to merge the mutable-global proposal into v1 of the spec.

Since this proposal doesn't actually change that much, I thought it might be nicer to squash the changes from the mutable-global repo it into one patch. This means we lose the change history here, but it's still available in the mutable global repo, so I think it's OK. What does everyone think?