### PR TITLE
Add more address overflow tests

### DIFF
--- a/test/core/address.wast
+++ b/test/core/address.wast
@@ -191,6 +191,13 @@
 (assert_return (invoke "32_good4" (i32.const 65508)) (i32.const 0))
 (assert_trap (invoke "32_good5" (i32.const 65508)) "out of bounds memory access")
 
+(assert_trap (invoke "8u_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "8s_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "16u_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "16s_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "32_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "32_good3" (i32.const -1)) "out of bounds memory access")
+
 (assert_trap (invoke "8u_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "8s_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "16u_bad" (i32.const 0)) "out of bounds memory access")
@@ -478,6 +485,14 @@
 (assert_return (invoke "64_good4" (i32.const 65504)) (i64.const 0))
 (assert_trap (invoke "64_good5" (i32.const 65504)) "out of bounds memory access")
 
+(assert_trap (invoke "8u_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "8s_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "16u_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "16s_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "32u_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "32s_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "64_good3" (i32.const -1)) "out of bounds memory access")
+
 (assert_trap (invoke "8u_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "8s_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "16u_bad" (i32.const 0)) "out of bounds memory access")
@@ -538,6 +553,9 @@
 (assert_return (invoke "32_good4" (i32.const 65525)) (f32.const 0.0))
 (assert_trap (invoke "32_good5" (i32.const 65525)) "out of bounds memory access")
 
+(assert_trap (invoke "32_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "32_good3" (i32.const -1)) "out of bounds memory access")
+
 (assert_trap (invoke "32_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "32_bad" (i32.const 1)) "out of bounds memory access")
 
@@ -584,6 +602,9 @@
 (assert_return (invoke "64_good3" (i32.const 65511)) (f64.const 0.0))
 (assert_return (invoke "64_good4" (i32.const 65511)) (f64.const 0.0))
 (assert_trap (invoke "64_good5" (i32.const 65511)) "out of bounds memory access")
+
+(assert_trap (invoke "64_good3" (i32.const -1)) "out of bounds memory access")
+(assert_trap (invoke "64_good3" (i32.const -1)) "out of bounds memory access")
 
 (assert_trap (invoke "64_bad" (i32.const 0)) "out of bounds memory access")
 (assert_trap (invoke "64_bad" (i32.const 1)) "out of bounds memory access")


### PR DESCRIPTION
There are already tests for effective address overflow, but those have a
large value baked into the offset. These tests all use `1` as the
immediate offset, and use `-1` for the address on the stack, which may
be compiled differently.