### PR TITLE
Stop trying to build js-api tests.

### DIFF
--- a/test/build.py
+++ b/test/build.py
@@ -13,7 +13,6 @@ INTERPRETER_DIR = os.path.join(SCRIPT_DIR, '..', 'interpreter')
 WASM_EXEC = os.path.join(INTERPRETER_DIR, 'wasm')
 
 WAST_TESTS_DIR = os.path.join(SCRIPT_DIR, 'core')
-JS_TESTS_DIR = os.path.join(SCRIPT_DIR, 'js-api')
 HARNESS_DIR = os.path.join(SCRIPT_DIR, 'harness')
 
 HARNESS_FILES = ['testharness.js', 'testharnessreport.js', 'testharness.css']
@@ -80,14 +79,6 @@ def convert_wast_to_js(out_js_dir):
 def build_js(out_js_dir, include_harness=False):
     print('Building JS...')
     convert_wast_to_js(out_js_dir)
-
-    print('Copying JS tests to the JS out dir...')
-    for path in os.listdir(JS_TESTS_DIR):
-        abspath = os.path.join(JS_TESTS_DIR, path)
-        if os.path.isdir(abspath):
-            shutil.copytree(abspath, os.path.join(out_js_dir, path))
-        else:
-            shutil.copy(abspath, out_js_dir)
 
     harness_dir = os.path.join(out_js_dir, 'harness')
     ensure_empty_dir(harness_dir)


### PR DESCRIPTION
The build tool can't handle the current js-api tests, and would take a
significant rewrite to do so. In particular, it would need to stop handling the
helper .js files as tests, and ensure they are included when running the tests
that need them.

However, all of this is already achieved without a build step in the wpt context
as well as in the integration into SpiderMonkey's jstests harness. This
suggests that trying to handle these tests in the build script is not
necessary.