### PR TITLE
[test] Add test to cover one checkpoint in Todo.md

### DIFF
--- a/test/Todo.md
+++ b/test/Todo.md
@@ -7,7 +7,6 @@ Linear memory semantics:
  - test that too-big `memory.grow` fails appropriately
  - test that too-big linear memory initial allocation fails
  - test that one can clobber the entire contents of the linear memory without corrupting: call stack, local variables, program execution.
- - test that an i64 store with 4-byte alignment that's 4 bytes out of bounds traps without storing anything.
 
 Misc optimizer bait:
  - test that the scheduler doesn't move a trapping div past a call which may not return

--- a/test/core/align.wast
+++ b/test/core/align.wast
@@ -848,3 +848,13 @@
 (assert_return (invoke "i64_align_switch" (i32.const 6) (i32.const 2)) (i64.const 10))
 (assert_return (invoke "i64_align_switch" (i32.const 6) (i32.const 4)) (i64.const 10))
 (assert_return (invoke "i64_align_switch" (i32.const 6) (i32.const 8)) (i64.const 10))
+
+;; Test that an i64 store with 4-byte alignment that's 4 bytes out of bounds traps without storing anything
+
+(module
+  (memory 1)
+  (func (export "store") (param i32 i64)
+    (i64.store align=4 (get_local 0) (get_local 1))
+  )
+)
+(assert_trap (invoke "store" (i32.const 65531) (i64.const 1)) "out of bounds memory access")

--- a/test/core/align.wast
+++ b/test/core/align.wast
@@ -861,6 +861,6 @@
   )
 )
 
-(assert_trap (invoke "store" (i32.const 65532) (i64.const 1)) "out of bounds memory access")
+(assert_trap (invoke "store" (i32.const 65532) (i64.const -1)) "out of bounds memory access")
 ;; No memory was changed
 (assert_return (invoke "load" (i32.const 65532)) (i32.const 0))

--- a/test/core/align.wast
+++ b/test/core/align.wast
@@ -856,5 +856,11 @@
   (func (export "store") (param i32 i64)
     (i64.store align=4 (get_local 0) (get_local 1))
   )
+  (func (export "load") (param i32) (result i32)
+    (i32.load (get_local 0))
+  )
 )
-(assert_trap (invoke "store" (i32.const 65531) (i64.const 1)) "out of bounds memory access")
+
+(assert_trap (invoke "store" (i32.const 65532) (i64.const 1)) "out of bounds memory access")
+;; No memory was changed
+(assert_return (invoke "load" (i32.const 65532)) (i32.const 0))


### PR DESCRIPTION
 - test that an i64 store with 4-byte alignment that's 4 bytes
   out of bounds traps without storing anything