### PR TITLE
Fix bikeshed build

### DIFF
--- a/document/core/index.bs
+++ b/document/core/index.bs
@@ -8,7 +8,7 @@ TR: https://www.w3.org/TR/wasm-core-1/
 ED: https://webassembly.github.io/spec/core/bikeshed/
 Editor: Andreas Rossberg (Dfinity Stiftung)
 Repository: WebAssembly/spec
-Markup Shorthands: css no, markdown yes, algorithm no
+Markup Shorthands: css no, markdown yes, algorithm no, idl no
 Abstract: This document describes version 1.0 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
 Prepare For TR: true
 </pre>

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -233,7 +233,7 @@ def Main():
         fixed = ('class="' + cls_before + ' ' + cls_after + '">' +
                  spans + ReplaceMath(cache, mth) + '<')
         done_fixups.append((start, end, fixed))
-      except KeyboardInterrupt, AssertionError:
+      except Exception:
         sys.stderr.write('!!! Error processing fragment')
 
       q.task_done()


### PR DESCRIPTION
A recent change caused the generated html to have a sequence that looked
like `{{abkasdfadsf}}`, which bikeshed misinterprets as a WebIDL markup
shorthand. Since we never use that shorthand in the core spec, we can
disable it.

Since bikeshed thought this was a IDL reference, it inserted an
additional `<code>` tag, so the `mathjax2katex.py` script was not able
to extract the math blocks properly. The `FindMatching` function was
raising an `IndexError`, but it was never caught and instead terminated
the worker thread. The main thread would then wait forever for a worker
thread that will never finish. The fix here is to catch all exceptions
and print an error, instead of just catching `KeyboardInterrupt` and
`AssertionError`.