### PR TITLE
Improve test coverage of call_indirect.wast and call.wast

### DIFF
--- a/test/core/call.wast
+++ b/test/core/call.wast
@@ -106,6 +106,89 @@
 
   (func $mutual-runaway1 (export "mutual-runaway") (call $mutual-runaway2))
   (func $mutual-runaway2 (call $mutual-runaway1))
+
+  ;; As parameter of control constructs and instructions
+
+  (memory 1)
+
+  (func (export "as-select-first") (result i32)
+    (select (call $const-i32) (i32.const 2) (i32.const 3))
+  )
+  (func (export "as-select-mid") (result i32)
+    (select (i32.const 2) (call $const-i32) (i32.const 3))
+  )
+  (func (export "as-select-last") (result i32)
+    (select (i32.const 2) (i32.const 3) (call $const-i32))
+  )
+
+  (func (export "as-if-condition") (result i32)
+    (if (result i32) (call $const-i32) (then (i32.const 1)) (else (i32.const 2)))
+  )
+
+  (func (export "as-br_if-first") (result i32)
+    (block (result i32) (br_if 0 (call $const-i32) (i32.const 2)))
+  )
+  (func (export "as-br_if-last") (result i32)
+    (block (result i32) (br_if 0 (i32.const 2) (call $const-i32)))
+  )
+
+  (func (export "as-br_table-first") (result i32)
+    (block (result i32) (call $const-i32) (i32.const 2) (br_table 0 0))
+  )
+  (func (export "as-br_table-last") (result i32)
+    (block (result i32) (i32.const 2) (call $const-i32) (br_table 0 0))
+  )
+
+  (func $func (param i32 i32) (result i32) (get_local 0))
+  (type $check (func (param i32 i32) (result i32)))
+  (table anyfunc (elem $func))
+  (func (export "as-call_indirect-first") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (call $const-i32) (i32.const 2) (i32.const 0)
+      )
+    )
+  )
+  (func (export "as-call_indirect-mid") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 2) (call $const-i32) (i32.const 0)
+      )
+    )
+  )
+  (func (export "as-call_indirect-last") (result i32)
+    (block (result i32)
+      (call_indirect (type $check)
+        (i32.const 1) (i32.const 2) (call $const-i32)
+      )
+    )
+  )
+
+  (func (export "as-store-first")
+    (call $const-i32) (i32.const 1) (i32.store)
+  )
+  (func (export "as-store-last")
+    (i32.const 10) (call $const-i32) (i32.store)
+  )
+
+  (func (export "as-memory.grow-value") (result i32)
+    (memory.grow (call $const-i32))
+  )
+  (func (export "as-return-value") (result i32)
+    (call $const-i32) (return)
+  )
+  (func (export "as-drop-operand")
+    (call $const-i32) (drop)
+  )
+  (func (export "as-br-value") (result i32)
+    (block (result i32) (br 0 (call $const-i32)))
+  )
+  (func (export "as-set_local-value") (result i32)
+    (local i32) (set_local 0 (call $const-i32)) (get_local 0)
+  )
+  (func (export "as-load-operand") (result i32)
+    (i32.load (call $const-i32))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -153,6 +236,31 @@
 (assert_exhaustion (invoke "runaway") "call stack exhausted")
 (assert_exhaustion (invoke "mutual-runaway") "call stack exhausted")
 
+(assert_return (invoke "as-select-first") (i32.const 0x132))
+(assert_return (invoke "as-select-mid") (i32.const 2))
+(assert_return (invoke "as-select-last") (i32.const 2))
+
+(assert_return (invoke "as-if-condition") (i32.const 1))
+
+(assert_return (invoke "as-br_if-first") (i32.const 0x132))
+(assert_return (invoke "as-br_if-last") (i32.const 2))
+
+(assert_return (invoke "as-br_table-first") (i32.const 0x132))
+(assert_return (invoke "as-br_table-last") (i32.const 2))
+
+(assert_return (invoke "as-call_indirect-first") (i32.const 0x132))
+(assert_return (invoke "as-call_indirect-mid") (i32.const 2))
+(assert_trap (invoke "as-call_indirect-last") "undefined element")
+
+(assert_return (invoke "as-store-first"))
+(assert_return (invoke "as-store-last"))
+
+(assert_return (invoke "as-memory.grow-value") (i32.const 1))
+(assert_return (invoke "as-return-value") (i32.const 0x132))
+(assert_return (invoke "as-drop-operand"))
+(assert_return (invoke "as-br-value") (i32.const 0x132))
+(assert_return (invoke "as-set_local-value") (i32.const 0x132))
+(assert_return (invoke "as-load-operand") (i32.const 1))
 
 ;; Invalid typing
 

--- a/test/core/call_indirect.wast
+++ b/test/core/call_indirect.wast
@@ -45,10 +45,12 @@
       $const-i32 $const-i64 $const-f32 $const-f64
       $id-i32 $id-i64 $id-f32 $id-f64
       $f32-i32 $i32-i64 $f64-f32 $i64-f64
-      $fac $fib $even $odd
+      $fac-i64 $fib-i64 $even $odd
       $runaway $mutual-runaway1 $mutual-runaway2
       $over-i32-duplicate $over-i64-duplicate
       $over-f32-duplicate $over-f64-duplicate
+      $fac-i32 $fac-f32 $fac-f64
+      $fib-i32 $fib-f32 $fib-f64
     )
   )
 
