### PR TITLE
[test] Remove duplicated tests

### DIFF
--- a/test/core/br.wast
+++ b/test/core/br.wast
@@ -442,31 +442,6 @@
   "type mismatch"
 )
 
-(assert_invalid
-  (module
-    (func $type-operand-missing-in-if
-      (block
-        (i32.const 0) (i32.const 0)
-        (if (result i32) (then (br 0)))
-      )
-      (i32.eqz) (drop)
-    )
-  )
-  "type mismatch"
-)
-(assert_invalid
-  (module
-    (func $type-operand-missing-in-else
-      (block
-        (i32.const 0) (i32.const 0)
-        (if (result i32) (then (i32.const 0)) (else (br 0)))
-      )
-      (i32.eqz) (drop)
-    )
-  )
-  "type mismatch"
-)
-
 
 (assert_invalid
   (module (func $unbound-label (br 1)))

--- a/test/core/br.wast
+++ b/test/core/br.wast
@@ -444,25 +444,6 @@
 
 (assert_invalid
   (module
-    (func $type-operand-missing
-      (block (result i32) (br 0))
-      (i32.eqz) (drop)
-    )
-  )
-  "type mismatch"
-)
-(assert_invalid
-  (module
-    (func $type-operand-missing-in-block
-      (i32.const 0)
-      (block (result i32) (br 0))
-      (i32.eqz) (drop)
-    )
-  )
-  "type mismatch"
-)
-(assert_invalid
-  (module
     (func $type-operand-missing-in-if
       (block
         (i32.const 0) (i32.const 0)
@@ -486,7 +467,6 @@
   "type mismatch"
 )
 
-;; TODO: Compare above "*operand-missing*" tests to others, identify and remove duplicates.
 
 (assert_invalid
   (module (func $unbound-label (br 1)))

--- a/test/core/i32.wast
+++ b/test/core/i32.wast
@@ -423,7 +423,7 @@
 
 (assert_invalid
   (module
-    (func $type-unary-operand-missing
+    (func $type-unary-operand-empty
       (i32.eqz) (drop)
     )
   )
@@ -431,7 +431,7 @@
 )
 (assert_invalid
   (module
-    (func $type-unary-operand-missing-in-block
+    (func $type-unary-operand-empty-in-block
       (i32.const 0)
       (block (i32.eqz) (drop))
     )
@@ -440,7 +440,7 @@
 )
 (assert_invalid
   (module
-    (func $type-unary-operand-missing-in-loop
+    (func $type-unary-operand-empty-in-loop
       (i32.const 0)
       (loop (i32.eqz) (drop))
     )
@@ -449,7 +449,7 @@
 )
 (assert_invalid
   (module
-    (func $type-unary-operand-missing-in-if
+    (func $type-unary-operand-empty-in-if
       (i32.const 0) (i32.const 0)
       (if (then (i32.eqz) (drop)))
     )
@@ -458,7 +458,7 @@
 )
 (assert_invalid
   (module
-    (func $type-unary-operand-missing-in-else
+    (func $type-unary-operand-empty-in-else
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (i32.eqz))) (drop)
     )
@@ -468,7 +468,7 @@
 
 (assert_invalid
   (module
-    (func $type-binary-1st-operand-missing
+    (func $type-binary-1st-operand-empty
       (i32.add) (drop)
     )
   )
@@ -476,7 +476,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-2nd-operand-missing
+    (func $type-binary-2nd-operand-empty
       (i32.const 0) (i32.add) (drop)
     )
   )
@@ -484,7 +484,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-1st-operand-missing-in-block
+    (func $type-binary-1st-operand-empty-in-block
       (i32.const 0) (i32.const 0)
       (block (i32.add) (drop))
     )
@@ -493,7 +493,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-2nd-operand-missing-in-block
+    (func $type-binary-2nd-operand-empty-in-block
       (i32.const 0)
       (block (i32.const 0) (i32.add) (drop))
     )
@@ -502,7 +502,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-1st-operand-missing-in-loop
+    (func $type-binary-1st-operand-empty-in-loop
       (i32.const 0) (i32.const 0)
       (loop (i32.add) (drop))
     )
@@ -511,7 +511,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-2nd-operand-missing-in-loop
+    (func $type-binary-2nd-operand-empty-in-loop
       (i32.const 0)
       (loop (i32.const 0) (i32.add) (drop))
     )
@@ -520,7 +520,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-1st-operand-missing-in-if
+    (func $type-binary-1st-operand-empty-in-if
       (i32.const 0) (i32.const 0) (i32.const 0)
       (if (i32.add) (then (drop)))
     )
@@ -529,7 +529,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-2nd-operand-missing-in-if
+    (func $type-binary-2nd-operand-empty-in-if
       (i32.const 0) (i32.const 0)
       (if (i32.const 0) (then (i32.add)) (else (drop)))
     )
@@ -538,7 +538,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-1st-operand-missing-in-else
+    (func $type-binary-1st-operand-empty-in-else
       (i32.const 0) (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (i32.add) (i32.const 0)))
       (drop) (drop)
@@ -548,7 +548,7 @@
 )
 (assert_invalid
   (module
-    (func $type-binary-2nd-operand-missing-in-else
+    (func $type-binary-2nd-operand-empty-in-else
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (i32.add)))
       (drop)

--- a/test/core/if.wast
+++ b/test/core/if.wast
@@ -724,7 +724,7 @@
 
 (assert_invalid
   (module
-    (func $type-operand-missing
+    (func $type-condition-empty
       (if (then))
     )
   )
@@ -732,7 +732,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-block
+    (func $type-condition-empty-in-block
       (i32.const 0)
       (block (if (then)))
     )
@@ -741,7 +741,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-loop
+    (func $type-condition-empty-in-loop
       (i32.const 0)
       (loop (if (then)))
     )
@@ -750,7 +750,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-if
+    (func $type-condition-empty-in-then
       (i32.const 0) (i32.const 0)
       (if (then (if (then))))
     )
@@ -759,7 +759,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-else
+    (func $type-condition-empty-in-else
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (if (then)) (i32.const 0)))
       (drop)

--- a/test/core/if.wast
+++ b/test/core/if.wast
@@ -768,8 +768,6 @@
   "type mismatch"
 )
 
-;; TODO: Compare above "*operand-missing*" tests to others, identify and remove duplicates.
-
 
 (assert_malformed
   (module quote "(func if end $l)")

--- a/test/core/return.wast
+++ b/test/core/return.wast
@@ -322,14 +322,6 @@
 
 (assert_invalid
   (module
-    (func $type-operand-missing (result i32)
-      (return)
-    )
-  )
-  "type mismatch"
-)
-(assert_invalid
-  (module
     (func $type-operand-missing-in-block (result i32)
       (i32.const 0)
       (block (return))
@@ -365,4 +357,3 @@
   "type mismatch"
 )
 
-;; TODO: Compare above "*operand-missing*" tests to others, identify and remove duplicates.

--- a/test/core/return.wast
+++ b/test/core/return.wast
@@ -312,17 +312,8 @@
   "type mismatch"
 )
 (assert_invalid
-  (module (func $type-value-void-vs-num (result f64) (return (nop))))
-  "type mismatch"
-)
-(assert_invalid
-  (module (func $type-value-num-vs-num (result f64) (return (i64.const 1))))
-  "type mismatch"
-)
-
-(assert_invalid
   (module
-    (func $type-operand-missing-in-block (result i32)
+    (func $type-value-empty-vs-num-in-block (result f64)
       (i32.const 0)
       (block (return))
     )
@@ -331,7 +322,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-loop (result i32)
+    (func $type-value-empty-vs-num-in-loop (result f64)
       (i32.const 0)
       (loop (return))
     )
@@ -340,7 +331,7 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-if (result i32)
+    (func $type-value-empty-vs-num-in-then (result f64)
       (i32.const 0) (i32.const 0)
       (if (then (return)))
     )
@@ -349,11 +340,19 @@
 )
 (assert_invalid
   (module
-    (func $type-operand-missing-in-else (result i32)
+    (func $type-value-empty-vs-num-in-else (result i32)
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (return))) (drop)
     )
   )
+  "type mismatch"
+)
+(assert_invalid
+  (module (func $type-value-void-vs-num (result f64) (return (nop))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func $type-value-num-vs-num (result f64) (return (i64.const 1))))
   "type mismatch"
 )
 


### PR DESCRIPTION
 - br.wast: "$type-operand-missing" and "$type-operand-missing-in-block"
   are similar to "$type-arg-empty-vs-num"
 - return.wast "$type-operand-missing" is similar to "$type-value-empty-vs-num"
 - if.wast: no duplicates