### PR TITLE
[test] Check for "unreachable" consistently

### DIFF
--- a/test/core/select.wast
+++ b/test/core/select.wast
@@ -205,10 +205,10 @@
 (assert_return (invoke "select_f64" (f64.const 2) (f64.const nan) (i32.const 0)) (f64.const nan))
 (assert_return (invoke "select_f64" (f64.const 2) (f64.const nan:0x20304) (i32.const 0)) (f64.const nan:0x20304))
 
-(assert_trap (invoke "select_trap_l" (i32.const 1)) "unreachable executed")
-(assert_trap (invoke "select_trap_l" (i32.const 0)) "unreachable executed")
-(assert_trap (invoke "select_trap_r" (i32.const 1)) "unreachable executed")
-(assert_trap (invoke "select_trap_r" (i32.const 0)) "unreachable executed")
+(assert_trap (invoke "select_trap_l" (i32.const 1)) "unreachable")
+(assert_trap (invoke "select_trap_l" (i32.const 0)) "unreachable")
+(assert_trap (invoke "select_trap_r" (i32.const 1)) "unreachable")
+(assert_trap (invoke "select_trap_r" (i32.const 0)) "unreachable")
 
 (assert_return (invoke "as-select-first" (i32.const 0)) (i32.const 1))
 (assert_return (invoke "as-select-first" (i32.const 1)) (i32.const 0))


### PR DESCRIPTION
The full error message generated by the interpreter is "unreachable executed", but all of the other tests check for just "unreachable".