### PR TITLE
[spec] Fix links to indices in exportdesc text format syntax definition

### DIFF
--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -422,13 +422,13 @@ The syntax for exports mirrors their :ref:`abstract syntax <syntax-export>` dire
      \text{(}~\text{export}~~\X{nm}{:}\Tname~~d{:}\Texportdesc_I~\text{)}
        &\Rightarrow& \{ \ENAME~\X{nm}, \EDESC~d \} \\
    \production{export description} & \Texportdesc_I &::=&
-     \text{(}~\text{func}~~x{:}\Bfuncidx_I~\text{)}
+     \text{(}~\text{func}~~x{:}\Tfuncidx_I~\text{)}
        &\Rightarrow& \EDFUNC~x \\ &&|&
-     \text{(}~\text{table}~~x{:}\Btableidx_I~\text{)}
+     \text{(}~\text{table}~~x{:}\Ttableidx_I~\text{)}
        &\Rightarrow& \EDTABLE~x \\ &&|&
-     \text{(}~\text{memory}~~x{:}\Bmemidx_I~\text{)}
+     \text{(}~\text{memory}~~x{:}\Tmemidx_I~\text{)}
        &\Rightarrow& \EDMEM~x \\ &&|&
-     \text{(}~\text{global}~~x{:}\Bglobalidx_I~\text{)}
+     \text{(}~\text{global}~~x{:}\Tglobalidx_I~\text{)}
        &\Rightarrow& \EDGLOBAL~x \\
    \end{array}
 


### PR DESCRIPTION
In [`exportdesc` text format syntax definition](https://webassembly.github.io/spec/core/text/modules.html#text-exportdesc), links to indices (`funcidx`, `tableidx`, `memidx`, `globalidx`) are linked to [the definitions in binary format](https://webassembly.github.io/spec/core/binary/modules.html#indices). If I'm correctly understanding the spec of text format, this seems a mistake. They should be linked to [the definitions in text format](https://webassembly.github.io/spec/core/text/modules.html#indices).

This PR fixes the links.