### PR TITLE
Remove link in test's README and update WPT link

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -5,9 +5,6 @@ directories:
 * [`js-api/`](js-api/), tests for the JavaScript API.
 * [`html/`](html/), tests for the JavaScript API in a DOM environment.
 
-A [landing page](out/index.html) contains a condensed version made of all
-these tests, converted to HTML.
-
 A list of to-do's can be found [here](Todo.md).
 
 ## Multi-stage testing
@@ -20,7 +17,7 @@ runnning all of them in HTML.
 
 The HTML tests are just [Web Platform Tests](http://testthewebforward.org)
 using the
-[testharness.js](http://testthewebforward.org/docs/testharness-library.html)
+[testharness.js](https://web-platform-tests.org/writing-tests/testharness-api.html)
 library.
 
 Each wast test gets its equivalent JS test, and each JS test (including wast


### PR DESCRIPTION
The directories built by the build.py script aren't checked in in the
repository, so don't try to link to them.