### PR TITLE
[interpreter] Add command-line option to set max recursion depth

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -80,6 +80,7 @@ where `file`, depending on its extension, either should be a binary (`.wasm`) or
 By default, the interpreter validates all modules.
 The `-u` option selects "unchecked mode", which skips validation and runs code as is.
 Runtime type errors will be captured and reported appropriately.
+The `-r` option may be used to explicitly set the maximum recursion depth.
 
 #### Converting Modules or Scripts
 

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -65,7 +65,11 @@ type config =
 }
 
 let frame inst locals = {inst; locals}
-let config inst vs es = {frame = frame inst []; code = vs, es; budget = 300}
+let config inst vs es =
+  { frame = frame inst [];
+    code = vs, es;
+    budget = max 0 !Flags.max_recursion_depth
+  }
 
 let plain e = Plain e.it @@ e.at
 

--- a/interpreter/main/flags.ml
+++ b/interpreter/main/flags.ml
@@ -5,3 +5,4 @@ let print_sig = ref false
 let dry = ref false
 let width = ref 80
 let harness = ref true
+let max_recursion_depth = ref 300

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -31,7 +31,10 @@ let argspec = Arg.align
   "-h", Arg.Clear Flags.harness, " exclude harness for JS conversion";
   "-d", Arg.Set Flags.dry, " dry, do not run program";
   "-t", Arg.Set Flags.trace, " trace execution";
-  "-v", Arg.Unit banner, " show version"
+  "-v", Arg.Unit banner, " show version";
+  "-r", Arg.Set_int Flags.max_recursion_depth,
+    " configure maximum recursion depth (default is " ^
+    string_of_int !Flags.max_recursion_depth ^ ")"
 ]
 
 let () =


### PR DESCRIPTION
In Eval.step function, fix Invoke case which did not handle negative integers.

close #1200