### PR TITLE
Use "Element Segment" terminology in js-api tests

### DIFF
--- a/test/harness/wasm-constants.js
+++ b/test/harness/wasm-constants.js
@@ -73,7 +73,7 @@ let kLocalNamesCode = 2;
 let kWasmFunctionTypeForm = 0x60;
 let kWasmAnyFunctionTypeForm = 0x70;
 
-let kResizableMaximumFlag = 1;
+let kHasMaximumFlag = 1;
 
 // Function declaration flags
 let kDeclFunctionName   = 0x01;

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -415,7 +415,6 @@ class WasmModuleBuilder {
       binary.emit_section(kMemorySectionCode, section => {
         section.emit_u8(1);  // one memory entry
         const has_max = wasm.memory.max !== undefined;
-        const is_shared = wasm.memory.shared !== undefined;
         section.emit_u8(has_max ? kHasMaximumFlag : 0);
         section.emit_u32v(wasm.memory.min);
         if (has_max) section.emit_u32v(wasm.memory.max);

--- a/test/harness/wasm-module-builder.js
+++ b/test/harness/wasm-module-builder.js
@@ -156,10 +156,10 @@ class WasmModuleBuilder {
     this.exports = [];
     this.globals = [];
     this.functions = [];
-    this.function_table = [];
-    this.function_table_length = 0;
-    this.function_table_inits = [];
-    this.segments = [];
+    this.table_length_min = 0;
+    this.table_length_max = undefined;
+    this.element_segments = [];
+    this.data_segments = [];
     this.explicit = [];
     this.num_imported_funcs = 0;
     this.num_imported_globals = 0;
@@ -256,21 +256,21 @@ class WasmModuleBuilder {
   }
 
   addDataSegment(addr, data, is_global = false) {
-    this.segments.push({addr: addr, data: data, is_global: is_global});
-    return this.segments.length - 1;
+    this.data_segments.push({addr: addr, data: data, is_global: is_global});
+    return this.data_segments.length - 1;
   }
 
   exportMemoryAs(name) {
     this.exports.push({name: name, kind: kExternalMemory, index: 0});
   }
 
-  addFunctionTableInit(base, is_global, array, is_import = false) {
-    this.function_table_inits.push({base: base, is_global: is_global,
+  addElementSegment(base, is_global, array, is_import = false) {
+    this.element_segments.push({base: base, is_global: is_global,
                                     array: array});
     if (!is_global) {
       var length = base + array.length;
-      if (length > this.function_table_length && !is_import) {
-        this.function_table_length = length;
+      if (length > this.table_length_min && !is_import) {
+        this.table_length_min = length;
       }
     }
     return this;
@@ -281,18 +281,18 @@ class WasmModuleBuilder {
       if (typeof n != 'number')
         throw new Error('invalid table (entries have to be numbers): ' + array);
     }
-    return this.addFunctionTableInit(this.function_table.length, false, array);
+    return this.addElementSegment(this.table_length_min, false, array);
   }
 
-  setFunctionTableBounds(min, max) {
-    this.function_table_length_min = min;
-    this.function_table_length_max = max;
+  setTableBounds(min, max) {
+    this.table_length_min = min;
+    this.table_length_max = max;
     return this;
   }
 
-  setFunctionTableLength(length) {
-    this.function_table_length_min = length;
-    this.function_table_length_max = length;
+  setTableLength(length) {
+    this.table_length_min = length;
+    this.table_length_max = length;
     return this;
   }
 
@@ -370,16 +370,16 @@ class WasmModuleBuilder {
       });
     }
 
-    // Add function_table.
-    if (wasm.function_table_length_min > 0) {
+    // Add table section
+    if (wasm.table_length_min > 0) {
       if (debug) print("emitting table @ " + binary.length);
       binary.emit_section(kTableSectionCode, section => {
         section.emit_u8(1);  // one table entry
         section.emit_u8(kWasmAnyFunctionTypeForm);
-        const max = wasm.function_table_length_max;
+        const max = wasm.table_length_max;
         const has_max = max !== undefined;
         section.emit_u8(has_max ? kResizableMaximumFlag : 0);
-        section.emit_u32v(wasm.function_table_length_min);
+        section.emit_u32v(wasm.table_length_min);
         if (has_max) section.emit_u32v(max);
       });
     }
@@ -475,11 +475,11 @@ class WasmModuleBuilder {
       });
     }
 
-    // Add table elements.
-    if (wasm.function_table_inits.length > 0) {
-      if (debug) print("emitting table @ " + binary.length);
+    // Add element segments
+    if (wasm.element_segments.length > 0) {
+      if (debug) print("emitting element segments @ " + binary.length);
       binary.emit_section(kElementSectionCode, section => {
-        var inits = wasm.function_table_inits;
+        var inits = wasm.element_segments;
         section.emit_u32v(inits.length);
 
         for (let init of inits) {
@@ -540,11 +540,11 @@ class WasmModuleBuilder {
     }
 
     // Add data segments.
-    if (wasm.segments.length > 0) {
+    if (wasm.data_segments.length > 0) {
       if (debug) print("emitting data segments @ " + binary.length);
       binary.emit_section(kDataSectionCode, section => {
-        section.emit_u32v(wasm.segments.length);
-        for (let seg of wasm.segments) {
+        section.emit_u32v(wasm.data_segments.length);
+        for (let seg of wasm.data_segments) {
           section.emit_u8(0);  // linear memory index 0
           if (seg.is_global) {
             // initializer is a global variable

--- a/test/js-api/jsapi.js
+++ b/test/js-api/jsapi.js
@@ -66,7 +66,7 @@ const complexExportingModuleBinary = (() => {
     builder.addMemory(1, 1, /* exported */ false);
     builder.exportMemoryAs('b');
 
-    builder.setFunctionTableLength(1);
+    builder.setTableLength(1);
     builder.addExportOfKind('c', kExternalTable, 0);
 
     // Default init for global values is 0. Keep that.
@@ -1111,7 +1111,6 @@ const complexTableReExportingModuleBinary = (() => {
             46
         ]).index;
 
-    builder.setFunctionTableLength(3);
     builder.appendToTable([fIndex, gIndex, hIndex]);
     builder.addExportOfKind('tab', kExternalTable, 0);
 

--- a/test/js-api/limits.js
+++ b/test/js-api/limits.js
@@ -298,18 +298,18 @@ testLimit("function returns", 0, kJSEmbeddingMaxFunctionReturns, (builder, count
     });
 
 testLimit("initial table size", 1, kJSEmbeddingMaxTableSize, (builder, count) => {
-        builder.setFunctionTableBounds(count, undefined);
+        builder.setTableBounds(count, undefined);
     });
 
 testLimit("maximum table size", 1, kJSEmbeddingMaxTableSize, (builder, count) => {
-        builder.setFunctionTableBounds(1, count);
+        builder.setTableBounds(1, count);
     });
 
 testLimit("element segments", 1, kJSEmbeddingMaxElementSegments, (builder, count) => {
-        builder.setFunctionTableBounds(1, 1);
+        builder.setTableBounds(1, 1);
         let array = [];
         for (let i = 0; i < count; i++) {
-            builder.addFunctionTableInit(0, false, array, false);
+            builder.addElementSegment(0, false, array, false);
         }
     });
 


### PR DESCRIPTION
This matches the nomenclature of the spec.

Also:

* Remove the `function_table` array from `wasm-module-builder.js` which
  is not used.
* The `appendToTable` function should reference
  `function_table_length` instead of `function_table.length`.