### PR TITLE
Don't require the element index in "uninitialized element" trap strings.

### DIFF
--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -350,7 +350,7 @@
 
 (register "module1" $module1)
 
-(assert_trap (invoke $module1 "call-7") "uninitialized element 7")
+(assert_trap (invoke $module1 "call-7") "uninitialized element")
 (assert_return (invoke $module1 "call-8") (i32.const 65))
 (assert_return (invoke $module1 "call-9") (i32.const 66))
 


### PR DESCRIPTION
One test in elem.wast expects the trap message "uninitialized element 7",
which requires wasm runtimes to be able to print the element index. This
is obviously nice for humans, but can be inconvenient to implement in wasm
implementations which use signals to implement traps, as it requires special
code to preserve the element index.

Other tests eg. in imports.wast don't include the number in the expected
message.

It seems better to allow implementations to decide for themselves
whether to print the index number, rather than having it be an outright
requirement of the spec test.