### PR TITLE
[spec] Normative: Remove ahead of time bounds checks from instantiation

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -601,35 +601,11 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
     b. Assert: due to :ref:`validation <valid-elem>`, :math:`\X{eoval}_i` is of the form :math:`\I32.\CONST~\X{eo}_i`.
 
-    c. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
-
-    d. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
-
-    e. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
-
-    f. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
-
-    g. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
-
-    h. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
-
 10. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
 
     a. Let :math:`\X{doval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
 
     b. Assert: due to :ref:`validation <valid-data>`, :math:`\X{doval}_i` is of the form :math:`\I32.\CONST~\X{do}_i`.
-
-    c. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
-
-    d. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
-
-    e. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
-
-    f. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
-
-    g. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
-
-    h. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
 
 11. Assert: due to :ref:`validation <valid-module>`, the frame :math:`F` is now on the top of the stack.
 
@@ -637,11 +613,23 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 13. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
 
-    a. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
+    a. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
+
+    b. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
+
+    c. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
+
+    d. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
+
+    e. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
+
+    f. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
+
+    g. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
 
        i. Trap.
 
-    b. For each :ref:`function index <syntax-funcidx>` :math:`\funcidx_{ij}` in :math:`\elem_i.\EINIT` (starting with :math:`j = 0`), do:
+    h. For each :ref:`function index <syntax-funcidx>` :math:`\funcidx_{ij}` in :math:`\elem_i.\EINIT` (starting with :math:`j = 0`), do:
 
        i. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MIFUNCS[\funcidx_{ij}]` exists.
 
@@ -651,11 +639,23 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 14. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
 
-    a. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
+    a. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
+
+    b. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
+
+    c. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
+
+    d. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
+
+    e. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
+
+    f. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
+
+    g. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
 
        i. Trap.
 
-    b. For each :ref:`byte <syntax-byte>` :math:`b_{ij}` in :math:`\data_i.\DINIT` (starting with :math:`j = 0`), do:
+    h. For each :ref:`byte <syntax-byte>` :math:`b_{ij}` in :math:`\data_i.\DINIT` (starting with :math:`j = 0`), do:
 
        i. Replace :math:`\meminst_i.\MIDATA[\X{do}_i + j]` with :math:`b_{ij}`.
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -362,7 +362,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. Let (|store|, |instance|) be [=instantiate_module=](|store|, |module|, |imports|).
     1. If |instance| is [=error=], throw an appropriate exception type:
         * A {{LinkError}} exception for most cases which occur during linking.
-        * If the error came when running the start function, throw a {{RuntimeError}} for most errors which occur from WebAssembly, or the error object propagated from inner ECMAScript code.
+        * If the error came when copying initial values to the table or memory, or when running the start function, throw a {{RuntimeError}} for most errors which occur from WebAssembly, or the error object propagated from inner ECMAScript code.
         * Another error type if appropriate, for example an out-of-memory exception, as documented in <a href="#errors">the WebAssembly error mapping</a>.
     1. Let |exportsObject| be ! [=ObjectCreate=](null).
     1. For each pair (|name|, |externtype|) in [=module_exports=](|module|),

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -158,7 +158,7 @@
 
 ;; Invalid bounds for data
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 0)
     (data (i32.const 0) "a")
@@ -166,7 +166,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 0 0)
     (data (i32.const 0) "a")
@@ -174,7 +174,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 0 1)
     (data (i32.const 0) "a")
@@ -182,7 +182,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 0)
     (data (i32.const 1))
@@ -190,7 +190,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 0 1)
     (data (i32.const 1))
@@ -199,7 +199,7 @@
 )
 
 ;; This seems to cause a time-out on Travis.
-(;assert_unlinkable
+(;assert_trap
   (module
     (memory 0x10000)
     (data (i32.const 0xffffffff) "ab")
@@ -207,7 +207,7 @@
   ""  ;; either out of memory or segment does not fit
 ;)
 
-(assert_unlinkable
+(assert_trap
   (module
     (global (import "spectest" "global_i32") i32)
     (memory 0)
@@ -216,14 +216,14 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 1 2)
     (data (i32.const 0x1_0000) "a")
   )
   "data segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const 0x1_0000) "a")
@@ -231,7 +231,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 2)
     (data (i32.const 0x2_0000) "a")
@@ -239,7 +239,7 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 2 3)
     (data (i32.const 0x2_0000) "a")
@@ -247,14 +247,14 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 1)
     (data (i32.const -1) "a")
   )
   "data segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const -1) "a")
@@ -262,14 +262,14 @@
   "data segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (memory 2)
     (data (i32.const -100) "a")
   )
   "data segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "memory" (memory 1))
     (data (i32.const -100) "a")

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -139,7 +139,7 @@
 
 ;; Invalid bounds for elements
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 0 anyfunc)
     (func $f)
@@ -148,7 +148,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 0 0 anyfunc)
     (func $f)
@@ -157,7 +157,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 0 1 anyfunc)
     (func $f)
@@ -166,7 +166,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 0 anyfunc)
     (elem (i32.const 1))
@@ -174,7 +174,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 10 anyfunc)
     (func $f)
@@ -182,7 +182,7 @@
   )
   "elements segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "table" (table 10 anyfunc))
     (func $f)
@@ -191,7 +191,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 10 20 anyfunc)
     (func $f)
@@ -199,7 +199,7 @@
   )
   "elements segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "table" (table 10 anyfunc))
     (func $f)
@@ -208,7 +208,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 10 anyfunc)
     (func $f)
@@ -216,7 +216,7 @@
   )
   "elements segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "table" (table 10 anyfunc))
     (func $f)
@@ -225,7 +225,7 @@
   "elements segment does not fit"
 )
 
-(assert_unlinkable
+(assert_trap
   (module
     (table 10 anyfunc)
     (func $f)
@@ -233,7 +233,7 @@
   )
   "elements segment does not fit"
 )
-(assert_unlinkable
+(assert_trap
   (module
     (import "spectest" "table" (table 10 anyfunc))
     (func $f)


### PR DESCRIPTION
See https://github.com/WebAssembly/threads/issues/94 for background. The current specification does not extend neatly to the multi-threaded case.

This PR corresponds to potential solution 2, which received a broadly positive initial response, and would allow data initialisers to be used with shared memories.

I choose to make the per-initialiser bounds checks result in a Trap/RuntimeError rather than a Fail/LinkError, since this makes the behaviour indistinguishable from using bulk memory operations in the start function, and I believe users might expect LinkError to guarantee no side effects have taken place.