### PR TITLE
[interpreter] Fix compilation warnings; upgrade to OCaml >=4.07

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,21 @@ dist: bionic
 addons:
   apt:
     sources:
+      - sourceline: 'ppa:avsm/ppa'
       - sourceline: 'deb https://dl.yarnpkg.com/debian/ stable main'
         key_url: 'https://dl.yarnpkg.com/debian/pubkey.gpg'
+    update: true
     packages:
-      - ocaml
-      - ocamlbuild
+      - opam
       - texlive-full
       - yarn
 
 install:
+  - opam init --auto-setup --compiler=4.07.1
+  - eval $(opam env)
+  - opam --version
+  - ocaml --version
+  - opam install --yes ocamlbuild.0.14.0
   - pip install Sphinx==2.4.4
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -15,7 +15,7 @@ The text format defines modules in S-expression syntax. Moreover, it is generali
 
 ## Building
 
-You'll need OCaml 4.02 or higher. An easy way to get this on Linux is to download the [source tarball from our mirror of the ocaml website](https://wasm.storage.googleapis.com/ocaml-4.02.2.tar.gz) and do the configure / make dance.  On macOS, with [Homebrew](http://brew.sh/) installed, simply `brew install ocaml ocamlbuild`.
+You'll need OCaml 4.07 or higher. Instructions for installing a recent version of OCaml on multiple platforms are available [here](https://ocaml.org/docs/install.html). On most platforms, the recommended way is through [OPAM](https://ocaml.org/docs/install.html#OPAM).
 
 Once you have OCaml, simply do
 
@@ -43,17 +43,20 @@ That builds `all`, plus updates `winmake.bat`.
 
 #### Building on Windows
 
-We recommend a pre-built installer. With [this one](https://protz.github.io/ocaml-installer/) you have two options:
+The instructions depend on how you [installed OCaml on Windows](https://ocaml.org/docs/install.html#Windows).
 
-1. Bare OCaml. If you just want to build the interpreter and don't care about modifying it, you don't need to install the Cygwin core that comes with the installer. Just install OCaml itself and run
+1. *Cygwin*: If you want to build a native code executable, or want to hack on the interpreter (i.e., use incremental compilation), then you need to install the Cygwin core that is included with the OCaml installer. Then you can build the interpreter using `make` in the Cygwin terminal, as described above.
+
+2. *Windows Subsystem for Linux* (WSL): You can build the interpreter using `make`, as described above.
+
+3. *From source*: If you just want to build the interpreter and don't care about modifying it, you don't need to install the Cygwin core that comes with the installer. Just install OCaml itself and run
 ```
 winmake.bat
 ```
 in a Windows shell, which creates a program named `wasm`. Note that this will be a byte code executable only, i.e., somewhat slower.
 
-2. OCaml + Cygwin. If you want to build a native code executable, or want to hack on the interpreter (i.e., use incremental compilation), then you need to install the Cygwin core that is included with the OCaml installer. Then you can build the interpreter using `make` in the Cygwin terminal, as described above.
+In any way, in order to run the test suite you'll need to have Python installed. If you used Option 3, you can invoke the test runner `runtests.py` directly instead of doing it through `make`.
 
-Either way, in order to run the test suite you'll need to have Python installed. If you used Option 1, you can invoke the test runner `runtests.py` directly instead of doing it through `make`.
 
 
 #### Cross-compiling the Interpreter to JavaScript ####

--- a/interpreter/exec/f32_convert.ml
+++ b/interpreter/exec/f32_convert.ml
@@ -28,20 +28,20 @@ let convert_i32_u x =
  * Values that are too large would get rounded when represented in f64,
  * but double rounding via i64->f64->f32 can produce inaccurate results.
  * Hence, for large values we shift right but make sure to accumulate the lost
- * bits in the least signifant bit, such that rounding still is correct.
+ * bits in the least significant bit, such that rounding still is correct.
  *)
 let convert_i64_s x =
   F32.of_float Int64.(
     if abs x < 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right x 12) r) *. (* TODO(ocaml-4.03): 0x1p12 *) 4096.0
+    to_float (logor (shift_right x 12) r) *. 0x1p12
   )
 
 let convert_i64_u x =
   F32.of_float Int64.(
     if I64.lt_u x 0x10_0000_0000_0000L then to_float x else
     let r = if logand x 0xfffL = 0L then 0L else 1L in
-    to_float (logor (shift_right_logical x 12) r) *. (* TODO(ocaml-4.03): 0x1p12 *) 4096.0
+    to_float (logor (shift_right_logical x 12) r) *. 0x1p12
   )
 
 let reinterpret_i32 = F32.of_bits

