### PR TITLE
[js-api] Fix some inconsistencies around handling bytes and buffers.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -89,7 +89,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation
-    text: binary format of a module; url: binary/modules.html
+    text: module grammar; url: binary/modules.html#binary-module
     text: custom section; url: binary/modules.html#custom-section
     text: customsec; url: binary/modules.html#binary-customsec
     text: memory instance; url: exec/runtime.html#memory-instances
@@ -265,7 +265,7 @@ Note:
 -->
 
 <div algorithm>
-  To <dfn>compile a WebAssembly module</dfn> from a {{BufferSource}} |bytes|, perform the following steps:
+  To <dfn>compile a WebAssembly module</dfn> from source bytes |bytes|, perform the following steps:
     1. Let |module| be [=decode_module=](|bytes|). If |module| is [=error=], return [=error=].
     1. If [=validate_module=](|module|) is [=error=], return [=error=].
     1. Return |module|.
@@ -273,7 +273,8 @@ Note:
 
 <div algorithm>
   The <dfn method for="WebAssembly">validate(|bytes|)</dfn> method, when invoked, performs the following steps:
-    1. [=Compile a WebAssembly module|Compile=] |bytes| as a WebAssembly module and store the results as |module|.
+    1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes|.
+    1. [=Compile a WebAssembly module|Compile=] |stableBytes| as a WebAssembly module and store the results as |module|.
     1. If |module| is [=error=], return false.
     1. Return true.
 </div>
@@ -282,7 +283,7 @@ Note:
 A {{Module}} object represents a single WebAssembly module. Each {{Module}} object has the following internal slots:
 
     * \[[Module]] : a WebAssembly [=module=]
-    * \[[Bytes]] : an {{ArrayBuffer}} which is source bytes of \[[Module]].
+    * \[[Bytes]] : the source bytes of \[[Module]].
 </div>
 
 <div algorithm>
@@ -295,7 +296,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
 </div>
 
 <div algorithm>
-  To <dfn>asynchronously compile a WebAssembly module</dfn> from a {{BufferSource}} |bytes|, using optional [=task source=] |taskSource|, perform the following steps:
+  To <dfn>asynchronously compile a WebAssembly module</dfn> from source bytes |bytes|, using optional [=task source=] |taskSource|, perform the following steps:
 
     1. Let |promise| be [=a new promise=].
     1. In parallel, [=compile a WebAssembly module|compile the WebAssembly module=] |bytes| and store the result as |module|.
@@ -496,11 +497,11 @@ interface Module {
     The <dfn method for="Module">customSections(|moduleObject|, |sectionName|)</dfn> method, when invoked, performs the following steps:
     1. Let |bytes| be |moduleObject|.\[[Bytes]].
     1. Let |customSections| be an empty [=list=] of {{ArrayBuffer}}s.
-    1. For each [=custom section=] |customSection| in the binary format of |bytes|,
+    1. For each [=custom section=] |customSection| in |bytes|, interpreted according to the [=module grammar=],
         1. Let |name| be the <code>name</code> of |customSection|, [=UTF-8 decode without BOM or fail|decoded as UTF-8=].
         1. Assert: |name| is not failure (|moduleObject|.\[[Module]] is [=valid=]).
         1. If |name| equals |sectionName| as string values,
-            1. [=Append=] a new {{ArrayBuffer}} containing a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bytes| for the range matched by this [=customsec=] production.
+            1. [=Append=] a new {{ArrayBuffer}} containing a copy of the bytes in |bytes| for the range matched by this [=customsec=] production.
     1. Return |customSections|.
 </div>
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -128,7 +128,8 @@ Note: This algorithm accepts a {{Response}} object, or a
             Note: Although it is specified here that the response is consumed entirely before compilation proceeds, that is purely for ease of specification; implementations are likely to instead perform processing in a streaming fashion. The different is unobservable, and thus the simpler model is specified. <!-- Using consume is a bit silly as it creates an ArrayBuffer but then we just want the underlying bytes. This is because of how streams is specced in terms of promises and JS objects whereas we want to operate more directly on the underlying concept. We can revisit this if things change in the Streams/Fetch specs. -->
 
         1. [=Upon fulfillment=] of |bodyPromise| with value |bodyArrayBuffer|:
-            1. [=Asynchronously compile a WebAssembly module|Asynchronously compile the WebAssembly module=] |bodyArrayBuffer| using the [=networking task source=] and [=resolve=] |returnValue| with the result.
+            1. Let |stableBytes| be a [=get a copy of the buffer source|copy of the bytes held by the buffer=] |bodyArrayBuffer|.
+            1. [=Asynchronously compile a WebAssembly module|Asynchronously compile the WebAssembly module=] |stableBytes| using the [=networking task source=] and [=resolve=] |returnValue| with the result.
         1. [=Upon rejection=] of |bodyPromise| with reason |reason|:
             1. [=Reject=] |returnValue| with |reason|.
      1. [=Upon rejection=] of |source| with reason |reason|:


### PR DESCRIPTION
This changes the specification to consistently grab the bytes immediately upon
receiving a BufferSource from user code, and store bytes directly in the
[[Bytes]] field.

This also clarifies the parsing of custom sections from the module bytes.