### PR TITLE
Mark `value` to be an optional argument

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -720,7 +720,7 @@ dictionary GlobalDescriptor {
   boolean mutable = false;
 };
 
-[LegacyNamespace=WebAssembly, Constructor(GlobalDescriptor descriptor, unrestricted double value = 0), Exposed=(Window,Worker,Worklet)]
+[LegacyNamespace=WebAssembly, Constructor(GlobalDescriptor descriptor, optional unrestricted double value = 0), Exposed=(Window,Worker,Worklet)]
 interface Global {
   unrestricted double valueOf();
   attribute unrestricted double value;


### PR DESCRIPTION
As non-optional arguments cannot have a default value. (https://heycam.github.io/webidl/#prod-ArgumentRest)