### PR TITLE
[interpreter] Fix float literals

### DIFF
--- a/interpreter/exec/f32_convert.ml
+++ b/interpreter/exec/f32_convert.ml
@@ -34,14 +34,14 @@ let convert_i64_s x =
   F32.of_float Int64.(
     if abs x < 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right x 12) r) *. 0x1p12
+    to_float (logor (shift_right x 12) r) *. 4096.0
   )
 
 let convert_i64_u x =
   F32.of_float Int64.(
     if I64.lt_u x 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right_logical x 12) r) *. 0x1p12
+    to_float (logor (shift_right_logical x 12) r) *. 4096.0
   )
 
 let reinterpret_i32 = F32.of_bits

--- a/interpreter/exec/i64_convert.ml
+++ b/interpreter/exec/i64_convert.ml
@@ -22,7 +22,7 @@ let trunc_f32_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
+      Int64.(logxor (of_float (xf -. 9223372036854775808.0)) min_int)
     else
       Int64.of_float xf
 
@@ -44,7 +44,7 @@ let trunc_f64_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
+      Int64.(logxor (of_float (xf -. 9223372036854775808.0)) min_int)
     else
       Int64.of_float xf
 


### PR DESCRIPTION
I cannot compile the spec interpreter with ToT. This PR fixes the problem for me. I tried to compile with ocaml 4.02.3, 4.06.0, and 4.08.0, by just running `make`.