### PR TITLE
Reference interpreter, step Return, clear stack

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -152,7 +152,7 @@ let rec step (c : config) : config =
         vs', [Plain (Br (Lib.List32.nth xs i)) @@ e.at]
 
       | Return, vs ->
-        vs, [Returning vs @@ e.at]
+        [], [Returning vs @@ e.at]
 
       | Call x, vs ->
         vs, [Invoke (func frame.inst x) @@ e.at]


### PR DESCRIPTION
according to
https://webassembly.github.io/spec/core/exec/instructions.html#exec-return
the `Return` instruction pops the top of the stack, until the next
frame. The equivalent in the reference interpreter should be to set
the value stack to `[]`. This is what is happening for `Break` as well.
So for consistency, also do it here.

This has no visible effect: If the first instruction is `Returning`, the
stack is ignored everywhere. So this is purely cosmetic.

(I am only 80% sure; if not I hope to at least learn something here.)