### PR TITLE
[spec] fix valid-limit (2)

### DIFF
--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -226,7 +226,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
    \frac{
      ((S \vdash \EVFUNC~\X{fa} : \ETFUNC~\functype)^?)^n
      \qquad
-     \vdashlimits \{\LMIN~n, \LMAX~m^?\} \ok
+     \vdashtabletype \{\LMIN~n, \LMAX~m^?\}~\FUNCREF \ok
    }{
      S \vdashtableinst \{ \TIELEM~(\X{fa}^?)^n, \TIMAX~m^? \} : \{\LMIN~n, \LMAX~m^?\}~\FUNCREF
    }
@@ -244,7 +244,7 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 
 .. math::
    \frac{
-     \vdashlimits \{\LMIN~n, \LMAX~m^?\} \ok
+     \vdashmemtype \{\LMIN~n, \LMAX~m^?\} \ok
    }{
      S \vdashmeminst \{ \MIDATA~b^n, \MIMAX~m^? \} : \{\LMIN~n, \LMAX~m^?\}
    }


### PR DESCRIPTION
Background: see https://github.com/WebAssembly/multi-value/issues/29

This is (2). The benefits are that this approach reuses `2^{32}` and `2^{16}` defined in Validation - Type. This is also closer to the future [reference-type one](https://webassembly.github.io/reference-types/core/appendix/properties.html#table-instances) in spirit where both `tableinst` and `memoryinst` instantiate a `tabletype` and `memtype` valid rule to use in the premises.

TODO: Prose need to be updated if this approach is preferred.