### PR TITLE
Allow test compilation on Python 3.6

### DIFF
--- a/test/build.py
+++ b/test/build.py
@@ -21,7 +21,6 @@ WPT_URL_PREFIX = '/resources'
 # Helpers.
 def run(*cmd):
     return subprocess.run(cmd,
-                          text=True,
                           stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT,
                           universal_newlines=True)


### PR DESCRIPTION
The `text` parameter (added in Python 3.7) is simply an alias for `universal_newlines` (added in Python 3.5), which we are already passing.  Remove the duplicate keyword argument to allow tests to generate on Ubuntu 18.04, which has Python 3.6.