### PR TITLE
[test/interpreter] Check for max number of locals

### DIFF
--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -1,5 +1,8 @@
 module Fun =
 struct
+  let curry f x y = f (x, y)
+  let uncurry f (x, y) = f x y
+
   let rec repeat n f x =
     if n = 0 then () else (f x; repeat (n - 1) f x)
 end

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -2,6 +2,9 @@
 
 module Fun :
 sig
+  val curry : ('a * 'b -> 'c) -> ('a -> 'b -> 'c)
+  val uncurry : ('a -> 'b -> 'c) -> ('a * 'b -> 'c)
+
   val repeat : int -> ('a -> unit) -> 'a -> unit
 end
 

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -325,3 +325,20 @@
   )
   "zero flag expected"
 )
+
+;; No more than 2^32 locals.
+(assert_malformed 
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\0a\0c\01"                ;; Code section
+
+    ;; function 0
+    "\0a\02"
+    "\ff\ff\ff\ff\0f\7f"       ;; 0xFFFFFFFF i32
+    "\02\7e"                   ;; 0x00000002 i64
+    "\0b"                      ;; end
+  )
+  "too many locals"
+)


### PR DESCRIPTION
Adds a test that there can be no more than 2^32 locals defined in a binary.
Adds a fast failure path for this case in the interpreter.

Addresses #823 and subsumes #824.