### PR TITLE
Remove unneeded PATH modifications

### DIFF
--- a/interpreter/meta/travis/build-test.sh
+++ b/interpreter/meta/travis/build-test.sh
@@ -7,6 +7,4 @@ set -x
 # from anywhere.
 cd $(dirname ${BASH_SOURCE[0]})/../..
 
-export PATH=$PWD/../ocaml/install/bin:$PATH
-
 make all


### PR DESCRIPTION
With #1162, we install ocaml via apt, not via our download script, so we
no longer need to modify the PATH to find ocaml.