### PR TITLE
[spec] Fix TeX maxbuffer option for MathJax

### DIFF
--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -480,7 +480,7 @@ rst_prolog = """
 """
 
 # https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax_config
-# https://docs.mathjax.org/en/latest/options/input/tex.html#the-configuration-block
+# http://docs.mathjax.org/en/v2.7-latest/options/input-processors/TeX.html
 mathjax_config = {
     'TeX': { 'MAXBUFFER': 30*1024 },
 }

--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -482,5 +482,5 @@ rst_prolog = """
 # https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax_config
 # https://docs.mathjax.org/en/latest/options/input/tex.html#the-configuration-block
 mathjax_config = {
-    'tex': { 'maxBuffer': 30*1024 },
+    'TeX': { 'MAXBUFFER': 30*1024 },
 }


### PR DESCRIPTION
When we upgraded Sphinx, the MathJax version changed, which has a
different way of configuring TeX options. This resulted in TeX's
maxbuffer not being set right, and so processing stopped.

Fixes #1166