--- a/interpreter/exec/float.ml
+++ b/interpreter/exec/float.ml
@@ -138,17 +138,17 @@ struct
   let mul x y = binary x ( *.) y
   let div x y = binary x (/.) y
 
-  let sqrt  x = unary Pervasives.sqrt x
+  let sqrt  x = unary Stdlib.sqrt x
 
-  let ceil  x = unary Pervasives.ceil x
-  let floor x = unary Pervasives.floor x
+  let ceil  x = unary Stdlib.ceil x
+  let floor x = unary Stdlib.floor x
 
   let trunc x =
     let xf = to_float x in
     (* preserve the sign of zero *)
     if xf = 0.0 then x else
     (* trunc is either ceil or floor depending on which one is toward zero *)
-    let f = if xf < 0.0 then Pervasives.ceil xf else Pervasives.floor xf in
+    let f = if xf < 0.0 then Stdlib.ceil xf else Stdlib.floor xf in
     let result = of_float f in
     if is_nan result then determine_unary_nan result else result
 
@@ -157,13 +157,13 @@ struct
     (* preserve the sign of zero *)
     if xf = 0.0 then x else
     (* nearest is either ceil or floor depending on which is nearest or even *)
-    let u = Pervasives.ceil xf in
-    let d = Pervasives.floor xf in
+    let u = Stdlib.ceil xf in
+    let d = Stdlib.floor xf in
     let um = abs_float (xf -. u) in
     let dm = abs_float (xf -. d) in
     let u_or_d =
       um < dm ||
-      um = dm && let h = u /. 2. in Pervasives.floor h = h
+      um = dm && let h = u /. 2. in Stdlib.floor h = h
     in
     let f = if u_or_d then u else d in
     let result = of_float f in
@@ -232,8 +232,8 @@ struct
       | n -> n
 
   let compare_mantissa_str hex s1 s2 =
-    let s1' = String.uppercase s1 in
-    let s2' = String.uppercase s2 in
+    let s1' = String.uppercase_ascii s1 in
+    let s2' = String.uppercase_ascii s2 in
     compare_mantissa_str' hex s1' (skip_zeroes s1' 0) s2' (skip_zeroes s2' 0)
 
   (*
@@ -267,7 +267,7 @@ struct
       if not hex then Printf.sprintf "%.*g" (String.length s) z else
       let m = logor (logand bits 0xf_ffff_ffff_ffffL) 0x10_0000_0000_0000L in
       (* Shift mantissa to match msb position in most significant hex digit *)
-      let i = skip_zeroes (String.uppercase s) 0 in
+      let i = skip_zeroes (String.uppercase_ascii s) 0 in
       if i = String.length s then Printf.sprintf "%.*g" (String.length s) z else
       let sh =
         match s.[i] with '1' -> 0 | '2'..'3' -> 1 | '4'..'7' -> 2 | _ -> 3 in
@@ -300,14 +300,7 @@ struct
       else
         Rep.logor x bare_nan
     else
-      (* TODO(ocmal-4.03): replace buffer hack with this:
       let s' = String.concat "" (String.split_on_char '_' s) in
-      *)
-      let buf = Buffer.create (String.length s) in
-      for i = 0 to String.length s - 1 do
-        if s.[i] <> '_' then Buffer.add_char buf s.[i]
-      done;
-      let s' = Buffer.contents buf in
       let x = of_float (float_of_string_prevent_double_rounding s') in
       if is_inf x then failwith "of_string" else x
 

--- a/interpreter/exec/i64_convert.ml
+++ b/interpreter/exec/i64_convert.ml
@@ -22,7 +22,7 @@ let trunc_f32_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. (* TODO(ocaml-4.03): 0x1p63 *) 9223372036854775808.0)) min_int)
+      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
     else
       Int64.of_float xf
 
@@ -44,7 +44,7 @@ let trunc_f64_u x =
     if xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0 then
       raise Numeric_error.IntegerOverflow
     else if xf >= -.Int64.(to_float min_int) then
-      Int64.(logxor (of_float (xf -. (* TODO(ocaml-4.03): 0x1p63 *) 9223372036854775808.0)) min_int)
+      Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
     else
       Int64.of_float xf
 


### PR DESCRIPTION
Fix deprecated warnings for String.uppercase (deprecated since 4.03.0) and Pervasives (deprecated since 4.08.0). Breaks compatibility with OCaml < 4.07.0. If compatibility is required, [stdlib-shims](https://github.com/ocaml/stdlib-shims) could be used.