### PR TITLE
[spec] C.return should be replaced not prepend

### DIFF
--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -42,7 +42,7 @@ Functions :math:`\func` are classified by :ref:`function types <syntax-functype>
    \frac{
      C.\CTYPES[x] = [t_1^\ast] \to [t_2^?]
      \qquad
-     C,\CLOCALS\,t_1^\ast~t^\ast,\CLABELS~[t_2^?],\CRETURN~[t_2^?] \vdashexpr \expr : [t_2^?]
+     C,\CLOCALS\,t_1^\ast~t^\ast,\CLABELS~[t_2^?] \with \CRETURN = [t_2^?] \vdashexpr \expr : [t_2^?]
    }{
      C \vdashfunc \{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \} : [t_1^\ast] \to [t_2^?]
    }


### PR DESCRIPTION
Since `C.return` is an optional occurrence, we should use _record field replacement_ defined at [structure - convention](http://webassembly.github.io/spec/core/syntax/conventions.html) instead of _prepend_  defined at [validation - convention](http://webassembly.github.io/spec/core/valid/conventions.html).

An alternative would be declaring the overloads for the `C, field A*` notation but I guess it would be more confusing than using already established `with`.