### PR TITLE
[test] Get the value of a WebAssembly.Global in JS test_harness

### DIFF
--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -362,7 +362,8 @@ function get(instance, name) {
   const loc = new Error().stack.toString().replace("Error", "");
   chain = Promise.all([instance, chain]).then(
     values => {
-      return values[0].exports[name];
+      let v = values[0].exports[name];
+      return (v instanceof WebAssembly.Global) ? v.value : v;
     },
     _ => {
       uniqueTest(_ => {

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -224,7 +224,8 @@ function get(instance, name) {
     if (instance.isError())
         return instance;
 
-    return ValueResult(instance.value.exports[name]);
+    let v = instance.value.exports[name];
+    return ValueResult((v instanceof WebAssembly.Global) ? v.value : v);
 }
 
 function exports(name, instance) {


### PR DESCRIPTION
The following test was failing in SpiderMonkey:

(module $Global
  (export "e" (global $g))
  (global $g i32 (i32.const 42))
)
(assert_return (get "e") (i32.const 42))

The issue was a generated call to index.js `get` which would return the
exported WebAssembly.Global object and compare it to a literal 42.

The harness emitted by js.ml seems to include this check. Not sure why
that's a separate harness, but for now it seems good to have the check
in all harnesses.