### PR TITLE
[test] Remove tested checkpoints in Todo.md

### DIFF
--- a/test/Todo.md
+++ b/test/Todo.md
@@ -4,10 +4,7 @@ have a link to an open issue/PR, or be obvious. Comments/corrections/additions
 welcome.
 
 Linear memory semantics:
- - test that too-big `memory.grow` fails appropriately
- - test that too-big linear memory initial allocation fails
  - test that one can clobber the entire contents of the linear memory without corrupting: call stack, local variables, program execution.
- - test that an i64 store with 4-byte alignment that's 4 bytes out of bounds traps without storing anything.
 
 Misc optimizer bait:
  - test that the scheduler doesn't move a trapping div past a call which may not return

--- a/test/Todo.md
+++ b/test/Todo.md
@@ -5,6 +5,7 @@ welcome.
 
 Linear memory semantics:
  - test that one can clobber the entire contents of the linear memory without corrupting: call stack, local variables, program execution.
+ - test that an i64 store with 4-byte alignment that's 4 bytes out of bounds traps without storing anything.
 
 Misc optimizer bait:
  - test that the scheduler doesn't move a trapping div past a call which may not return


### PR DESCRIPTION
Following 3 checkpoints have been tested in [memory_grow.wast(L36-L60)](https://github.com/WebAssembly/spec/blob/master/test/core/memory_grow.wast#L36), [memory.wast(L52-L75)](https://github.com/WebAssembly/spec/blob/master/test/core/memory.wast#L52), [align.wast(L436)](https://github.com/WebAssembly/spec/blob/master/test/core/align.wast#L436) respectively
 - test that too-big `memory.grow` fails appropriately
 - test that too-big linear memory initial allocation fails
 - test that an i64 store with 4-byte alignment that's 4 bytes out of bounds traps without storing anything.