### PR TITLE
Move sign-extension-ops before saturating truncation ops.

### DIFF
--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -374,6 +374,16 @@ All other numeric instructions are plain opcodes without any immediates.
      \hex{BF} &\Rightarrow& \F64.\REINTERPRET\K{\_}\I64 \\
    \end{array}
 
+.. math::
+   \begin{array}{llclll}
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
+     \hex{C0} &\Rightarrow& \I32.\EXTEND\K{8\_s} \\ &&|&
+     \hex{C1} &\Rightarrow& \I32.\EXTEND\K{16\_s} \\ &&|&
+     \hex{C2} &\Rightarrow& \I64.\EXTEND\K{8\_s} \\ &&|&
+     \hex{C3} &\Rightarrow& \I64.\EXTEND\K{16\_s} \\ &&|&
+     \hex{C4} &\Rightarrow& \I64.\EXTEND\K{32\_s} \\
+   \end{array}
+
 .. _binary-cvtop-trunc-sat:
 
 The saturating truncation instructions all have a one byte prefix.
@@ -389,17 +399,6 @@ The saturating truncation instructions all have a one byte prefix.
      \hex{FC}~\hex{05} &\Rightarrow& \I64.\TRUNC\K{\_sat\_}\F32\K{\_u} \\ &&|&
      \hex{FC}~\hex{06} &\Rightarrow& \I64.\TRUNC\K{\_sat\_}\F64\K{\_s} \\ &&|&
      \hex{FC}~\hex{07} &\Rightarrow& \I64.\TRUNC\K{\_sat\_}\F64\K{\_u} \\
-   \end{array}
-
-
-.. math::
-   \begin{array}{llclll}
-   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
-     \hex{C0} &\Rightarrow& \I32.\EXTEND\K{8\_s} \\ &&|&
-     \hex{C1} &\Rightarrow& \I32.\EXTEND\K{16\_s} \\ &&|&
-     \hex{C2} &\Rightarrow& \I64.\EXTEND\K{8\_s} \\ &&|&
-     \hex{C3} &\Rightarrow& \I64.\EXTEND\K{16\_s} \\ &&|&
-     \hex{C4} &\Rightarrow& \I64.\EXTEND\K{32\_s} \\
    \end{array}
 
 


### PR DESCRIPTION
Address comment in https://github.com/WebAssembly/spec/pull/1144#issuecomment-629550300.
Looks like this now.

![gQjxU1AQeAz](https://user-images.githubusercontent.com/1749303/82239329-75d84400-98ed-11ea-96bf-244c65aabcc2.png)
