### PR TITLE
[test] Update wasm-module-builder.js

### DIFF
--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -627,6 +627,11 @@ class WasmModuleBuilder {
     return instance;
   }
 
+  asyncInstantiate(ffi) {
+    return WebAssembly.instantiate(this.Buffer(), ffi)
+        .then(({module, instance}) => instance);
+  }
+
   toModule(debug = false) {
     return new WebAssembly.Module(this.toBuffer(debug));
   }


### PR DESCRIPTION
Bring wasm-module-builder.js in sync with the version in V8.