### PR TITLE
Clean up deprecated options, silence warnings.

### DIFF
--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -17,7 +17,7 @@ NEWMATHJAX    = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/document/core/util/mathdef.py
+++ b/document/core/util/mathdef.py
@@ -111,9 +111,11 @@ class MathdefDirective(Replace):
 
 def setup(app):
   app.add_node(math,
+               override = True,
                html = (ext_html_visit_math, None),
                latex = (ext_latex_visit_math, None))
   app.add_node(displaymath,
+               override = True,
                html = (ext_html_visit_displaymath, None),
                latex = (ext_latex_visit_displaymath, None))
   app.add_role('math', ext_math_role)


### PR DESCRIPTION
latex_paper_size is deprecated since 1.6.1 [0]. Also add override
keyword when adding node to silence the warnings.

[0] https://www.sphinx-doc.org/en/master/changes.html#id100