### PR TITLE
[spec] Terminology nits

### DIFF
--- a/document/core/appendix/algorithm.rst
+++ b/document/core/appendix/algorithm.rst
@@ -202,5 +202,5 @@ Other instructions are checked in a similar manner.
 
 .. note::
    It is an invariant under the current WebAssembly instruction set that an operand of :code:`Unknown` type is never duplicated on the stack.
-   This would change if the language were extended with stack operators like :code:`dup`.
+   This would change if the language were extended with stack instructions like :code:`dup`.
    Under such an extension, the above algorithm would need to be refined by replacing the :code:`Unknown` type with proper *type variables* to ensure that all uses are consistent.

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -129,9 +129,9 @@ For each type, several subcategories can be distinguished:
 
 * *Constants*: return a static constant.
 
-* *Unary Operators*: consume one operand and produce one result of the respective type.
+* *Unary Operations*: consume one operand and produce one result of the respective type.
 
-* *Binary Operators*: consume two operands and produce one result of the respective type.
+* *Binary Operations*: consume two operands and produce one result of the respective type.
 
 * *Tests*: consume one operand of the respective type and produce a Boolean integer result.
 
@@ -184,9 +184,9 @@ Instructions in this group can operate on operands of any :ref:`value type <synt
      \SELECT
    \end{array}
 
-The |DROP| operator simply throws away a single operand.
+The |DROP| instruction simply throws away a single operand.
 
-The |SELECT| operator selects one of its first two operands based on whether its third operand is zero or not.
+The |SELECT| instruction selects one of its first two operands based on whether its third operand is zero or not.
 
 
 .. index:: ! variable instruction, local, global, local index, global index

--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -141,6 +141,7 @@ clean:
 		rm -rf _build/jslib $(LIB).mlpack _tags
 		$(OCB) -clean
 
+
 # Opam support
 
 .PHONY:		check install uninstall


### PR DESCRIPTION
Properly use "instruction" not "operator" in a couple of places.