### PR TITLE
Reject the promise if reading the imports fails.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -414,6 +414,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. Let |promise| be [=a new promise=].
     1. Let |module| be |moduleObject|.\[[Module]].
     1. [=Read the imports=] of |module| with imports |importObject|, and let |imports| be the result.
+        If this operation throws an exception, catch it, [=reject=] |promise| with the exception, and return |promise|.
     1. [=Queue a task=] to perform the following steps:
         1.  [=Instantiate the core of a WebAssembly module=] |module| with |imports|, and let |instance| be the result.
             If this throws an exception, catch it, [=reject=] |promise| with the exception, and terminate these substeps.


### PR DESCRIPTION
I missed this in #988.