### PR TITLE
[interpreter] Strictify and specify .bin.wast format

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -518,7 +518,7 @@ where:
    S', \globaladdr^\ast &=& \allocglobal^\ast(S_3, (\global.\GTYPE)^\ast, \val^\ast)
      \qquad\quad~ (\where \global^\ast = \module.\MGLOBALS) \\
    \exportinst^\ast &=& \{ \EINAME~(\export.\ENAME), \EIVALUE~\externval_{\F{ex}} \}^\ast
-     \quad (\where \export^\ast = \module.\MEXPORTS) \\[1ex]
+     \quadd (\where \export^\ast = \module.\MEXPORTS) \\[1ex]
    \evfuncs(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MIFUNCS[x])^\ast
      \qquad~ (\where x^\ast = \edfuncs(\module.\MEXPORTS)) \\
    \evtables(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MITABLES[x])^\ast

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -518,7 +518,7 @@ where:
    S', \globaladdr^\ast &=& \allocglobal^\ast(S_3, (\global.\GTYPE)^\ast, \val^\ast)
      \qquad\quad~ (\where \global^\ast = \module.\MGLOBALS) \\
    \exportinst^\ast &=& \{ \EINAME~(\export.\ENAME), \EIVALUE~\externval_{\F{ex}} \}^\ast
