### PR TITLE
Indent substeps correctly in the Global constructor.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -770,10 +770,10 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |mutable| be |descriptor|["mutable"].
     1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
     1. If |v| is undefined,
-       1. let |value| be [=DefaultValue=](|valuetype|).
+        1. let |value| be [=DefaultValue=](|valuetype|).
     1. Otherwise,
-       1. If |valuetype| is [=𝗂𝟨𝟦=], throw a {{TypeError}} exception.
-       1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
+        1. If |valuetype| is [=𝗂𝟨𝟦=], throw a {{TypeError}} exception.
+        1. Let |value| be [=ToWebAssemblyValue=](|v|, |valuetype|).
     1. If |mutable| is true, let |globaltype| be [=var=] |valuetype|; otherwise, let |globaltype| be [=const=] |valuetype|.
     1. Let |store| be the current agent's [=associated store=].
     1. Let (|store|, |globaladdr|) be [=alloc_global=](|store|, |globaltype|, |value|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->


### PR DESCRIPTION
They need four spaces rather than three to escape from the parent list.