### PR TITLE
Very small typo #2

### DIFF
--- a/document/core/appendix/implementation.rst
+++ b/document/core/appendix/implementation.rst
@@ -40,7 +40,7 @@ An implementation may impose restrictions on the following dimensions of a modul
 * the number of :ref:`element segments <syntax-elem>` in a :ref:`module <syntax-module>`
 * the number of :ref:`data segments <syntax-data>` in a :ref:`module <syntax-module>`
 * the number of :ref:`imports <syntax-import>` to a :ref:`module <syntax-module>`
-* the number of :ref:`exports <syntax-export>` form a :ref:`module <syntax-module>`
+* the number of :ref:`exports <syntax-export>` from a :ref:`module <syntax-module>`
 * the number of parameters in a :ref:`function type <syntax-functype>`
 * the number of results in a :ref:`function type <syntax-functype>`
 * the number of :ref:`locals <syntax-local>` in a :ref:`function <syntax-func>`

--- a/document/core/appendix/index-types.rst
+++ b/document/core/appendix/index-types.rst
@@ -12,7 +12,7 @@ Category                                  Constructor                           
 :ref:`Value type <syntax-valtype>`        |I64|                                        :math:`\hex{7E}` (-2 as |Bs7|)
 :ref:`Value type <syntax-valtype>`        |F32|                                        :math:`\hex{7D}` (-3 as |Bs7|)
 :ref:`Value type <syntax-valtype>`        |F64|                                        :math:`\hex{7C}` (-4 as |Bs7|)
-(reserved)                                                                             :math:`\hex{7C}` .. :math:`\hex{71}`
+(reserved)                                                                             :math:`\hex{7B}` .. :math:`\hex{71}`
 :ref:`Element type <syntax-elemtype>`     |FUNCREF|                                    :math:`\hex{70}` (-16 as |Bs7|)
 (reserved)                                                                             :math:`\hex{6F}` .. :math:`\hex{61}`
 :ref:`Function type <syntax-functype>`    :math:`[\valtype^\ast] \to [\valtype^\ast]`  :math:`\hex{60}` (-32 as |Bs7|)


### PR DESCRIPTION
Includes commit from #1011

Addition:
![image](https://user-images.githubusercontent.com/22679778/57244897-74e8b300-7007-11e9-9aad-382f3d66ccff.png)
It originally states that `0x7C` is both `f64` and `(reserved)`, changes range from `0x7C .. 0x71` to `0x7B .. 0x71`
