### PR TITLE
[interpreter] Make roundtrips perfect

### DIFF
--- a/interpreter/exec/float.ml
+++ b/interpreter/exec/float.ml
@@ -348,7 +348,6 @@ struct
       let payload = Rep.logand (abs x) (Rep.lognot bare_nan) in
       "nan:0x" ^ Rep.to_hex_string payload
     else
-      (* TODO(ocaml-4.03): use sprintf "%h" *)
-      let s = string_of_float (to_float (abs x)) in
+      let s = Printf.sprintf "%.17g" (to_float (abs x)) in
       group_digits (if s.[String.length s - 1] = '.' then s ^ "0" else s)
 end

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -196,20 +196,21 @@ let extension = function
   | Memory.SX -> "_s"
   | Memory.ZX -> "_u"
 
-let memop name {ty; align; offset; _} =
+let memop name {ty; align; offset; _} sz =
   value_type ty ^ "." ^ name ^
   (if offset = 0l then "" else " offset=" ^ nat32 offset) ^
-  (if 1 lsl align = size ty then "" else " align=" ^ nat (1 lsl align))
+  (if 1 lsl align = sz then "" else " align=" ^ nat (1 lsl align))
 
 let loadop op =
   match op.sz with
-  | None -> memop "load" op
-  | Some (sz, ext) -> memop ("load" ^ pack_size sz ^ extension ext) op
+  | None -> memop "load" op (size op.ty)
+  | Some (sz, ext) ->
+    memop ("load" ^ pack_size sz ^ extension ext) op (Memory.packed_size sz)
 
 let storeop op =
   match op.sz with
-  | None -> memop "store" op
-  | Some sz -> memop ("store" ^ pack_size sz) op
+  | None -> memop "store" op (size op.ty)
+  | Some sz -> memop ("store" ^ pack_size sz) op (Memory.packed_size sz)
 
 
 (* Expressions *)
@@ -305,18 +306,21 @@ let data seg =
 let typedef i ty =
   Node ("type $" ^ nat i, [struct_type ty.it])
 
-let import_desc i d =
+let import_desc fx tx mx gx d =
   match d.it with
   | FuncImport x ->
-    Node ("func $" ^ nat i, [Node ("type", [atom var x])])
-  | TableImport t -> table 0 i ({ttype = t} @@ d.at)
-  | MemoryImport t -> memory 0 i ({mtype = t} @@ d.at)
-  | GlobalImport t -> Node ("global $" ^ nat i, [global_type t])
+    incr fx; Node ("func $" ^ nat (!fx - 1), [Node ("type", [atom var x])])
+  | TableImport t ->
+    incr tx; table 0 (!tx - 1) ({ttype = t} @@ d.at)
+  | MemoryImport t ->
+    incr mx; memory 0 (!mx - 1) ({mtype = t} @@ d.at)
+  | GlobalImport t ->
+    incr gx; Node ("global $" ^ nat (!gx - 1), [global_type t])
 
-let import i im =
+let import fx tx mx gx im =
   let {module_name; item_name; idesc} = im.it in
   Node ("import",
-    [atom name module_name; atom name item_name; import_desc i idesc]
+    [atom name module_name; atom name item_name; import_desc fx tx mx gx idesc]
   )
 
 let export_desc d =
@@ -341,30 +345,19 @@ let var_opt = function
   | None -> ""
   | Some x -> " " ^ x.it
 
-let is_func_import im =
-  match im.it.idesc.it with FuncImport _ -> true | _ -> false
-let is_table_import im =
-  match im.it.idesc.it with TableImport _ -> true | _ -> false
-let is_memory_import im =
-  match im.it.idesc.it with MemoryImport _ -> true | _ -> false
-let is_global_import im =
-  match im.it.idesc.it with GlobalImport _ -> true | _ -> false
-
 let module_with_var_opt x_opt m =
