### PR TITLE
Fix python3 incompatibilities in script

### DIFF
--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -84,7 +84,7 @@ def ReplaceMath(cache, data):
   data = re.sub('([^\\\\])[$]', '\\1', data)
   data = '\\mathrm{' + data + '}'
 
-  if cache.has_key(data):
+  if data in cache:
     return cache[data]
 
   macros = {}
@@ -99,7 +99,7 @@ def ReplaceMath(cache, data):
     value = parts[name_end+len('#1'):end]
     macros[name] = value
     data = data[:start] + data[end:]
-  for k, v in macros.iteritems():
+  for k, v in macros.items():
     while True:
       start, end = FindMatching(data, k + '{')
       if start is None:
@@ -107,7 +107,7 @@ def ReplaceMath(cache, data):
       data = data[:start] + v.replace('#1', data[start+len(k):end]) + data[end:]
   p = subprocess.Popen(
       ['node', os.path.join(SCRIPT_DIR, 'katex/cli.js'), '--display-mode'],
-      stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+      stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
   ret = p.communicate(input=data)[0]
   if p.returncode != 0:
     sys.stderr.write('BEFORE:\n' + old + '\n')


### PR DESCRIPTION
1. shelve.DbfilenameShelf no longer has has_key, use `in`
2. dict no longer has iteritems(), use items()
3. open subprocess as text, since we are passing text to it

This will fix the errors mentioned in https://github.com/WebAssembly/spec/pull/1151#issuecomment-603961826