### PR TITLE
[js-api] Bump limit for maximum memory size to 4GiB

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1133,7 +1133,8 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum size of a table is 10000000.</li>
 <li>The maximum number of table entries in any table initialization is 10000000.</li>
 <li>The maximum number of memories, including declared or imported memories, is 1.</li>
-<li>The initial or maximum number of pages for any memory, declared or imported, is at most 32767.</li>
+<li>The initial number of pages for any memory, declared or imported, is at most 32767.</li>
+<li>The maximum number of pages for any memory, declared or imported, is at most 65536.</li>
 
 <li>The maximum number of parameters to any function is 1000.</li>
 <li>The maximum number of return values for any function is 1.</li>

--- a/test/js-api/limits.any.js
+++ b/test/js-api/limits.any.js
@@ -9,7 +9,8 @@ const kJSEmbeddingMaxExports = 100000;
 const kJSEmbeddingMaxGlobals = 1000000;
 const kJSEmbeddingMaxDataSegments = 100000;
 
-const kJSEmbeddingMaxMemoryPages = 65536;
+const kJSEmbeddingMaxInitialMemoryPages = 32767;
+const kJSEmbeddingMaxMaximumMemoryPages = 65536;
 const kJSEmbeddingMaxModuleSize = 1024 * 1024 * 1024;  // = 1 GiB
 const kJSEmbeddingMaxFunctionSize = 7654321;
 const kJSEmbeddingMaxFunctionLocals = 50000;
@@ -109,22 +110,22 @@ testLimit("data segments", 1, kJSEmbeddingMaxDataSegments, (builder, count) => {
         }
     });
 
-testLimit("initial declared memory pages", 1, kJSEmbeddingMaxMemoryPages,
+testLimit("initial declared memory pages", 1, kJSEmbeddingMaxInitialMemoryPages,
           (builder, count) => {
             builder.addMemory(count, undefined, false, false);
           });
 
-testLimit("maximum declared memory pages", 1, kJSEmbeddingMaxMemoryPages,
+testLimit("maximum declared memory pages", 1, kJSEmbeddingMaxMaximumMemoryPages,
           (builder, count) => {
             builder.addMemory(1, count, false, false);
           });
 
-testLimit("initial imported memory pages", 1, kJSEmbeddingMaxMemoryPages,
+testLimit("initial imported memory pages", 1, kJSEmbeddingMaxInitialMemoryPages,
           (builder, count) => {
             builder.addImportedMemory("mod", "mem", count, undefined);
           });
 
-testLimit("maximum imported memory pages", 1, kJSEmbeddingMaxMemoryPages,
+testLimit("maximum imported memory pages", 1, kJSEmbeddingMaxMaximumMemoryPages,
           (builder, count) => {
             builder.addImportedMemory("mod", "mem", 1, count);
           });


### PR DESCRIPTION
Per discussion in #1116, the limit for initial memory pages remains at
32767 (just under 2GiB), while the limit for maximum memory pages is
increased to 65536 (4GiB).
Spec tests are brought in line with these definitions (they actually did
not reflect the spec text before).

Fixes: #1116.