### PR TITLE
Upgrade Sphinx to 2.3.0 and fixes to extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - ./interpreter/meta/travis/install-ocaml.sh
-  - sudo pip install sphinx==1.7.9
+  - sudo pip install sphinx==2.3.0
   - sudo apt-get install texlive-full yarn
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - ./interpreter/meta/travis/install-ocaml.sh
-  - sudo pip install Sphinx==2.3.0
+  - pip install Sphinx==2.3.0
   - sudo apt-get install texlive-full yarn
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - ./interpreter/meta/travis/install-ocaml.sh
-  - sudo pip install sphinx==2.3.0
+  - sudo pip install Sphinx==2.3.0
   - sudo apt-get install texlive-full yarn
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed

--- a/document/core/util/mathdef.py
+++ b/document/core/util/mathdef.py
@@ -41,6 +41,8 @@ def latex_transform_math_xref(node):
   new_text = xref_re.sub(lambda m: latex_hyperlink(m.group(1), m.group(2)), node.astext())
   node.children[0] = nodes.Text(new_text)
 
+# TODO: this is duplicated from sphinx.writers.latex.LaTeXTranslator, figure out
+# a better way to extend it so that we don't have to duplicate this code.
 def latex_visit_math(self, node):
   if self.in_title:
       self.body.append(r'\protect\(%s\protect\)' % node.astext())
@@ -52,6 +54,8 @@ def ext_latex_visit_math(self, node):
   latex_transform_math_xref(node)
   latex_visit_math(self, node)
 
+# TODO: this is duplicated from sphinx.writers.latex.LaTeXTranslator, figure out
+# a better way to extend it so that we don't have to duplicate this code.
 def latex_visit_displaymath(self, node):
   if node.get('label'):
       label = "equation:%s:%s" % (node['docname'], node['label'])
@@ -120,6 +124,7 @@ class MathdefDirective(Replace):
     doc = self.state.document
     if not hasattr(doc, 'mathdefs'):
       doc.mathdefs = {}
+    # TODO: we don't ever hit the case where len(self.content) > 1
     for i, s in enumerate(self.content):
       self.content[i] = replace_mathdefs(doc, s)
     doc.mathdefs[name] = [arity, ''.join(self.content)]

--- a/document/core/util/mathdef.py
+++ b/document/core/util/mathdef.py
@@ -1,13 +1,12 @@
 from sphinx.ext.mathbase import math
 from sphinx.ext.mathbase import displaymath
-from sphinx.ext.mathbase import math_role
 from sphinx.ext.mathbase import MathDirective
-from sphinx.ext.mathbase import latex_visit_math
-from sphinx.ext.mathbase import latex_visit_displaymath
 from sphinx.ext.mathjax import html_visit_math
 from sphinx.ext.mathjax import html_visit_displaymath
 from sphinx.util.texescape import tex_escape_map, tex_replace_map
+from docutils import nodes, utils
 from docutils.parsers.rst.directives.misc import Replace
+from docutils.parsers.rst.roles import math_role
 from six import text_type
 import re
 
@@ -20,8 +19,8 @@ def html_hyperlink(file, id):
   return '\\href{../%s.html#%s}' % (file, id.replace('_', '-'))
 
 def html_transform_math_xref(node):
-  node['latex'] = \
-    xref_re.sub(lambda m: html_hyperlink(m.group(1), m.group(2)), node['latex'])
+  new_text = xref_re.sub(lambda m: html_hyperlink(m.group(1), m.group(2)), node.astext())
+  node.children[0] = nodes.Text(new_text)
 
 def ext_html_visit_math(self, node):
   html_transform_math_xref(node)
@@ -39,12 +38,35 @@ def latex_hyperlink(file, id):
   return '\\hyperref[%s:%s]' % (file, id)
 
 def latex_transform_math_xref(node):
-  node['latex'] = \
-    xref_re.sub(lambda m: latex_hyperlink(m.group(1), m.group(2)), node['latex'])
+  new_text = xref_re.sub(lambda m: latex_hyperlink(m.group(1), m.group(2)), node.astext())
+  node.children[0] = nodes.Text(new_text)
+
+def latex_visit_math(self, node):
+  if self.in_title:
+      self.body.append(r'\protect\(%s\protect\)' % node.astext())
+  else:
+      self.body.append(r'\(%s\)' % node.astext())
+  raise nodes.SkipNode
 
 def ext_latex_visit_math(self, node):
   latex_transform_math_xref(node)
   latex_visit_math(self, node)
+
+def latex_visit_displaymath(self, node):
+  if node.get('label'):
+      label = "equation:%s:%s" % (node['docname'], node['label'])
+  else:
+      label = None
+
+  if node.get('nowrap'):
+      if label:
+          self.body.append(r'\label{%s}' % label)
+      self.body.append(node.astext())
+  else:
+      from sphinx.util.math import wrap_displaymath
+      self.body.append(wrap_displaymath(node.astext(), label,
+                                        self.builder.config.math_number_all))
+  raise nodes.SkipNode
 
 def ext_latex_visit_displaymath(self, node):
   latex_transform_math_xref(node)
@@ -75,8 +97,7 @@ def replace_mathdefs(doc, s):
 
 def ext_math_role(role, raw, text, line, inliner, options = {}, content = []):
   text = replace_mathdefs(inliner.document, raw.split('`')[1])
-  return math_role(role, raw, text, line, inliner, options = options,
-                   content = content)
+  return [math(raw, text)], []
 
 class ExtMathDirective(MathDirective):
   def run(self):


### PR DESCRIPTION
Couple of breaking changes due to the Sphinx upgrade, requiring fixes:

1. node['latex'] is an invalid access. It was used when Sphinx created
custom math nodes for the math role. But now that docutils supports it,
we don't need to do this anymore.
2. we copied latex_visit_math and latex_visit_displaymath from sphinx's
LaTeXTranslator visit_math and visit_math_block, we can't call them
directly because those call respective superclass methods, and since we
call add_node, it will override those methods with ext_latex_visit_math,
and ending up in a stack overflow.
3. directly create a math node rather than calling into docutils
math_role, because it only looks at raw_text, and overrides text,
which contains what we care about (latex code).
4. Similar changes to mathdefbs

Finally we can pin the Sphinx version to 2.3.0 in .travis.yml.

I mostly manually verified that this change is okay, looking at the html
(multi-page), html (single-page), and pdf, checking the math equations,
both inline and block, making sure the links still work.

Issue #1157