### PR TITLE
[spec] Work around Sphinx/Latex issue

### DIFF
--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -119,35 +119,35 @@
 
 .. |byte| mathdef:: \xref{syntax/values}{syntax-byte}{\X{byte}}
 
-.. |uX#1| mathdef:: {\X{u}#1}
-.. |sX#1| mathdef:: {\X{s}#1}
-.. |iX#1| mathdef:: {\X{i}#1}
-.. |fX#1| mathdef:: {\X{f}#1}
+.. |uX#1| mathdef:: {\X{u#1}}
+.. |sX#1| mathdef:: {\X{s#1}}
+.. |iX#1| mathdef:: {\X{i#1}}
+.. |fX#1| mathdef:: {\X{f#1}}
 
-.. |uN| mathdef:: \xref{syntax/values}{syntax-int}{\uX{N}}
-.. |uM| mathdef:: \xref{syntax/values}{syntax-int}{\uX{M}}
-.. |u1| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{1}}}
-.. |u8| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{8}}}
-.. |u16| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{16}}}
-.. |u32| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{32}}}
-.. |u64| mathdef:: \xref{syntax/values}{syntax-int}{\uX{\X{64}}}
+.. |uN| mathdef:: \xref{syntax/values}{syntax-int}{\X{u}N}
+.. |uM| mathdef:: \xref{syntax/values}{syntax-int}{\X{u}M}
+.. |u1| mathdef:: \xref{syntax/values}{syntax-int}{\X{u1}}
+.. |u8| mathdef:: \xref{syntax/values}{syntax-int}{\X{u8}}
+.. |u16| mathdef:: \xref{syntax/values}{syntax-int}{\X{u16}}
+.. |u32| mathdef:: \xref{syntax/values}{syntax-int}{\X{u32}}
+.. |u64| mathdef:: \xref{syntax/values}{syntax-int}{\X{u64}}
 
-.. |sN| mathdef:: \xref{syntax/values}{syntax-int}{\sX{N}}
-.. |s8| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{8}}}
-.. |s16| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{16}}}
-.. |s32| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{32}}}
-.. |s64| mathdef:: \xref{syntax/values}{syntax-int}{\sX{\X{64}}}
+.. |sN| mathdef:: \xref{syntax/values}{syntax-int}{\X{s}N}
+.. |s8| mathdef:: \xref{syntax/values}{syntax-int}{\X{s8}}
+.. |s16| mathdef:: \xref{syntax/values}{syntax-int}{\X{s16}}
+.. |s32| mathdef:: \xref{syntax/values}{syntax-int}{\X{s32}}
+.. |s64| mathdef:: \xref{syntax/values}{syntax-int}{\X{s64}}
 
-.. |iN| mathdef:: \xref{syntax/values}{syntax-int}{\iX{N}}
-.. |i8| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{8}}}
-.. |i16| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{16}}}
-.. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{32}}}
-.. |i64| mathdef:: \xref{syntax/values}{syntax-int}{\iX{\X{64}}}
+.. |iN| mathdef:: \xref{syntax/values}{syntax-int}{\X{i}N}
+.. |i8| mathdef:: \xref{syntax/values}{syntax-int}{\X{i8}}
+.. |i16| mathdef:: \xref{syntax/values}{syntax-int}{\X{i16}}
+.. |i32| mathdef:: \xref{syntax/values}{syntax-int}{\X{i32}}
+.. |i64| mathdef:: \xref{syntax/values}{syntax-int}{\X{i64}}
 
-.. |fN| mathdef:: \xref{syntax/values}{syntax-float}{\fX{N}}
-.. |fNmag| mathdef:: \xref{syntax/values}{syntax-float}{\fX{\X{Nmag}}}
-.. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\fX{\X{32}}}
-.. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\fX{\X{64}}}
+.. |fN| mathdef:: \xref{syntax/values}{syntax-float}{\X{f}N}
+.. |fNmag| mathdef:: \xref{syntax/values}{syntax-float}{\X{f}\X{Nmag}}
+.. |f32| mathdef:: \xref{syntax/values}{syntax-float}{\X{f32}}
+.. |f64| mathdef:: \xref{syntax/values}{syntax-float}{\X{f64}}
 
 .. |name| mathdef:: \xref{syntax/values}{syntax-name}{\X{name}}
 .. |char| mathdef:: \xref{syntax/values}{syntax-name}{\X{char}}


### PR DESCRIPTION
We are using local \def for macros due to Sphinx limitations, but Latex does not like that in captions. So avoid some of those macros.