### PR TITLE
[test] Add more tests for operand missing -Part2

### DIFF
--- a/test/core/br.wast
+++ b/test/core/br.wast
@@ -442,6 +442,155 @@
   "type mismatch"
 )
 
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-br
+      (i32.const 0)
+      (block (result i32) (br 0 (br 0))) (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-br_if
+      (i32.const 0)
+      (block (result i32) (br_if 0 (br 0) (i32.const 1))) (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-br_table
+      (i32.const 0)
+      (block (result i32) (br_table 0 (br 0))) (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-return
+      (block (result i32)
+        (return (br 0))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-select
+      (block (result i32)
+        (select (br 0) (i32.const 1) (i32.const 2))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-call
+      (block (result i32)
+        (call 1 (br 0))
+      )
+      (i32.eqz) (drop)
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-arg-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (br 0) (i32.const 0)
+        )
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-local.set
+      (local i32)
+      (block (result i32)
+        (local.set 0 (br 0)) (local.get 0)
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-arg-empty-in-local.tee
+      (local i32)
+      (block (result i32)
+        (local.tee 0 (br 0))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-arg-empty-in-global.set
+      (block (result i32)
+        (global.set $x (br 0)) (global.get $x)
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-arg-empty-in-memory.grow
+      (block (result i32)
+        (memory.grow (br 0))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-arg-empty-in-load
+      (block (result i32)
+        (i32.load (br 0))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-arg-empty-in-store
+      (block (result i32)
+        (i32.store (br 0) (i32.const 0))
+      )
+      (i32.eqz) (drop)
+    )
+  )
+  "type mismatch"
+)
 
 (assert_invalid
   (module (func $unbound-label (br 1)))

--- a/test/core/i32.wast
+++ b/test/core/i32.wast
@@ -465,6 +465,128 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-br
+      (i32.const 0)
+      (block (br 0 (i32.eqz)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-br_if
+      (i32.const 0)
+      (block (br_if 0 (i32.eqz) (i32.const 1)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-br_table
+      (i32.const 0)
+      (block (br_table 0 (i32.eqz)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-return
+      (return (i32.eqz)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-select
+      (select (i32.eqz) (i32.const 1) (i32.const 2)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-call
+      (call 1 (i32.eqz)) (drop)
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-unary-operand-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (i32.eqz) (i32.const 0)
+        )
+        (drop)
+      )
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-local.set
+      (local i32)
+      (local.set 0 (i32.eqz)) (local.get 0) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-unary-operand-empty-in-local.tee
+      (local i32)
+      (local.tee 0 (i32.eqz)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-unary-operand-empty-in-global.set
+      (global.set $x (i32.eqz)) (global.get $x) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-unary-operand-empty-in-memory.grow
+      (memory.grow (i32.eqz)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-unary-operand-empty-in-load
+      (i32.load (i32.eqz)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-unary-operand-empty-in-store
+      (i32.store (i32.eqz) (i32.const 1))
+    )
+  )
+  "type mismatch"
+)
 
 (assert_invalid
   (module
@@ -552,6 +674,250 @@
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (i32.add)))
       (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-br
+      (i32.const 0) (i32.const 0)
+      (block (br 0 (i32.add)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-br
+      (i32.const 0)
+      (block (br 0 (i32.const 0) (i32.add)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-br_if
+      (i32.const 0) (i32.const 0)
+      (block (br_if 0 (i32.add) (i32.const 1)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-br_if
+      (i32.const 0)
+      (block (br_if 0 (i32.const 0) (i32.add) (i32.const 1)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-br_table
+      (i32.const 0) (i32.const 0)
+      (block (br_table 0 (i32.add)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-br_table
+      (i32.const 0)
+      (block (br_table 0 (i32.const 0) (i32.add)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-return
+      (return (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-return
+      (return (i32.const 0) (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-select
+      (select (i32.add) (i32.const 1) (i32.const 2)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-select
+      (select (i32.const 0) (i32.add) (i32.const 1) (i32.const 2)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-call
+      (call 1 (i32.add)) (drop)
+    )
+    (func (param i32 i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-call
+      (call 1 (i32.const 0) (i32.add)) (drop)
+    )
+    (func (param i32 i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-binary-1st-operand-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (i32.add) (i32.const 0)
+        )
+        (drop)
+      )
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-binary-2nd-operand-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (i32.const 0) (i32.add) (i32.const 0)
+        )
+        (drop)
+      )
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-local.set
+      (local i32)
+      (local.set 0 (i32.add)) (local.get 0) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-local.set
+      (local i32)
+      (local.set 0 (i32.const 0) (i32.add)) (local.get 0) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-1st-operand-empty-in-local.tee
+      (local i32)
+      (local.tee 0 (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-binary-2nd-operand-empty-in-local.tee
+      (local i32)
+      (local.tee 0 (i32.const 0) (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-binary-1st-operand-empty-in-global.set
+      (global.set $x (i32.add)) (global.get $x) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-binary-2nd-operand-empty-in-global.set
+      (global.set $x (i32.const 0) (i32.add)) (global.get $x) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-binary-1st-operand-empty-in-memory.grow
+      (memory.grow (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-binary-2nd-operand-empty-in-memory.grow
+      (memory.grow (i32.const 0) (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-binary-1st-operand-empty-in-load
+      (i32.load (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-binary-2nd-operand-empty-in-load
+      (i32.load (i32.const 0) (i32.add)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-binary-1st-operand-empty-in-store
+      (i32.store (i32.add) (i32.const 1))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-binary-2nd-operand-empty-in-store
+      (i32.store (i32.const 1) (i32.add) (i32.const 0))
     )
   )
   "type mismatch"

--- a/test/core/if.wast
+++ b/test/core/if.wast
@@ -767,6 +767,128 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-br
+      (i32.const 0)
+      (block (br 0 (if(then))) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-br_if
+      (i32.const 0)
+      (block (br_if 0 (if(then)) (i32.const 1)) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-br_table
+      (i32.const 0)
+      (block (br_table 0 (if(then))) (drop))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-return
+      (return (if(then))) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-select
+      (select (if(then)) (i32.const 1) (i32.const 2)) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-call
+      (call 1 (if(then))) (drop)
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-condition-empty-in-call_indirect
+      (block (result i32)
+        (call_indirect (type $sig)
+          (if(then)) (i32.const 0)
+        )
+        (drop)
+      )
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-local.set
+      (local i32)
+      (local.set 0 (if(then))) (local.get 0) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-condition-empty-in-local.tee
+      (local i32)
+      (local.tee 0 (if(then))) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-condition-empty-in-global.set
+      (global.set $x (if(then))) (global.get $x) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-condition-empty-in-memory.grow
+      (memory.grow (if(then))) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-condition-empty-in-load
+      (i32.load (if(then))) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-condition-empty-in-store
+      (i32.store (if(then)) (i32.const 1))
+    )
+  )
+  "type mismatch"
+)
 
 
 (assert_malformed

--- a/test/core/return.wast
+++ b/test/core/return.wast
@@ -308,12 +308,12 @@
 (assert_return (invoke "as-memory.grow-size") (i32.const 40))
 
 (assert_invalid
-  (module (func $type-value-empty-vs-num (result f64) (return)))
+  (module (func $type-value-empty-vs-num (result i32) (return)))
   "type mismatch"
 )
 (assert_invalid
   (module
-    (func $type-value-empty-vs-num-in-block (result f64)
+    (func $type-value-empty-vs-num-in-block (result i32)
       (i32.const 0)
       (block (return))
     )
@@ -322,7 +322,7 @@
 )
 (assert_invalid
   (module
-    (func $type-value-empty-vs-num-in-loop (result f64)
+    (func $type-value-empty-vs-num-in-loop (result i32)
       (i32.const 0)
       (loop (return))
     )
@@ -331,7 +331,7 @@
 )
 (assert_invalid
   (module
-    (func $type-value-empty-vs-num-in-then (result f64)
+    (func $type-value-empty-vs-num-in-then (result i32)
       (i32.const 0) (i32.const 0)
       (if (then (return)))
     )
@@ -343,6 +343,127 @@
     (func $type-value-empty-vs-num-in-else (result i32)
       (i32.const 0) (i32.const 0)
       (if (result i32) (then (i32.const 0)) (else (return))) (drop)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-br (result i32)
+      (i32.const 0)
+      (block (br 0 (return)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-br_if (result i32)
+      (i32.const 0)
+      (block (br_if 0 (return) (i32.const 1)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-br_table (result i32)
+      (i32.const 0)
+      (block (br_table 0 (return)))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-return (result i32)
+      (return (return))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-select (result i32)
+      (select (return) (i32.const 1) (i32.const 2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-call (result i32)
+      (call 1 (return))
+    )
+    (func (param i32) (result i32) (local.get 0))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $f (param i32) (result i32) (local.get 0))
+    (type $sig (func (param i32) (result i32)))
+    (table funcref (elem $f))
+    (func $type-value-empty-vs-num-in-call_indirect (result i32)
+      (block (result i32)
+        (call_indirect (type $sig)
+          (return) (i32.const 0)
+        )
+      )
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-local.set (result i32)
+      (local i32)
+      (local.set 0 (return)) (local.get 0)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-value-empty-vs-num-in-local.tee (result i32)
+      (local i32)
+      (local.tee 0 (return))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (global $x (mut i32) (i32.const 0))
+    (func $type-value-empty-vs-num-in-global.set (result i32)
+      (global.set $x (return)) (global.get $x)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-value-empty-vs-num-in-memory.grow (result i32)
+      (memory.grow (return))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 0)
+    (func $type-value-empty-vs-num-in-load (result i32)
+      (i32.load (return))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (memory 1)
+    (func $type-value-empty-vs-num-in-store (result i32)
+      (i32.store (return) (i32.const 1))
     )
   )
   "type mismatch"


### PR DESCRIPTION
This is the second part to fix following task in typecheck.wast:
;; TODO(stack): more of the above