-     \quadd (\where \export^\ast = \module.\MEXPORTS) \\[1ex]
+     \quad (\where \export^\ast = \module.\MEXPORTS) \\[1ex]
    \evfuncs(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MIFUNCS[x])^\ast
      \qquad~ (\where x^\ast = \edfuncs(\module.\MEXPORTS)) \\
    \evtables(\externval_{\F{ex}}^\ast) &=& (\moduleinst.\MITABLES[x])^\ast

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -164,8 +164,8 @@ The implementation consumes a WebAssembly AST given in S-expression syntax. Here
 
 Note: The grammar is shown here for convenience, the definite source is the [specification of the text format](https://webassembly.github.io/spec/core/text/).
 ```
-num:    <digit> (_? <digit>)*
-hexnum: <hexdigit> (_? <hexdigit>)*
+num:    <digit>(_? <digit>)*
+hexnum: <hexdigit>(_? <hexdigit>)*
 nat:    <num> | 0x<hexnum>
 int:    <nat> | +<nat> | -<nat>
 float:  <num>.<num>?(e|E <num>)? | 0x<hexnum>.<hexnum>?(p|P <num>)?
@@ -356,10 +356,61 @@ A module of the form `(module quote <string>*)` is given in textual form and wil
 There are also a number of meta commands.
 The `script` command is a simple mechanism to name sub-scripts themselves. This is mainly useful for converting scripts with the `output` command. Commands inside a `script` will be executed normally, but nested meta are expanded in place (`input`, recursively) or elided (`output`) in the named script.
 
-The `input` and `output` meta commands determine the requested file format from the file name extension. They can handle both `.wasm`, `.wat`, and `.wast` files. In the case of input, a `.wast` script will be recursively executed. Output additionally handles `.js` as a target, which will convert the referenced script to an equivalent, self-contained JavaScript runner. It also recognises `.bin.wast` specially, which creates a script where module definitions are in binary.
+The `input` and `output` meta commands determine the requested file format from the file name extension. They can handle both `.wasm`, `.wat`, and `.wast` files. In the case of input, a `.wast` script will be recursively executed. Output additionally handles `.js` as a target, which will convert the referenced script to an equivalent, self-contained JavaScript runner. It also recognises `.bin.wast` specially, which creates a _binary script_ where module definitions are in binary, as defined below.
 
 The interpreter supports a "dry" mode (flag `-d`), in which modules are only validated. In this mode, all actions and assertions are ignored.
 It also supports an "unchecked" mode (flag `-u`), in which module definitions are not validated before use.
+
+### Binary Scripts
+
+The grammar of binary scripts is a subset of the grammar for general scripts:
+```
+binscript: <cmd>*
+
+cmd:
+  <module>                                   ;; define, validate, and initialize module
+  ( register <string> <name>? )              ;; register module for imports
+module with given failure string
+  <action>                                   ;; perform action and print results
+  <assertion>                                ;; assert result of an action
+
+module:
+  ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)
+
+action:
+  ( invoke <name>? <string> <expr>* )        ;; invoke function export
+  ( get <name>? <string> )                   ;; get global export
+
+assertion:
+  ( assert_return <action> <result>* )       ;; assert action has expected results
+  ( assert_trap <action> <failure> )         ;; assert action traps with given failure string
+  ( assert_exhaustion <action> <failure> )   ;; assert action exhausts system resources
+  ( assert_malformed <module> <failure> )    ;; assert module cannot be decoded with given failure string
+  ( assert_invalid <module> <failure> )      ;; assert module is invalid with given failure string
+  ( assert_unlinkable <module> <failure> )   ;; assert module fails to link
+  ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
+
+result:
+  ( <val_type>.const <numpat> )
+
+numpat:
+  <value>                                    ;; literal result
+  nan:canonical                              ;; NaN in canonical form
+  nan:arithmetic                             ;; NaN with 1 in MSB of payload
+
+value:  <int> | <float>
+int:    0x<hexnum>
+float:  0x<hexnum>.<hexnum>?(p|P <num>)?
+hexnum: <hexdigit>(_? <hexdigit>)*
+
+name:   $(<letter> | <digit> | _ | . | + | - | * | / | \ | ^ | ~ | = | < | > | ! | ? | @ | # | $ | % | & | | | : | ' | `)+
+string: "(<char> | \n | \t | \\ | \' | \" | \<hex><hex> | \u{<hex>+})*"
+```
+This grammar removes meta commands, textual and quoted modules.
+All numbers are in hex notation.
+
+Moreover, float values are required to be precise, that is, they may not contain bits that would lead to rounding.
+
 
 ## Abstract Syntax
 

--- a/interpreter/exec/i32.ml
+++ b/interpreter/exec/i32.ml
@@ -4,4 +4,5 @@ include Int.Make
   (struct
     include Int32
     let bitwidth = 32
+    let to_hex_string = Printf.sprintf "%lx"
   end)

--- a/interpreter/exec/i64.ml
+++ b/interpreter/exec/i64.ml
@@ -4,4 +4,5 @@ include Int.Make
   (struct
     include Int64
     let bitwidth = 64
+    let to_hex_string = Printf.sprintf "%Lx"
   end)

--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -26,6 +26,7 @@ sig
   val of_int : int -> t
   val to_int : t -> int
   val to_string : t -> string
+  val to_hex_string : t -> string
 
   val bitwidth : int
 end
@@ -77,6 +78,7 @@ sig
   val of_string : string -> t
   val to_string_s : t -> string
   val to_string_u : t -> string
+  val to_hex_string : t -> string
 end
 
 module Make (Rep : RepType) : S with type bits = Rep.t and type t = Rep.t =
@@ -277,25 +279,27 @@ struct
 
   (* String conversion that groups digits for readability *)
 
-  let rec add_digits buf s i j k =
+  let rec add_digits buf s i j k n =
     if i < j then begin
       if k = 0 then Buffer.add_char buf '_';
       Buffer.add_char buf s.[i];
-      add_digits buf s (i + 1) j ((k + 2) mod 3)
+      add_digits buf s (i + 1) j ((k + n - 1) mod n) n
     end
 
-  let group_digits s =
+  let group_digits n s =
     let len = String.length s in
     let num = if s.[0] = '-' then 1 else 0 in
-    let buf = Buffer.create (len*4/3) in
+    let buf = Buffer.create (len*(n+1)/n) in
     Buffer.add_substring buf s 0 num;
-    add_digits buf s num len ((len - num) mod 3 + 3);
+    add_digits buf s num len ((len - num) mod n + n) n;
     Buffer.contents buf
 
-  let to_string_s i = group_digits (Rep.to_string i)
+  let to_string_s i = group_digits 3 (Rep.to_string i)
   let to_string_u i =
     if i >= Rep.zero then
-      group_digits (Rep.to_string i)
+      group_digits 3 (Rep.to_string i)
     else
-      group_digits (Rep.to_string (div_u i ten) ^ Rep.to_string (rem_u i ten))
+      group_digits 3 (Rep.to_string (div_u i ten) ^ Rep.to_string (rem_u i ten))
+
+  let to_hex_string i = "0x" ^ group_digits 4 (Rep.to_hex_string i)
 end

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -467,4 +467,4 @@ let command mode cmd =
   | Assertion ass -> assertion mode ass
   | Meta _ -> assert false
 
-let script mode scr = List.concat_map (command mode) scr
+let script mode scr = Lib.List.concat_map (command mode) scr

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -101,6 +101,10 @@ struct
       match f x with
       | None -> map_filter f xs
       | Some y -> y :: map_filter f xs
+
+  let rec concat_map f = function
+    | [] -> []
+    | x::xs -> f x @ concat_map f xs
 end
 
 module List32 =

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -21,6 +21,7 @@ sig
   val index_of : 'a -> 'a list -> int option
   val index_where : ('a -> bool) -> 'a list -> int option
   val map_filter : ('a -> 'b option) -> 'a list -> 'b list
+  val concat_map : ('a -> 'b list) -> 'a list -> 'b list
 end
 
 module List32 :


### PR DESCRIPTION
Add a specification of the subset grammar produced by binary (.bin.wast) conversion. In particular, this grammar excludes meta commands, textual or quoted modules, and non-hex or imprecise values.

Accordingly, change interpreter to produce hex floats and numbers in binary output mode and omit quoted modules.