### PR TITLE
Normative: GlobalDescriptor shoud use DOMString

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -732,7 +732,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
 
 <pre class="idl">
 dictionary GlobalDescriptor {
-  required USVString value;
+  required DOMString value;
   boolean mutable = false;
 };
 


### PR DESCRIPTION
Following https://github.com/WebAssembly/spec/issues/915.

There's no reasons (I'm aware of) that the `value` property in the GlobalDescriptor use a `USVString` String. As for Module.customSection let's switch it to `DOMString`.

cc @Ms2ger 