### PR TITLE
Dont expect indices in validation messages either.

### DIFF
--- a/test/core/call_indirect.wast
+++ b/test/core/call_indirect.wast
@@ -938,5 +938,5 @@
 
 (assert_invalid
   (module (table funcref (elem 0 0)))
-  "unknown function 0"
+  "unknown function"
 )

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -283,7 +283,7 @@
   (module
     (data (i32.const 0) "")
   )
-  "unknown memory 0"
+  "unknown memory"
 )
 
 ;; Invalid offsets

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -249,7 +249,7 @@
     (func $f)
     (elem (i32.const 0) $f)
   )
-  "unknown table 0"
+  "unknown table"
 )
 
 ;; Invalid offsets


### PR DESCRIPTION
Similar to #1076, don't include index numbers in expected error messages
from validation. This allows implementations to avoid creating
dynamically formatted strings for validation error messages. Admittedly
this isn't a huge burden, but it does seem like something that shouldn't
be required to pass the spec test.