### PR TITLE
[spec] C.fields should be replaced in valid/fun

### DIFF
--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -42,7 +42,7 @@ Functions :math:`\func` are classified by :ref:`function types <syntax-functype>
    \frac{
      C.\CTYPES[x] = [t_1^\ast] \to [t_2^?]
      \qquad
-     C,\CLOCALS\,t_1^\ast~t^\ast,\CLABELS~[t_2^?],\CRETURN~[t_2^?] \vdashexpr \expr : [t_2^?]
+     C \with \CLOCALS = t_1^\ast~t^\ast \with \CLABELS = [t_2^?] \with \CRETURN = [t_2^?] \vdashexpr \expr : [t_2^?]
    }{
      C \vdashfunc \{ \FTYPE~x, \FLOCALS~t^\ast, \FBODY~\expr \} : [t_1^\ast] \to [t_2^?]
    }


### PR DESCRIPTION
This commit is an update on #1070 (I carelessly force push the branch then the PR is closed).
This commit also changes `locals` and `labels` via `with` without adding new syntax as I questioned in PR #1070 and issue #1072.

The `document/README.md` talked about deployment as well. I assumed that's something only members do after PR approval?