### PR TITLE
[web-api] Editorial: Remove a year from the ECMAScript Language title in normative reference

### DIFF
--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -17,7 +17,7 @@ Prepare For TR: true
 {
   "ECMA-262": {
     "href": "https://tc39.github.io/ecma262",
-    "title": "ECMAScript® 2018 Language Specification",
+    "title": "ECMAScript® Language Specification",
     "publisher": "ECMA TC39",
     "status": "Current Editor's Draft"
   },


### PR DESCRIPTION
The URL points to latest spec draft so it should be just ECMAScript and not ES2018. This also make it consistent with [WebAssembly JS API Normative Reference](https://www.w3.org/TR/2019/PR-wasm-js-api-1-20191001/#normative)