### PR TITLE
[test] update wasm-module-builder.js

### DIFF
--- a/test/js-api/instanceTestFactory.js
+++ b/test/js-api/instanceTestFactory.js
@@ -140,7 +140,7 @@ const instanceTestFactory = [
         .addBody([])
         .exportFunc();
 
-      builder.setFunctionTableLength(1);
+      builder.setTableBounds(1);
       builder.addExportOfKind("table", kExternalTable, 0);
 
       builder.addGlobal(kWasmI32, true)

--- a/test/js-api/instanceTestFactory.js
+++ b/test/js-api/instanceTestFactory.js
@@ -133,15 +133,11 @@ const instanceTestFactory = [
 
       builder
         .addFunction("fn", kSig_v_d)
-        .addBody([
-            kExprEnd
-        ])
+        .addBody([])
         .exportFunc();
       builder
         .addFunction("fn2", kSig_v_v)
-        .addBody([
-            kExprEnd
-        ])
+        .addBody([])
         .exportFunc();
 
       builder.setFunctionTableLength(1);
@@ -190,7 +186,6 @@ const instanceTestFactory = [
             kExprGetGlobal,
             index,
             kExprReturn,
-            kExprEnd,
         ])
         .exportFunc();
 

--- a/test/js-api/module/exports.any.js
+++ b/test/js-api/module/exports.any.js
@@ -92,15 +92,11 @@ test(() => {
 
   builder
     .addFunction("fn", kSig_v_v)
-    .addBody([
-        kExprEnd
-    ])
+    .addBody([])
     .exportFunc();
   builder
     .addFunction("fn2", kSig_v_v)
-    .addBody([
-        kExprEnd
-    ])
+    .addBody([])
     .exportFunc();
 
   builder.setFunctionTableLength(1);

--- a/test/js-api/module/exports.any.js
+++ b/test/js-api/module/exports.any.js
@@ -99,7 +99,7 @@ test(() => {
     .addBody([])
     .exportFunc();
 
-  builder.setFunctionTableLength(1);
+  builder.setTableBounds(1);
   builder.addExportOfKind("table", kExternalTable, 0);
 
   builder.addGlobal(kWasmI32, true)

--- a/test/js-api/table/get-set.any.js
+++ b/test/js-api/table/get-set.any.js
@@ -9,15 +9,11 @@ setup(() => {
 
   builder
     .addFunction("fn", kSig_v_d)
-    .addBody([
-        kExprEnd
-    ])
+    .addBody([])
     .exportFunc();
   builder
     .addFunction("fn2", kSig_v_v)
-    .addBody([
-        kExprEnd
-    ])
+    .addBody([])
     .exportFunc();
 
   const buffer = builder.toBuffer()

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -98,6 +98,12 @@ class WasmFunctionBuilder {
   }
 
   addBody(body) {
+    const bodyCopy = body.slice();
+    bodyCopy.push(kExprEnd);
+    return this.addBodyWithEnd(bodyCopy);
+  }
+
+  addBodyWithEnd(body) {
     this.body = body;
     return this;
   }
@@ -260,6 +266,11 @@ class WasmModuleBuilder {
   // TODO(ssauleau): legacy, remove this
   setFunctionTableLength(length) {
     return this.setTableBounds(length);
+  }
+
+  // TODO(ssauleau): legacy, remove this
+  setTableLength(min, max = undefined) {
+    return this.setTableBounds(min, max);
   }
 
   toArray(debug = false) {

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -263,16 +263,6 @@ class WasmModuleBuilder {
     return this;
   }
 
-  // TODO(ssauleau): legacy, remove this
-  setFunctionTableLength(length) {
-    return this.setTableBounds(length);
-  }
-
-  // TODO(ssauleau): legacy, remove this
-  setTableLength(min, max = undefined) {
-    return this.setTableBounds(min, max);
-  }
-
   toArray(debug = false) {
     let binary = new Binary;
     let wasm = this;


### PR DESCRIPTION
This is for consistency with other WebAssembly tests, in v8 or in wpt.
Edit: also removes legacy methods.

cc @binji @hammacher 