### PR TITLE
Update katex to v0.10.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "document/core/util/katex"]
 	path = document/core/util/katex
-	url = https://github.com/Khan/KaTeX.git
+	url = https://github.com/KaTeX/KaTeX.git

--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -147,6 +147,7 @@ bikeshed:
 	mkdir -p $(BUILDDIR)/bikeshed_mathjax/
 	bikeshed spec index.bs $(BUILDDIR)/bikeshed_mathjax/index.html
 	mkdir -p $(BUILDDIR)/html/bikeshed/
+	(cd util/katex/ && npm install --only=prod)
 	python util/mathjax2katex.py $(BUILDDIR)/bikeshed_mathjax/index.html \
 		>$(BUILDDIR)/html/bikeshed/index.html
 	mkdir -p $(BUILDDIR)/html/bikeshed/katex/dist/

--- a/document/core/util/katex_fix.patch
+++ b/document/core/util/katex_fix.patch
@@ -1,7 +1,3 @@
-113c113
-< .katex-display {
----
-> div > .katex-display {
 123c123,126
 <   font: normal 1.21em KaTeX_Main, Times New Roman, serif;
 ---
@@ -9,21 +5,27 @@
 >   font-weight: normal;
 >   font-size: 1.21em;
 >   font-family: KaTeX_Main, Times New Roman, serif;
-127d129
+126d128
 <   text-rendering: auto;
-133c135
-<   display: inline-block;
+989c991
+< .katex-display {
 ---
-> /*  display: inline-block; */
-1060,1065d1061
-< .katex svg path {
-<   fill: currentColor;
-< }
-< .katex svg line {
-<   stroke: currentColor;
-< }
-1142a1139,1152
-> }
+> div > .katex-display {
+994c996
+< .katex-display > .katex {
+---
+> div > .katex-display > .katex {
+999c1001
+< .katex-display > .katex > .katex-html {
+---
+> div > .katex-display > .katex > .katex-html {
+1003c1005
+< .katex-display > .katex > .katex-html > .tag {
+---
+> div > .katex-display > .katex > .katex-html > .tag {
+1007c1009,1022
+< 
+---
 > /* Force borders on tables */
 > table {
 >   border-collapse: collapse;
@@ -37,3 +39,4 @@
 > }
 > .codepre {
 >   white-space: pre;
+> }

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -11,6 +11,8 @@ import threading
 
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+# Update this to invalidate the cache; e.g. when updating katex.
+CACHE_VERSION = 2
 
 
 def FindMatching(data, prefix):
@@ -67,7 +69,7 @@ def ReplaceMath(cache, data):
   data = data.replace('’', '\\text{’}')
   data = data.replace('‘', '\\text{‘}')
   data = data.replace('\\hfill', '')
-  data = data.replace('\\mbox', '\\mathrel')
+  data = data.replace('\\mbox', '\\text')
   data = data.replace('\\begin{split}', '\\begin{aligned}')
   data = data.replace('\\end{split}', '\\end{aligned}')
   data = data.replace('&amp;', '&')
@@ -121,13 +123,6 @@ def ReplaceMath(cache, data):
   # Fix stray spans that come out of katex.
   ret = re.sub('[<]span class="vlist" style="height:[0-9.]+em;"[>]',
                '<span class="vlist">', ret)
-  # Drop bad italic font adjustment.
-  # https://github.com/WebAssembly/spec/issues/669
-  # https://github.com/Khan/KaTeX/issues/1259
-  ret = re.sub(
-      'mathit" style="margin-right:0.[0-9]+em', 'mathit" style="', ret)
-  ret = re.sub(
-      'mainit" style="margin-right:0.[0-9]+em', 'mathit" style="', ret)
   assert HasBalancedTags(ret)
 
   cache[data] = ret
@@ -152,7 +147,7 @@ def Main():
     return 'x' * len(match.group())
 
   data = open(sys.argv[1]).read()
-  cache = shelve.open(sys.argv[1] + '.cache')
+  cache = shelve.open('%s.%d.cache' % (sys.argv[1], CACHE_VERSION))
   # Drop index + search links.
   data = data.replace(
       '<link href="genindex.html" rel="index" title="Index">', '')


### PR DESCRIPTION
This includes a fix for italic fonts.

Running katex from the commandline has a dependency, so `npm install`
must be run.

See issue #669.