### PR TITLE
improve error message when running core tests

### DIFF
--- a/test/core/run.py
+++ b/test/core/run.py
@@ -41,7 +41,12 @@ class RunTests(unittest.TestCase):
   def _runCommand(self, command, logPath, expectedExitCode = 0):
     with open(logPath, 'w+') as out:
       exitCode = subprocess.call(command, shell=True, stdout=out, stderr=subprocess.STDOUT)
-      self.assertEqual(expectedExitCode, exitCode, "failed with exit code %i (expected %i) for %s" % (exitCode, expectedExitCode, command))
+      if exitCode != expectedExitCode:
+          out.flush()
+          out.seek(0)
+          raise Exception(
+            "!! failed with exit code %i (expected %i) for %s\n%s" 
+            % (exitCode, expectedExitCode, command, out.read()))
 
   def _auxFile(self, path):
     if os.path.exists(path):


### PR DESCRIPTION
Example run after changing the first test in i32.wast to return 777 instead:

```
$ test/core/run.py --wasm $(which wasm-reference) test/core/i32.wast
E
======================================================================
ERROR: test i32.wast (__main__.RunTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/core/run.py", line 113, in <lambda>
    setattr(RunTests, testName, lambda self, file=fileName: self._runTestFile(file))
  File "test/core/run.py", line 71, in _runTestFile
    self._runCommand(('%s "%s"') % (wasmCommand, inputPath), logPath, expectedExitCode)
  File "test/core/run.py", line 49, in _runCommand
    % (exitCode, expectedExitCode, command, out.read()))
Exception: !! failed with exit code 1 (expected 0) for /home/rett/bin/wasm-reference "test/core/i32.wast"
Result: 2 : i32
Expect: 777 : i32
test/core/i32.wast:35.1-35.75: assertion failure: wrong return values


----------------------------------------------------------------------
Ran 1 test in 0.009s

FAILED (errors=1)
```
