### PR TITLE
[test] Add test when start function traps

### DIFF
--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -352,3 +352,37 @@
   "elements segment does not fit"
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
+
+;; Store is modified if the start function traps.
+(module $Ms
+  (type $t (func (result i32)))
+  (memory (export "memory") 1)
+  (table (export "table") 1 funcref)
+  (func (export "get memory[0]") (type $t)
+    (i32.load8_u (i32.const 0))
+  )
+  (func (export "get table[0]") (type $t)
+    (call_indirect (type $t) (i32.const 0))
+  )
+)
+(register "Ms" $Ms)
+
+(assert_trap
+  (module
+    (import "Ms" "memory" (memory 1))
+    (import "Ms" "table" (table 1 funcref))
+    (data (i32.const 0) "hello")
+    (elem (i32.const 0) $f)
+    (func $f (result i32)
+      (i32.const 0xdead)
+    )
+    (func $main
+      (unreachable)
+    )
+    (start $main)
+  )
+  "unreachable"
+)
+
+(assert_return (invoke $Ms "get memory[0]") (i32.const 104))  ;; 'h'
+(assert_return (invoke $Ms "get table[0]") (i32.const 0xdead))


### PR DESCRIPTION
The start function is invoked after the store has been modified. So if a
start function traps, all data and element segments will have been
copied into the memory and table respectively. This means that functions
can be invoked on this instance, even though the instance is not
available to the embedder directly.

See issue #993.