### PR TITLE
Potential copy&paste error in loop's note

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -509,7 +509,7 @@ Control Instructions
    }
 
 .. note::
-   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,[t^?]` inserts the new label type at index :math:`0`, shifting all others.
+   The :ref:`notation <notation-extend>` :math:`C,\CLABELS\,[]` inserts the new label type at index :math:`0`, shifting all others.
 
    The fact that the nested instruction sequence :math:`\instr^\ast` must have type :math:`[] \to [t^?]` implies that it cannot access operands that have been pushed on the stack before the loop was entered.
    This may be generalized in future versions of WebAssembly.


### PR DESCRIPTION
This appears to me like a copy&paste error (coming from `block`'s note). You don't actually use this notation here. You use a simpler version with the empty sequence label type. While this is not wrong as written (for `t^?` is allowed to be empty) it is confusing. But feel free to close if I am mistaken.