### PR TITLE
[jsapi] Fix tests after wasm-module-builder.js update

### DIFF
--- a/test/js-api/module/customSections.any.js
+++ b/test/js-api/module/customSections.any.js
@@ -96,7 +96,7 @@ test(() => {
   });
 
   const builder = new WasmModuleBuilder();
-  builder.addExplicitSection(binary);
+  builder.addExplicitSection(binary.trunc_buffer());
   const buffer = builder.toBuffer()
   const module = new WebAssembly.Module(buffer);
 
@@ -126,7 +126,7 @@ test(() => {
   });
 
   const builder = new WasmModuleBuilder();
-  builder.addExplicitSection(binary);
+  builder.addExplicitSection(binary.trunc_buffer());
   const buffer = builder.toBuffer();
   const module = new WebAssembly.Module(buffer);
 
@@ -147,7 +147,7 @@ test(() => {
   });
 
   const builder = new WasmModuleBuilder();
-  builder.addExplicitSection(binary);
+  builder.addExplicitSection(binary.trunc_buffer());
   const buffer = builder.toBuffer();
   const module = new WebAssembly.Module(buffer);
 

--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -622,7 +622,7 @@ class WasmModuleBuilder {
     return this;
   }
 
-  toUint8Array(debug = false) {
+  toBuffer(debug = false) {
     let binary = new Binary;
     let wasm = this;
 
@@ -905,12 +905,8 @@ class WasmModuleBuilder {
     return binary.trunc_buffer();
   }
 
-  toBuffer(debug = false) {
-    return this.toUint8Array(debug).buffer;
-  }
-
   toArray(debug = false) {
-    return Array.from(this.toUint8Array(debug));
+    return Array.from(this.toBuffer(debug));
   }
 
   instantiate(ffi) {


### PR DESCRIPTION
Updating the wasm-module-builder.js broke the jsapi tests. I was under
the impression that travis would run them, but it seems like this is
not the case. Rolling the updated version to v8 failed then:
https://crrev.com/c/1516684

This fixes two things:
1) {toBuffer} returns a Uint8Array as before, not an ArrayBuffer,
2) {addExplicitSection} expects a byte sequence, hence pass the
   truncated buffer instead of the {Binary} object.