### PR TITLE
Set travis env to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c++
 language: python
 python:
-  - "2.7"
+  - "3.7"
 
 sudo: on
 
@@ -15,7 +15,6 @@ install:
   - sudo pip install sphinx==1.7.9
   - sudo apt-get install texlive-full yarn
   - git clone https://github.com/tabatkins/bikeshed.git
-  - git -C $PWD/bikeshed checkout 087ea90e1ebd0321c20373d89950d1c6b73d5df1
   - pip install --editable $PWD/bikeshed
   - bikeshed update
 

--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: latin-1 -*-
 
 import os

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: latin-1 -*-
 
 import queue

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -239,7 +239,7 @@ def Main():
       q.task_done()
       sys.stderr.write('.')
 
-  q = Queue.Queue()
+  q = queue.Queue()
   for i in range(40):
     t = threading.Thread(target=Worker)
     t.daemon = True

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: latin-1 -*-
 
-import Queue
+import queue
 import os
 import re
 import shelve

--- a/test/core/run.py
+++ b/test/core/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import argparse


### PR DESCRIPTION
Bikeshed requires 3.7, see
https://github.com/tabatkins/bikeshed/issues/321#issuecomment-601295711

I don't think we can run both 2.7 and 3.7 in travis, we will need to to use 2 different versions of bikeshed, but no way to specific which version of bikeshed in which version of python (could be wrong).