### PR TITLE
Downgrade to Ocaml 4.02

### DIFF
--- a/interpreter/exec/f32_convert.ml
+++ b/interpreter/exec/f32_convert.ml
@@ -34,14 +34,14 @@ let convert_i64_s x =
   F32.of_float Int64.(
     if abs x < 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right x 12) r) *. 0x1p12
+    to_float (logor (shift_right x 12) r) *. (* TODO(ocaml-4.03): 0x1p12 *) 4096.0
   )
 
 let convert_i64_u x =
   F32.of_float Int64.(
     if I64.lt_u x 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right_logical x 12) r) *. 0x1p12
+    to_float (logor (shift_right_logical x 12) r) *. (* TODO(ocaml-4.03): 0x1p12 *) 4096.0
   )
 
 let reinterpret_i32 = F32.of_bits

--- a/interpreter/exec/float.ml
+++ b/interpreter/exec/float.ml
@@ -296,7 +296,7 @@ struct
       else
         Rep.logor x bare_nan
     else
-      (* TODO: once we update past 4.02, replace buffer hack with this
+      (* TODO(ocmal-4.03): replace buffer hack with this:
       let s' = String.concat "" (String.split_on_char '_' s) in
       *)
       let buf = Buffer.create (String.length s) in
@@ -348,7 +348,7 @@ struct
       let payload = Rep.logand (abs x) (Rep.lognot bare_nan) in
       "nan:0x" ^ Rep.to_hex_string payload
     else
-      (* TODO: use sprintf "%h" once we have upgraded to OCaml 4.03 *)
+      (* TODO(ocaml-4.03): use sprintf "%h" *)
       let s = string_of_float (to_float (abs x)) in
       group_digits (if s.[String.length s - 1] = '.' then s ^ "0" else s)
 end

--- a/interpreter/exec/i64_convert.ml
+++ b/interpreter/exec/i64_convert.ml
@@ -22,7 +22,7 @@ let trunc_f32_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
+      Int64.(logxor (of_float (xf -. (* TODO(ocaml-4.03): 0x1p63 *) 9223372036854775808.0)) min_int)
     else
       Int64.of_float xf
 
@@ -44,7 +44,7 @@ let trunc_f64_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
+      Int64.(logxor (of_float (xf -. (* TODO(ocaml-4.03): 0x1p63 *) 9223372036854775808.0)) min_int)
     else
       Int64.of_float xf
 


### PR DESCRIPTION
Since some distros are still stuck on Ocmal 4.02, and we only use very few newer features, downgrade those and add respective comments.