### PR TITLE
wasm-module-builder: use a loop instead of spreading

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -74,7 +74,9 @@ class Binary extends Array {
     // Emit section length.
     this.emit_u32v(section.length);
     // Copy the temporary buffer.
-    this.push(...section);
+    for (let i = 0, len = section.length; i < len; i++) {
+      this.push(section[i]);
+    }
   }
 }
 


### PR DESCRIPTION
Spreading many parameters tends to blow up the stack, whereas a loop is safer.

I ran in this issue with the Wasm limits test.

cc @Ms2ger 