### PR TITLE
[js-api] use DOMString

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -446,14 +446,14 @@ enum ImportExportKind {
 };
 
 dictionary ModuleExportDescriptor {
-  required DOMString name;
+  required USVString name;
   required ImportExportKind kind;
   // Note: Other fields such as signature may be added in the future.
 };
 
 dictionary ModuleImportDescriptor {
-  required DOMString module;
-  required DOMString name;
+  required USVString module;
+  required USVString name;
   required ImportExportKind kind;
 };
 
@@ -732,7 +732,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
 <pre class="idl">
 dictionary GlobalDescriptor {
-  required DOMString value;
+  required USVString value;
   boolean mutable = false;
 };
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -446,14 +446,14 @@ enum ImportExportKind {
 };
 
 dictionary ModuleExportDescriptor {
-  required USVString name;
+  required DOMString name;
   required ImportExportKind kind;
   // Note: Other fields such as signature may be added in the future.
 };
 
 dictionary ModuleImportDescriptor {
-  required USVString module;
-  required USVString name;
+  required DOMString module;
+  required DOMString name;
   required ImportExportKind kind;
 };
 
@@ -732,7 +732,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
 <pre class="idl">
 dictionary GlobalDescriptor {
-  required USVString value;
+  required DOMString value;
   boolean mutable = false;
 };
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -461,7 +461,7 @@ dictionary ModuleImportDescriptor {
 interface Module {
   static sequence&lt;ModuleExportDescriptor> exports(Module moduleObject);
   static sequence&lt;ModuleImportDescriptor> imports(Module moduleObject);
-  static sequence&lt;ArrayBuffer> customSections(Module moduleObject, USVString sectionName);
+  static sequence&lt;ArrayBuffer> customSections(Module moduleObject, DOMString sectionName);
 };
 </pre>
 

--- a/test/js-api/module/customSections.any.js
+++ b/test/js-api/module/customSections.any.js
@@ -156,9 +156,7 @@ test(() => {
   assert_sections(WebAssembly.Module.customSections(module, "na\uFFFDme"), [
     bytes,
   ]);
-  assert_sections(WebAssembly.Module.customSections(module, "na\uDC01me"), [
-    bytes,
-  ]);
+  assert_sections(WebAssembly.Module.customSections(module, "na\uDC01me"), []);
 }, "Custom sections with U+FFFD");
 
 test(() => {


### PR DESCRIPTION
Switching from USVString to DOMString will allow the string to contain non normalized surrogates.

Currently, JavaScript engines already use a DOMString as argument.

Fixes #915 

cc @Ms2ger @littledan 