### PR TITLE
Add more i32.trunc_f64_s conversion checks

### DIFF
--- a/test/core/conversions.wast
+++ b/test/core/conversions.wast
@@ -120,6 +120,8 @@
 (assert_return (invoke "i32.trunc_f64_s" (f64.const -2.0)) (i32.const -2))
 (assert_return (invoke "i32.trunc_f64_s" (f64.const 2147483647.0)) (i32.const 2147483647))
 (assert_return (invoke "i32.trunc_f64_s" (f64.const -2147483648.0)) (i32.const -2147483648))
+(assert_return (invoke "i32.trunc_f64_s" (f64.const 2147483647.9999998)) (i32.const 2147483647))
+(assert_trap   (invoke "i32.trunc_f64_s" (f64.const 2147483647.9999999)) "integer overflow")
 (assert_trap (invoke "i32.trunc_f64_s" (f64.const 2147483648.0)) "integer overflow")
 (assert_trap (invoke "i32.trunc_f64_s" (f64.const -2147483649.0)) "integer overflow")
 (assert_trap (invoke "i32.trunc_f64_s" (f64.const inf)) "integer overflow")


### PR DESCRIPTION
I may be missing something here, sorry if so. Looks like the
existing tests check for `2147483647.0` and `2147483648.0`,
but not the precise fraction where things change. I think that
is fully defined by the spec, so it should be testable?

I noticed this as the binaryen fuzzer found a difference between
the binaryen interpreter and other VMs, so I assume the spec
interpreter is right and these tests are valid?