### PR TITLE
[spec][js-api] Fix some links

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -149,6 +149,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: the instantiation algorithm; url: exec/modules.html#instantiation
     text: module; url: syntax/modules.html#syntax-module
     text: 𝗂𝗆𝗉𝗈𝗋𝗍𝗌; url: syntax/modules.html#syntax-module
+    text: import; url: syntax/modules.html#syntax-import
     url: syntax/types.html#external-types
         text: external type
         text: 𝖿𝗎𝗇𝖼
@@ -218,7 +219,7 @@ fetch('demo.wasm').then(response =>
 
 Note: WebAssembly semantics are defined in terms of an abstract [=store=], representing the state of the WebAssembly abstract machine. WebAssembly operations take a store and return an updated store.
 
-Each [=agent=] has an <dfn>associated store</dfn>. When a new agent is created, its associated store is set to the result of [=init_store=]().
+Each [=agent=] has an <dfn>associated store</dfn>. When a new agent is created, its associated store is set to the result of [=store_init=]().
 
 Note: In this specification, no WebAssembly-related objects, memory or addresses can be shared among agents in an [=agent cluster=]. In a future version of WebAssembly, this may change.
 
@@ -1089,6 +1090,4 @@ In practice, an implementation may run out of resources for valid modules below 
 
 <p><em>This section is non-normative.</em></p>
 
-This document defines a host environment for WebAssembly.
-It enables a WebAssembly instance to :ref:`import <syntax-import>` and :ref:`export <syntax-export>` all Javascript functions and APIs.
-This WebAssembly instance is thusly bound to the same constraints as any other Javascript program.
+This document defines a host environment for WebAssembly. It enables a WebAssembly instance to [=import=] JavaScript objects and functions from an [=read the imports|import object=], but otherwise provides no access to the embedding environment. Thus a WebAssembly instance is bounds to the same constraints as JavaScript.


### PR DESCRIPTION
Replace `init_store` with `store_init`.

Also, reword the "Security and Privacy Considerations" section, and fix
the references are using ReST syntax (which doesn't work in bikeshed).