### PR TITLE
[core test] Reject "long" LEB128 reserved bytes

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -287,6 +287,80 @@
   "zero flag expected"
 )
 
+;; call_indirect reserved byte should not be a "long" LEB128 zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"      ;; Type section
+    "\03\02\01\00"            ;; Function section
+    "\04\04\01\70\00\00"      ;; Table section
+    "\0a\0a\01"               ;; Code section
+
+    ;; function 0
+    "\07\00"
+    "\41\00"                   ;; i32.const 0
+    "\11\00"                   ;; call_indirect (type 0)
+    "\80\00"                   ;; call_indirect reserved byte
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; Same as above for 3, 4, and 5-byte zero encodings.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"      ;; Type section
+    "\03\02\01\00"            ;; Function section
+    "\04\04\01\70\00\00"      ;; Table section
+    "\0a\0b\01"               ;; Code section
+
+    ;; function 0
+    "\08\00"
+    "\41\00"                   ;; i32.const 0
+    "\11\00"                   ;; call_indirect (type 0)
+    "\80\80\00"                ;; call_indirect reserved byte
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"      ;; Type section
+    "\03\02\01\00"            ;; Function section
+    "\04\04\01\70\00\00"      ;; Table section
+    "\0a\0c\01"               ;; Code section
+
+    ;; function 0
+    "\09\00"
+    "\41\00"                   ;; i32.const 0
+    "\11\00"                   ;; call_indirect (type 0)
+    "\80\80\80\00"             ;; call_indirect reserved byte
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"      ;; Type section
+    "\03\02\01\00"            ;; Function section
+    "\04\04\01\70\00\00"      ;; Table section
+    "\0a\0d\01"               ;; Code section
+
+    ;; function 0
+    "\0a\00"
+    "\41\00"                   ;; i32.const 0
+    "\11\00"                   ;; call_indirect (type 0)
+    "\80\80\80\80\00"          ;; call_indirect reserved byte
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
 ;; memory.grow reserved byte equal to zero.
 (assert_malformed
   (module binary
@@ -307,6 +381,84 @@
   "zero flag expected"
 )
 
+;; memory.grow reserved byte should not be a "long" LEB128 zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0a\01"                ;; Code section
+
+    ;; function 0
+    "\08\00"
+    "\41\00"                   ;; i32.const 0
+    "\40"                      ;; memory.grow
+    "\80\00"                   ;; memory.grow reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; Same as above for 3, 4, and 5-byte zero encodings.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0b\01"                ;; Code section
+
+    ;; function 0
+    "\09\00"
+    "\41\00"                   ;; i32.const 0
+    "\40"                      ;; memory.grow
+    "\80\80\00"                ;; memory.grow reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0c\01"                ;; Code section
+
+    ;; function 0
+    "\0a\00"
+    "\41\00"                   ;; i32.const 0
+    "\40"                      ;; memory.grow
+    "\80\80\80\00"             ;; memory.grow reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0d\01"                ;; Code section
+
+    ;; function 0
+    "\0b\00"
+    "\41\00"                   ;; i32.const 0
+    "\40"                      ;; memory.grow
+    "\80\80\80\80\00"          ;; memory.grow reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
 ;; memory.size reserved byte equal to zero.
 (assert_malformed
   (module binary
@@ -320,6 +472,80 @@
     "\05\00"
     "\3f"                      ;; memory.size
     "\01"                      ;; memory.size reserved byte is not equal to zero!
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; memory.size reserved byte should not be a "long" LEB128 zero.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\08\01"                ;; Code section
+
+    ;; function 0
+    "\06\00"
+    "\3f"                      ;; memory.size
+    "\80\00"                   ;; memory.size reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+;; Same as above for 3, 4, and 5-byte zero encodings.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\09\01"                ;; Code section
+
+    ;; function 0
+    "\07\00"
+    "\3f"                      ;; memory.size
+    "\80\80\00"                ;; memory.size reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0a\01"                ;; Code section
+
+    ;; function 0
+    "\08\00"
+    "\3f"                      ;; memory.size
+    "\80\80\80\00"             ;; memory.size reserved byte
+    "\1a"                      ;; drop
+    "\0b"                      ;; end
+  )
+  "zero flag expected"
+)
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section
+    "\03\02\01\00"             ;; Function section
+    "\05\03\01\00\00"          ;; Memory section
+    "\0a\0b\01"                ;; Code section
+
+    ;; function 0
+    "\09\00"
+    "\3f"                      ;; memory.size
+    "\80\80\80\80\00"          ;; memory.size reserved byte
     "\1a"                      ;; drop
     "\0b"                      ;; end
   )


### PR DESCRIPTION
`call_indirect`, `memory.grow`, and `memory.size` all require the
memory/table index to be a single zero byte.

These tests ensure that the index is not being parsed as a LEB128, which
can encode zero as two or more bytes: `0x80 0x00`, `0x80 0x80 0x00`,
etc.