### PR TITLE
Inconsistency of implementation-defined limits

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1122,6 +1122,7 @@ Note: ECMAScript doesn't specify any sort of behavior on out-of-memory condition
 The WebAssembly core specification allows an implementation to define limits on the syntactic structure of the module.
 While each embedding of WebAssembly may choose to define its own limits, for predictability the standard WebAssembly JavaScript Interface described in this document defines the following exact limits.
 An implementation must reject a module that exceeds one of the following limits with a {{CompileError}}:
+In practice, an implementation may run out of resources for valid modules below these limits.
 
 <ul>
 <li>The maximum size of a module is 1073741824 bytes (1 GiB).</li>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1121,8 +1121,7 @@ Note: ECMAScript doesn't specify any sort of behavior on out-of-memory condition
 
 The WebAssembly core specification allows an implementation to define limits on the syntactic structure of the module.
 While each embedding of WebAssembly may choose to define its own limits, for predictability the standard WebAssembly JavaScript Interface described in this document defines the following exact limits.
-An implementation must reject a module that exceeds these limits with a {{CompileError}}.
-In practice, an implementation may run out of resources for valid modules below these limits.
+An implementation must reject a module that exceeds one of the following limits with a {{CompileError}}:
 
 <ul>
 <li>The maximum size of a module is 1073741824 bytes (1 GiB).</li>
@@ -1134,16 +1133,21 @@ In practice, an implementation may run out of resources for valid modules below 
 <li>The maximum number of data segments defined in a module is 100000.</li>
 
 <li>The maximum number of tables, including declared or imported tables, is 1.</li>
-<li>The maximum size of a table is 10000000.</li>
 <li>The maximum number of table entries in any table initialization is 10000000.</li>
 <li>The maximum number of memories, including declared or imported memories, is 1.</li>
-<li>The initial or maximum number of pages for any memory, declared or imported, is at most 65536.</li>
 
 <li>The maximum number of parameters to any function or block is 1000.</li>
 <li>The maximum number of return values for any function or block is 1000.</li>
 <li>The maximum size of a function body, including locals declarations, is 7654321 bytes.</li>
 <li>The maximum number of locals declared in a function, including implicitly declared as parameters, is 50000.</li>
+</ul>
 
+An implementation must throw a {{RuntimeError}} if one of the following limits is exceeded during runtime:
+In practice, an implementation may run out of resources for valid modules below these limits.
+
+<ul>
+<li>The maximum size of a table is 10000000.</li>
+<li>The initial or maximum number of pages for any memory, declared or imported, is at most 65536.</li>
 </ul>
 
 <h2 id="security-considerations">Security and Privacy Considerations</h2>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1147,7 +1147,7 @@ In practice, an implementation may run out of resources for valid modules below 
 
 <ul>
 <li>The maximum size of a table is 10000000.</li>
-<li>The initial or maximum number of pages for any memory, declared or imported, is at most 65536.</li>
+<li>The maximum number of pages of a memory is 65536.</li>
 </ul>
 
 <h2 id="security-considerations">Security and Privacy Considerations</h2>


### PR DESCRIPTION
This PR resolves an inconsistency of implementation-defined limits in the js-api specification, and execution limits in the core specification. The core specification requires under [execution limits](https://webassembly.github.io/spec/core/appendix/implementation.html#execution) that implementations throw a runtime error if tables or memories grow beyond an implementation-defined limit. The js-api specification, however, required a compile error if the module defines limits beyond the implementation-defined limits.

This PR resolves this inconsistency by adjusting the js-api specification. For the maximum memory size and maximum table size, a RuntimeError is now required instead of a CompileError.