### PR TITLE
[spec] Upgrade to IEEE 754-2019

### DIFF
--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -52,8 +52,8 @@ def Main():
   )
 
   data = data.replace(
-      """<a class="reference external" href="http://ieeexplore.ieee.org/document/4610935/">IEEE 754-2008</a>""",
-      "[[!IEEE-754-2008]]"
+      """<a class="reference external" href="https://ieeexplore.ieee.org/document/8766229">IEEE 754-2019</a>""",
+      "[[!IEEE-754-2019]]"
   )
 
   sys.stdout.write(data)

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -9,8 +9,8 @@
 .. |WasmIssues| replace:: http://github.com/webassembly/spec/issues/
 .. _WasmIssues: http://github.com/webassembly/spec/issues/
 
-.. |IEEE754| replace:: IEEE 754-2008
-.. _IEEE754: http://ieeexplore.ieee.org/document/4610935/
+.. |IEEE754| replace:: IEEE 754-2019
+.. _IEEE754: https://ieeexplore.ieee.org/document/8766229
 
 .. |Unicode| replace:: Unicode
 .. _Unicode: http://www.unicode.org/versions/latest/


### PR DESCRIPTION
A new 2019 revision of the  IEEE 754 standard has been released: http://754r.ucbtest.org/background/

It's just a minor revision, and none of the listed changes affect Wasm, so this merely updates the reference.