### PR TITLE
[interpreter/test] Table limits

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -310,11 +310,11 @@ and check_block (c : context) (es : instr list) (ts : stack_type) at =
 (* Types *)
 
 let check_limits {min; max} range at msg =
-  require (I64.le_u (Int64.of_int32 min) range) at msg;
+  require (I64.le_u (I64_convert.extend_i32_u min) range) at msg;
   match max with
   | None -> ()
   | Some max ->
-    require (I64.le_u (Int64.of_int32 max) range) at msg;
+    require (I64.le_u (I64_convert.extend_i32_u max) range) at msg;
     require (I32.le_u min max) at
       "size minimum must not be greater than maximum"
 
@@ -329,7 +329,7 @@ let check_func_type (ft : func_type) at =
 
 let check_table_type (tt : table_type) at =
   let TableType (lim, _) = tt in
-  check_limits lim 0x1_0000_0000L at "table size must be at most 2^32"
+  check_limits lim 0xffff_ffffL at "table size must be at most 2^32-1"
 
 let check_memory_type (mt : memory_type) at =
   let MemoryType lim = mt in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -310,11 +310,11 @@ and check_block (c : context) (es : instr list) (ts : stack_type) at =
 (* Types *)
 
 let check_limits {min; max} range at msg =
-  require (I64.le_u (I64_convert.extend_i32_u min) range) at msg;
+  require (I32.le_u min range) at msg;
   match max with
   | None -> ()
   | Some max ->
-    require (I64.le_u (I64_convert.extend_i32_u max) range) at msg;
+    require (I32.le_u max range) at msg;
     require (I32.le_u min max) at
       "size minimum must not be greater than maximum"
 
@@ -329,11 +329,11 @@ let check_func_type (ft : func_type) at =
 
 let check_table_type (tt : table_type) at =
   let TableType (lim, _) = tt in
-  check_limits lim 0xffff_ffffL at "table size must be at most 2^32-1"
+  check_limits lim 0xffff_ffffl at "table size must be at most 2^32-1"
 
 let check_memory_type (mt : memory_type) at =
   let MemoryType lim = mt in
-  check_limits lim 0x1_0000L at
+  check_limits lim 0x1_0000l at
     "memory size must be at most 65536 pages (4GiB)"
 
 let check_global_type (gt : global_type) at =

--- a/test/core/memory.wast
+++ b/test/core/memory.wast
@@ -1,5 +1,7 @@
 ;; Test memory section structure
 
+(module (memory 0))
+(module (memory 1))
 (module (memory 0 0))
 (module (memory 0 1))
 (module (memory 1 256))
@@ -72,6 +74,19 @@
 (assert_invalid
   (module (memory 0 4294967295))
   "memory size must be at most 65536 pages (4GiB)"
+)
+
+(assert_malformed
+  (module quote "(memory 0x1_0000_0000)")
+  "i32 constant out of range"
+)
+(assert_malformed
+  (module quote "(memory 0x1_0000_0000 0x1_0000_0000)")
+  "i32 constant out of range"
+)
+(assert_malformed
+  (module quote "(memory 0 0x1_0000_0000)")
+  "i32 constant out of range"
 )
 
 (module

--- a/test/core/table.wast
+++ b/test/core/table.wast
@@ -1,3 +1,43 @@
+;; Test table section structure
+
+(module (table 0 funcref))
+(module (table 1 funcref))
+(module (table 0 0 funcref))
+(module (table 0 1 funcref))
+(module (table 1 256 funcref))
+(module (table 0 65536 funcref))
+(module (table 0 0xffff_ffff funcref))
+
+(assert_invalid (module (table 0 funcref) (table 0 funcref)) "multiple tables")
+(assert_invalid (module (table (import "spectest" "table") 0 funcref) (table 0 funcref)) "multiple tables")
+
+(assert_invalid (module (elem (i32.const 0))) "unknown table")
+(assert_invalid (module (elem (i32.const 0) $f) (func $f)) "unknown table")
+
+
+(assert_invalid
+  (module (table 1 0 funcref))
+  "size minimum must not be greater than maximum"
+)
+(assert_invalid
+  (module (table 0xffff_ffff 0 funcref))
+  "size minimum must not be greater than maximum"
+)
+
+(assert_malformed
+  (module quote "(table 0x1_0000_0000 funcref)")
+  "i32 constant out of range"
+)
+(assert_malformed
+  (module quote "(table 0x1_0000_0000 0x1_0000_0000 funcref)")
+  "i32 constant out of range"
+)
+(assert_malformed
+  (module quote "(table 0 0x1_0000_0000 funcref)")
+  "i32 constant out of range"
+)
+
+
 ;; Duplicate table identifiers
 
 (assert_malformed (module quote


### PR DESCRIPTION
Remove bogus signed i32->i64 conversion on limit values and fix upper limit for table size. Add tests for table limits.

Fixes #1158.
