### PR TITLE
Editorial: Remove links from Number, Object when checking types

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -323,7 +323,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. Let |imports| be an empty [=list=] of [=external value=]s.
     1. For each (|moduleName|, |componentName|, |externtype|) in [=module_imports=](|module|), do
         1. Let |o| be ? [=Get=](|importObject|, |moduleName|).
-        1. If [=Type=](|o|) is not [=Object=], throw a {{TypeError}} exception.
+        1. If [=Type=](|o|) is not Object, throw a {{TypeError}} exception.
         1. Let |v| be ? [=Get=](|o|, |componentName|)
         1. If |externtype| is of the form [=𝖿𝗎𝗇𝖼=] |functype|,
             1. If [=IsCallable=](|v|) is false, throw a {{LinkError}} exception.
@@ -337,7 +337,7 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
             1. Let |externfunc| be the [=external value=] [=external value|𝖿𝗎𝗇𝖼=] |funcaddr|.
             1. [=Append=] |externfunc| to |imports|.
         1. If |externtype| is of the form [=𝗀𝗅𝗈𝖻𝖺𝗅=] <var ignore>mut</var> |valtype|,
-            1. If [=Type=](|v|) is [=Number=],
+            1. If [=Type=](|v|) is Number,
                 1. If |valtype| is [=𝗂𝟨𝟦=], throw a {{LinkError}} exception.
                 1. Let |value| be [=ToWebAssemblyValue=](|v|, |valtype|)
                 1. Let |store| be the [=surrounding agent=]'s [=associated store=].


### PR DESCRIPTION
This follows the convention followed by the JavaScript spec and HTML.

Fixes #1026