### PR TITLE
[spec] Fix float text format

### DIFF
--- a/document/core/text/values.rst
+++ b/document/core/text/values.rst
@@ -96,6 +96,8 @@ Floating-Point
      h{:}\Thexdigit~~q{:}\Thexfrac &\Rightarrow& (h+q)/16 \\ &&|&
      h{:}\Thexdigit~~\text{\_}~~~~p{:}\Thexdigit~~q{:}\Thexfrac &\Rightarrow& (h+(p+q)/16)/16 \\
    \production{decimal floating-point number} & \Tfloat &::=&
+     p{:}\Tnum
+       &\Rightarrow& p \\ &&|&
      p{:}\Tnum~\text{.}~q{:}\Tfrac
        &\Rightarrow& p+q \\ &&|&
      p{:}\Tnum~(\text{E}~|~\text{e})~{\pm}{:}\Tsign~e{:}\Tnum
@@ -103,6 +105,8 @@ Floating-Point
      p{:}\Tnum~\text{.}~q{:}\Tfrac~(\text{E}~|~\text{e})~{\pm}{:}\Tsign~e{:}\Tnum
        &\Rightarrow& (p+q)\cdot 10^{\pm e} \\
    \production{hexadecimal floating-point number} & \Thexfloat &::=&
+     \text{0x}~p{:}\Thexnum
+       &\Rightarrow& p \\ &&|&
      \text{0x}~p{:}\Thexnum~\text{.}~q{:}\Thexfrac
        &\Rightarrow& p+q \\ &&|&
      \text{0x}~p{:}\Thexnum~(\text{P}~|~\text{p})~{\pm}{:}\Tsign~e{:}\Tnum

--- a/interpreter/exec/float.ml
+++ b/interpreter/exec/float.ml
@@ -265,6 +265,7 @@ struct
       let m = logor (logand bits 0xf_ffff_ffff_ffffL) 0x10_0000_0000_0000L in
       (* Shift mantissa to match msb position in most significant hex digit *)
       let i = skip_zeroes (String.uppercase s) 0 in
+      if i = String.length s then Printf.sprintf "%.*g" (String.length s) z else
       let sh =
         match s.[i] with '1' -> 0 | '2'..'3' -> 1 | '4'..'7' -> 2 | _ -> 3 in
       Printf.sprintf "%Lx" (shift_left m sh)

--- a/test/core/const.wast
+++ b/test/core/const.wast
@@ -2,6 +2,250 @@
 
 ;; Syntax error
 
+(module (func (i32.const 0_123_456_789) drop))
+(module (func (i32.const 0x0_9acf_fBDF) drop))
+(assert_malformed
+  (module quote "(func (i32.const) drop)")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (i32.const 0x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (i32.const 1x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (i32.const 0xg) drop)")
+  "unknown operator"
+)
+
+(module (func (i64.const 0_123_456_789) drop))
+(module (func (i64.const 0x0125_6789_ADEF_bcef) drop))
+(assert_malformed
+  (module quote "(func (i64.const) drop)")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (i64.const 0x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (i64.const 1x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (i64.const 0xg) drop)")
+  "unknown operator"
+)
+
+(module (func (f32.const 0123456789) drop))
+(module (func (f32.const 0123456789e019) drop))
+(module (func (f32.const 0123456789e+019) drop))
+(module (func (f32.const 0123456789e-019) drop))
+(module (func (f32.const 0123456789.) drop))
+(module (func (f32.const 0123456789.e019) drop))
+(module (func (f32.const 0123456789.e+019) drop))
+(module (func (f32.const 0123456789.e-019) drop))
+(module (func (f32.const 0123456789.0123456789) drop))
+(module (func (f32.const 0123456789.0123456789e019) drop))
+(module (func (f32.const 0123456789.0123456789e+019) drop))
+(module (func (f32.const 0123456789.0123456789e-019) drop))
+(module (func (f32.const 0x0123456789ABCDEF) drop))
+(module (func (f32.const 0x0123456789ABCDEFp019) drop))
+(module (func (f32.const 0x0123456789ABCDEFp+019) drop))
+(module (func (f32.const 0x0123456789ABCDEFp-019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.) drop))
+(module (func (f32.const 0x0123456789ABCDEF.p019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.p+019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.p-019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.019aF) drop))
+(module (func (f32.const 0x0123456789ABCDEF.019aFp019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.019aFp+019) drop))
+(module (func (f32.const 0x0123456789ABCDEF.019aFp-019) drop))
+(assert_malformed
+  (module quote "(func (f32.const) drop)")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (f32.const .0) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const .0e0) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0e) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0e+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0.0e) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0.0e-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 1x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0xg) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x.) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0.g) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0p) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0p+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0p-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0.0p) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0.0p+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0.0p-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f32.const 0x0pA) drop)")
+  "unknown operator"
+)
+
+
+(module (func (f64.const 0123456789) drop))
+(module (func (f64.const 0123456789e019) drop))
+(module (func (f64.const 0123456789e+019) drop))
+(module (func (f64.const 0123456789e-019) drop))
+(module (func (f64.const 0123456789.) drop))
+(module (func (f64.const 0123456789.e019) drop))
+(module (func (f64.const 0123456789.e+019) drop))
+(module (func (f64.const 0123456789.e-019) drop))
+(module (func (f64.const 0123456789.0123456789) drop))
+(module (func (f64.const 0123456789.0123456789e019) drop))
+(module (func (f64.const 0123456789.0123456789e+019) drop))
+(module (func (f64.const 0123456789.0123456789e-019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdefp019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdefp+019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdefp-019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.p019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.p+019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.p-019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.0123456789ABCDEFabcdef) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.0123456789ABCDEFabcdefp019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.0123456789ABCDEFabcdefp+019) drop))
+(module (func (f64.const 0x0123456789ABCDEFabcdef.0123456789ABCDEFabcdefp-019) drop))
+(assert_malformed
+  (module quote "(func (f64.const) drop)")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (f64.const .0) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const .0e0) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0e) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0e+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0.0e) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0.0e-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 1x) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0xg) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x.) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0.g) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0p) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0p+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0p-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0.0p) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0.0p+) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0.0p-) drop)")
+  "unknown operator"
+)
+(assert_malformed
+  (module quote "(func (f64.const 0x0pA) drop)")
+  "unknown operator"
+)
+
+
+;; Range error
+
 (module (func (i32.const 0xffffffff) drop))
 (module (func (i32.const -0x80000000) drop))
 (assert_malformed


### PR DESCRIPTION
Fixes #1066. Also fixes a recent bug in interpreter's double rounding mitigation and adds parsing tests.