### PR TITLE
[test] Remove br_table binary test

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -736,28 +736,6 @@
   "\0b\0b\0b"                               ;; end
 )
 
-;; 2 br_table target declared, 1 given
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01"                             ;; type section
-    "\60\00\00"                             ;; type 0
-    "\03\02\01\00"                          ;; func section
-    "\0a\12\01"                             ;; code section
-    "\10\00"                                ;; func 0
-    "\02\40"                                ;; block 0
-    "\41\01"                                ;; condition of if 0
-    "\04\40"                                ;; if 0
-    "\41\01"                                ;; index of br_table element
-    "\0e\02"                                ;; br_table with inconsistent target count (2 declared, 1 given)
-    "\00"                                   ;; break depth 0
-    ;; "\01"                                ;; break depth 1 (missed)
-    "\02"                                   ;; break depth for default
-    "\0b\0b\0b"                             ;; end
-  )
-  "unexpected end of section or function"
-)
-
 ;; 1 br_table target declared, 2 given
 (assert_malformed
   (module binary


### PR DESCRIPTION
This test doesn't really test what it says: the br_table is consumed
correctly, and instead the `end` instruction is missing. This has caused
various issues in decoders (see issue #1170) as well as requiring
changing the error message in future proposals (e.g. bulk memory).