-  let func_imports = List.filter is_func_import m.it.imports in
-  let table_imports = List.filter is_table_import m.it.imports in
-  let memory_imports = List.filter is_memory_import m.it.imports in
-  let global_imports = List.filter is_global_import m.it.imports in
+  let fx = ref 0 in
+  let tx = ref 0 in
+  let mx = ref 0 in
+  let gx = ref 0 in
+  let imports = list (import fx tx mx gx) m.it.imports in
   Node ("module" ^ var_opt x_opt,
     listi typedef m.it.types @
-    listi import table_imports @
-    listi import memory_imports @
-    listi import global_imports @
-    listi import func_imports @
-    listi (table (List.length table_imports)) m.it.tables @
-    listi (memory (List.length memory_imports)) m.it.memories @
-    listi (global (List.length global_imports)) m.it.globals @
-    listi (func_with_index (List.length func_imports)) m.it.funcs @
+    imports @
+    listi (table !tx) m.it.tables @
+    listi (memory !mx) m.it.memories @
+    listi (global !gx) m.it.globals @
+    listi (func_with_index !fx) m.it.funcs @
     list export m.it.exports @
     opt start m.it.start @
     list elems m.it.elems @
@@ -391,23 +384,26 @@ let literal lit =
 
 let definition mode x_opt def =
   try
-    match mode, def.it with
-    | `Textual, _ | `Original, Textual _ ->
+    match mode with
+    | `Textual ->
       let rec unquote def =
         match def.it with
         | Textual m -> m
         | Encoded (_, bs) -> Decode.decode "" bs
         | Quoted (_, s) -> unquote (Parse.string_to_module s)
       in module_with_var_opt x_opt (unquote def)
-    | `Binary, _ | `Original, Encoded _ ->
+    | `Binary ->
       let rec unquote def =
         match def.it with
         | Textual m -> Encode.encode m
-        | Encoded (_, bs) -> bs
+        | Encoded (_, bs) -> Encode.encode (Decode.decode "" bs)
         | Quoted (_, s) -> unquote (Parse.string_to_module s)
       in binary_module_with_var_opt x_opt (unquote def)
-    | `Original, Quoted (_, s) ->
-      quoted_module_with_var_opt x_opt s
+    | `Original ->
+      match def.it with
+      | Textual m -> module_with_var_opt x_opt m
+      | Encoded (_, bs) -> binary_module_with_var_opt x_opt bs
+      | Quoted (_, s) -> quoted_module_with_var_opt x_opt s
   with Parse.Syntax _ ->
     quoted_module_with_var_opt x_opt "<invalid module>"
 

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -68,26 +68,29 @@ class RunTests(unittest.TestCase):
     if expectedExitCode != 0:
       return
 
-    # Convert to binary and validate again
+    # Convert to binary and run again
     wasmPath = self._auxFile(outputPath + ".bin.wast")
     logPath = self._auxFile(wasmPath + ".log")
     self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, inputPath, wasmPath), logPath)
-    self._runCommand(('%s -d "%s"') % (wasmCommand, wasmPath), logPath)
+    self._runCommand(('%s "%s"') % (wasmCommand, wasmPath), logPath)
 
-    # Convert back to text and validate again
+    # Convert back to text and run again
     wastPath = self._auxFile(wasmPath + ".wast")
     logPath = self._auxFile(wastPath + ".log")
     self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, wasmPath, wastPath), logPath)
-    self._runCommand(('%s -d "%s" ') % (wasmCommand, wastPath), logPath)
+    self._runCommand(('%s "%s"') % (wasmCommand, wastPath), logPath)
 
     # Convert back to binary once more and compare
     wasm2Path = self._auxFile(wastPath + ".bin.wast")
     logPath = self._auxFile(wasm2Path + ".log")
     self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, wastPath, wasm2Path), logPath)
-    self._runCommand(('%s -d "%s"') % (wasmCommand, wasm2Path), logPath)
-    # TODO: The binary should stay the same, but OCaml's float-string conversions are inaccurate.
-    # Once we upgrade to OCaml 4.03, use sprintf "%s" for printing floats.
-    # self._compareFile(wasmPath, wasm2Path)
+    self._compareFile(wasmPath, wasm2Path)
+
+    # Convert back to text once more and compare
+    wast2Path = self._auxFile(wasm2Path + ".wast")
+    logPath = self._auxFile(wast2Path + ".log")
+    self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, wasm2Path, wast2Path), logPath)
+    self._compareFile(wastPath, wast2Path)
 
     # Convert to JavaScript
     jsPath = self._auxFile(outputPath.replace(".wast", ".js"))


### PR DESCRIPTION
Improve text format pretty printer such that text/binary roundtrips are idempotent:

* Fix bug with alignment shorthand being based on wrong size.
* Increase precision for printing float literals.
* Don't sort imports.
* Normalise input binaries.

Test runner now checks that roundtrips produce the exact same files after the first step. Also, re-run script after conversions, do not just re-validate.

Fixes #1054.