@@ -131,13 +133,22 @@
     (call_indirect (type $over-i64) (get_local 1) (get_local 0))
   )
 
-  (func (export "dispatch-structural") (param i32) (result i64)
+  (func (export "dispatch-structural-i64") (param i32) (result i64)
     (call_indirect (type $over-i64-duplicate) (i64.const 9) (get_local 0))
+  )
+  (func (export "dispatch-structural-i32") (param i32) (result i32)
+    (call_indirect (type $over-i32-duplicate) (i32.const 9) (get_local 0))
+  )
+  (func (export "dispatch-structural-f32") (param i32) (result f32)
+    (call_indirect (type $over-f32-duplicate) (f32.const 9.0) (get_local 0))
+  )
+  (func (export "dispatch-structural-f64") (param i32) (result f64)
+    (call_indirect (type $over-f64-duplicate) (f64.const 9.0) (get_local 0))
   )
 
   ;; Recursion
 
-  (func $fac (export "fac") (type $over-i64)
+  (func $fac-i64 (export "fac-i64") (type $over-i64)
     (if (result i64) (i64.eqz (get_local 0))
       (then (i64.const 1))
       (else
@@ -152,7 +163,7 @@
     )
   )
 
-  (func $fib (export "fib") (type $over-i64)
+  (func $fib-i64 (export "fib-i64") (type $over-i64)
     (if (result i64) (i64.le_u (get_local 0) (i64.const 1))
       (then (i64.const 1))
       (else
@@ -164,6 +175,105 @@
           (call_indirect (type $over-i64)
             (i64.sub (get_local 0) (i64.const 1))
             (i32.const 13)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fac-i32 (export "fac-i32") (type $over-i32)
+    (if (result i32) (i32.eqz (get_local 0))
+      (then (i32.const 1))
+      (else
+        (i32.mul
+          (get_local 0)
+          (call_indirect (type $over-i32)
+            (i32.sub (get_local 0) (i32.const 1))
+            (i32.const 23)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fac-f32 (export "fac-f32") (type $over-f32)
+    (if (result f32) (f32.eq (get_local 0) (f32.const 0.0))
+      (then (f32.const 1.0))
+      (else
+        (f32.mul
+          (get_local 0)
+          (call_indirect (type $over-f32)
+            (f32.sub (get_local 0) (f32.const 1.0))
+            (i32.const 24)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fac-f64 (export "fac-f64") (type $over-f64)
+    (if (result f64) (f64.eq (get_local 0) (f64.const 0.0))
+      (then (f64.const 1.0))
+      (else
+        (f64.mul
+          (get_local 0)
+          (call_indirect (type $over-f64)
+            (f64.sub (get_local 0) (f64.const 1.0))
+            (i32.const 25)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fib-i32 (export "fib-i32") (type $over-i32)
+    (if (result i32) (i32.le_u (get_local 0) (i32.const 1))
+      (then (i32.const 1))
+      (else
+        (i32.add
+          (call_indirect (type $over-i32)
+            (i32.sub (get_local 0) (i32.const 2))
+            (i32.const 26)
+          )
+          (call_indirect (type $over-i32)
+            (i32.sub (get_local 0) (i32.const 1))
+            (i32.const 26)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fib-f32 (export "fib-f32") (type $over-f32)
+    (if (result f32) (f32.le (get_local 0) (f32.const 1.0))
+      (then (f32.const 1.0))
+      (else
+        (f32.add
+          (call_indirect (type $over-f32)
+            (f32.sub (get_local 0) (f32.const 2.0))
+            (i32.const 27)
+          )
+          (call_indirect (type $over-f32)
+            (f32.sub (get_local 0) (f32.const 1.0))
+            (i32.const 27)
+          )
+        )
+      )
+    )
+  )
+
+  (func $fib-f64 (export "fib-f64") (type $over-f64)
+    (if (result f64) (f64.le (get_local 0) (f64.const 1.0))
+      (then (f64.const 1.0))
+      (else
+        (f64.add
+          (call_indirect (type $over-f64)
+            (f64.sub (get_local 0) (f64.const 2.0))
+            (i32.const 28)
+          )
+          (call_indirect (type $over-f64)
+            (f64.sub (get_local 0) (f64.const 1.0))
+            (i32.const 28)
           )
         )
       )
@@ -206,6 +316,64 @@
 
   (func $mutual-runaway1 (export "mutual-runaway") (call_indirect (type $proc) (i32.const 18)))
   (func $mutual-runaway2 (call_indirect (type $proc) (i32.const 17)))
+
+  ;; As parameter of control constructs and instructions
+
+  (memory 1)
+
+  (func (export "as-select-first") (result i32)
+    (select (call_indirect (type $out-i32) (i32.const 0)) (i32.const 2) (i32.const 3))
+  )
+  (func (export "as-select-mid") (result i32)
+    (select (i32.const 2) (call_indirect (type $out-i32) (i32.const 0)) (i32.const 3))
+  )
+  (func (export "as-select-last") (result i32)
+    (select (i32.const 2) (i32.const 3) (call_indirect (type $out-i32) (i32.const 0)))
+  )
+
+  (func (export "as-if-condition") (result i32)
+    (if (result i32) (call_indirect (type $out-i32) (i32.const 0)) (then (i32.const 1)) (else (i32.const 2)))
+  )
+
+  (func (export "as-br_if-first") (result i64)
+    (block (result i64) (br_if 0 (call_indirect (type $out-i64) (i32.const 1)) (i32.const 2)))
+  )
+  (func (export "as-br_if-last") (result i32)
+    (block (result i32) (br_if 0 (i32.const 2) (call_indirect (type $out-i32) (i32.const 0))))
+  )
+
+  (func (export "as-br_table-first") (result f32)
+    (block (result f32) (call_indirect (type $out-f32) (i32.const 2)) (i32.const 2) (br_table 0 0))
+  )
+  (func (export "as-br_table-last") (result i32)
+    (block (result i32) (i32.const 2) (call_indirect (type $out-i32) (i32.const 0)) (br_table 0 0))
+  )
+
+  (func (export "as-store-first")
+    (call_indirect (type $out-i32) (i32.const 0)) (i32.const 1) (i32.store)
+  )
+  (func (export "as-store-last")
+    (i32.const 10) (call_indirect (type $out-f64) (i32.const 3)) (f64.store)
+  )
+
+  (func (export "as-memory.grow-value") (result i32)
+    (memory.grow (call_indirect (type $out-i32) (i32.const 0)))
+  )
+  (func (export "as-return-value") (result i32)
+    (call_indirect (type $over-i32) (i32.const 1) (i32.const 4)) (return)
+  )
+  (func (export "as-drop-operand")
+    (call_indirect (type $over-i64) (i64.const 1) (i32.const 5)) (drop)
+  )
+  (func (export "as-br-value") (result f32)
+    (block (result f32) (br 0 (call_indirect (type $over-f32) (f32.const 1) (i32.const 6))))
+  )
+  (func (export "as-set_local-value") (result f64)
+    (local f64) (set_local 0 (call_indirect (type $over-f64) (f64.const 1) (i32.const 7))) (get_local 0)
+  )
+  (func (export "as-load-operand") (result i32)
+    (i32.load (call_indirect (type $out-i32) (i32.const 0)))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -232,27 +400,81 @@
 (assert_return (invoke "dispatch" (i32.const 20) (i64.const 2)) (i64.const 2))
 (assert_trap (invoke "dispatch" (i32.const 0) (i64.const 2)) "indirect call type mismatch")
 (assert_trap (invoke "dispatch" (i32.const 15) (i64.const 2)) "indirect call type mismatch")
-(assert_trap (invoke "dispatch" (i32.const 23) (i64.const 2)) "undefined element")
+(assert_trap (invoke "dispatch" (i32.const 29) (i64.const 2)) "undefined element")
 (assert_trap (invoke "dispatch" (i32.const -1) (i64.const 2)) "undefined element")
 (assert_trap (invoke "dispatch" (i32.const 1213432423) (i64.const 2)) "undefined element")
 
-(assert_return (invoke "dispatch-structural" (i32.const 5)) (i64.const 9))
-(assert_return (invoke "dispatch-structural" (i32.const 5)) (i64.const 9))
-(assert_return (invoke "dispatch-structural" (i32.const 12)) (i64.const 362880))
-(assert_return (invoke "dispatch-structural" (i32.const 20)) (i64.const 9))
-(assert_trap (invoke "dispatch-structural" (i32.const 11)) "indirect call type mismatch")
-(assert_trap (invoke "dispatch-structural" (i32.const 22)) "indirect call type mismatch")
+(assert_return (invoke "dispatch-structural-i64" (i32.const 5)) (i64.const 9))
+(assert_return (invoke "dispatch-structural-i64" (i32.const 12)) (i64.const 362880))
+(assert_return (invoke "dispatch-structural-i64" (i32.const 13)) (i64.const 55))
+(assert_return (invoke "dispatch-structural-i64" (i32.const 20)) (i64.const 9))
+(assert_trap (invoke "dispatch-structural-i64" (i32.const 11)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch-structural-i64" (i32.const 22)) "indirect call type mismatch")
 
-(assert_return (invoke "fac" (i64.const 0)) (i64.const 1))
-(assert_return (invoke "fac" (i64.const 1)) (i64.const 1))
-(assert_return (invoke "fac" (i64.const 5)) (i64.const 120))
-(assert_return (invoke "fac" (i64.const 25)) (i64.const 7034535277573963776))
+(assert_return (invoke "dispatch-structural-i32" (i32.const 4)) (i32.const 9))
+(assert_return (invoke "dispatch-structural-i32" (i32.const 23)) (i32.const 362880))
+(assert_return (invoke "dispatch-structural-i32" (i32.const 26)) (i32.const 55))
+(assert_return (invoke "dispatch-structural-i32" (i32.const 19)) (i32.const 9))
+(assert_trap (invoke "dispatch-structural-i32" (i32.const 9)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch-structural-i32" (i32.const 21)) "indirect call type mismatch")
 
-(assert_return (invoke "fib" (i64.const 0)) (i64.const 1))
-(assert_return (invoke "fib" (i64.const 1)) (i64.const 1))
-(assert_return (invoke "fib" (i64.const 2)) (i64.const 2))
-(assert_return (invoke "fib" (i64.const 5)) (i64.const 8))
-(assert_return (invoke "fib" (i64.const 20)) (i64.const 10946))
+(assert_return (invoke "dispatch-structural-f32" (i32.const 6)) (f32.const 9.0))
+(assert_return (invoke "dispatch-structural-f32" (i32.const 24)) (f32.const 362880.0))
+(assert_return (invoke "dispatch-structural-f32" (i32.const 27)) (f32.const 55.0))
+(assert_return (invoke "dispatch-structural-f32" (i32.const 21)) (f32.const 9.0))
+(assert_trap (invoke "dispatch-structural-f32" (i32.const 8)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch-structural-f32" (i32.const 19)) "indirect call type mismatch")
+
+(assert_return (invoke "dispatch-structural-f64" (i32.const 7)) (f64.const 9.0))
+(assert_return (invoke "dispatch-structural-f64" (i32.const 25)) (f64.const 362880.0))
+(assert_return (invoke "dispatch-structural-f64" (i32.const 28)) (f64.const 55.0))
+(assert_return (invoke "dispatch-structural-f64" (i32.const 22)) (f64.const 9.0))
+(assert_trap (invoke "dispatch-structural-f64" (i32.const 10)) "indirect call type mismatch")
+(assert_trap (invoke "dispatch-structural-f64" (i32.const 18)) "indirect call type mismatch")
+
+(assert_return (invoke "fac-i64" (i64.const 0)) (i64.const 1))
+(assert_return (invoke "fac-i64" (i64.const 1)) (i64.const 1))
+(assert_return (invoke "fac-i64" (i64.const 5)) (i64.const 120))
+(assert_return (invoke "fac-i64" (i64.const 25)) (i64.const 7034535277573963776))
+
+(assert_return (invoke "fac-i32" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "fac-i32" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "fac-i32" (i32.const 5)) (i32.const 120))
+(assert_return (invoke "fac-i32" (i32.const 10)) (i32.const 3628800))
+
+(assert_return (invoke "fac-f32" (f32.const 0.0)) (f32.const 1.0))
+(assert_return (invoke "fac-f32" (f32.const 1.0)) (f32.const 1.0))
+(assert_return (invoke "fac-f32" (f32.const 5.0)) (f32.const 120.0))
+(assert_return (invoke "fac-f32" (f32.const 10.0)) (f32.const 3628800.0))
+
+(assert_return (invoke "fac-f64" (f64.const 0.0)) (f64.const 1.0))
+(assert_return (invoke "fac-f64" (f64.const 1.0)) (f64.const 1.0))
+(assert_return (invoke "fac-f64" (f64.const 5.0)) (f64.const 120.0))
+(assert_return (invoke "fac-f64" (f64.const 10.0)) (f64.const 3628800.0))
+
+(assert_return (invoke "fib-i64" (i64.const 0)) (i64.const 1))
+(assert_return (invoke "fib-i64" (i64.const 1)) (i64.const 1))
+(assert_return (invoke "fib-i64" (i64.const 2)) (i64.const 2))
+(assert_return (invoke "fib-i64" (i64.const 5)) (i64.const 8))
+(assert_return (invoke "fib-i64" (i64.const 20)) (i64.const 10946))
+
+(assert_return (invoke "fib-i32" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "fib-i32" (i32.const 1)) (i32.const 1))
+(assert_return (invoke "fib-i32" (i32.const 2)) (i32.const 2))
+(assert_return (invoke "fib-i32" (i32.const 5)) (i32.const 8))
+(assert_return (invoke "fib-i32" (i32.const 20)) (i32.const 10946))
+
+(assert_return (invoke "fib-f32" (f32.const 0.0)) (f32.const 1.0))
+(assert_return (invoke "fib-f32" (f32.const 1.0)) (f32.const 1.0))
+(assert_return (invoke "fib-f32" (f32.const 2.0)) (f32.const 2.0))
+(assert_return (invoke "fib-f32" (f32.const 5.0)) (f32.const 8.0))
+(assert_return (invoke "fib-f32" (f32.const 20.0)) (f32.const 10946.0))
+
+(assert_return (invoke "fib-f64" (f64.const 0.0)) (f64.const 1.0))
+(assert_return (invoke "fib-f64" (f64.const 1.0)) (f64.const 1.0))
+(assert_return (invoke "fib-f64" (f64.const 2.0)) (f64.const 2.0))
+(assert_return (invoke "fib-f64" (f64.const 5.0)) (f64.const 8.0))
+(assert_return (invoke "fib-f64" (f64.const 20.0)) (f64.const 10946.0))
 
 (assert_return (invoke "even" (i32.const 0)) (i32.const 44))
 (assert_return (invoke "even" (i32.const 1)) (i32.const 99))
@@ -266,6 +488,27 @@
 (assert_exhaustion (invoke "runaway") "call stack exhausted")
 (assert_exhaustion (invoke "mutual-runaway") "call stack exhausted")
 
+(assert_return (invoke "as-select-first") (i32.const 0x132))
+(assert_return (invoke "as-select-mid") (i32.const 2))
+(assert_return (invoke "as-select-last") (i32.const 2))
+
+(assert_return (invoke "as-if-condition") (i32.const 1))
+
+(assert_return (invoke "as-br_if-first") (i64.const 0x164))
+(assert_return (invoke "as-br_if-last") (i32.const 2))
+
+(assert_return (invoke "as-br_table-first") (f32.const 0xf32))
+(assert_return (invoke "as-br_table-last") (i32.const 2))
+
+(assert_return (invoke "as-store-first"))
+(assert_return (invoke "as-store-last"))
+
+(assert_return (invoke "as-memory.grow-value") (i32.const 1))
+(assert_return (invoke "as-return-value") (i32.const 1))
+(assert_return (invoke "as-drop-operand"))
+(assert_return (invoke "as-br-value") (f32.const 1))
+(assert_return (invoke "as-set_local-value") (f64.const 1))
+(assert_return (invoke "as-load-operand") (i32.const 1))
 
 ;; Invalid syntax
 


### PR DESCRIPTION
 - Partial funcs(e.g. $over-i32-duplicate) without tests covered
 - Add tests for call/call_indirect as param of control constructs/instructions

@rossberg, PTAL. Thanks!