### PR TITLE
[js-api] Bump limit for initial memory size to 4GiB

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1126,8 +1126,7 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum size of a table is 10000000.</li>
 <li>The maximum number of table entries in any table initialization is 10000000.</li>
 <li>The maximum number of memories, including declared or imported memories, is 1.</li>
-<li>The initial number of pages for any memory, declared or imported, is at most 32767.</li>
-<li>The maximum number of pages for any memory, declared or imported, is at most 65536.</li>
+<li>The initial or maximum number of pages for any memory, declared or imported, is at most 65536.</li>
 
 <li>The maximum number of parameters to any function is 1000.</li>
 <li>The maximum number of return values for any function is 1.</li>

--- a/test/js-api/limits.any.js
+++ b/test/js-api/limits.any.js
@@ -9,8 +9,7 @@ const kJSEmbeddingMaxExports = 100000;
 const kJSEmbeddingMaxGlobals = 1000000;
 const kJSEmbeddingMaxDataSegments = 100000;
 
-const kJSEmbeddingMaxInitialMemoryPages = 32767;
-const kJSEmbeddingMaxMaximumMemoryPages = 65536;
+const kJSEmbeddingMaxMemoryPages = 65536;
 const kJSEmbeddingMaxModuleSize = 1024 * 1024 * 1024;  // = 1 GiB
 const kJSEmbeddingMaxFunctionSize = 7654321;
 const kJSEmbeddingMaxFunctionLocals = 50000;
@@ -110,22 +109,22 @@ testLimit("data segments", 1, kJSEmbeddingMaxDataSegments, (builder, count) => {
         }
     });
 
-testLimit("initial declared memory pages", 1, kJSEmbeddingMaxInitialMemoryPages,
+testLimit("initial declared memory pages", 1, kJSEmbeddingMaxMemoryPages,
           (builder, count) => {
             builder.addMemory(count, undefined, false, false);
           });
 
-testLimit("maximum declared memory pages", 1, kJSEmbeddingMaxMaximumMemoryPages,
+testLimit("maximum declared memory pages", 1, kJSEmbeddingMaxMemoryPages,
           (builder, count) => {
             builder.addMemory(1, count, false, false);
           });
 
-testLimit("initial imported memory pages", 1, kJSEmbeddingMaxInitialMemoryPages,
+testLimit("initial imported memory pages", 1, kJSEmbeddingMaxMemoryPages,
           (builder, count) => {
             builder.addImportedMemory("mod", "mem", count, undefined);
           });
 
-testLimit("maximum imported memory pages", 1, kJSEmbeddingMaxMaximumMemoryPages,
+testLimit("maximum imported memory pages", 1, kJSEmbeddingMaxMemoryPages,
           (builder, count) => {
             builder.addImportedMemory("mod", "mem", 1, count);
           });


### PR DESCRIPTION
As agreed upon in the CG meeting earlier this week, we can allow 4GB in both the initial and maximum memory sizes, and not just the maximum.

Followup to #1121 which raised the limit to the initial size.