### PR TITLE
[test] Add "invalid section id" tests

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -44,6 +44,13 @@
 (assert_malformed (module binary "\00asm\00\00\01\00") "unknown binary version")
 (assert_malformed (module binary "\00asm\00\00\00\01") "unknown binary version")
 
+;; Invalid section id.
+(assert_malformed (module binary "\00asm" "\01\00\00\00" "\0c\00") "invalid section id")
+(assert_malformed (module binary "\00asm" "\01\00\00\00" "\7f\00") "invalid section id")
+(assert_malformed (module binary "\00asm" "\01\00\00\00" "\80\00\01\00") "invalid section id")
+(assert_malformed (module binary "\00asm" "\01\00\00\00" "\81\00\01\00") "invalid section id")
+(assert_malformed (module binary "\00asm" "\01\00\00\00" "\ff\00\01\00") "invalid section id")
+
 
 ;; call_indirect reserved byte equal to zero.
 (assert_malformed


### PR DESCRIPTION
This adds explicit tests for "invalid section id". Previously there was only single test for it in custom.wast.

Some of the test cases are designed in a way to reproduce issues of parsing section ids as LEB128 encoded values.

This reproduces the bug in [wabt](https://github.com/WebAssembly/wabt) fixed by https://github.com/WebAssembly/wabt/pull/1501.

The bug has been discovered by fuzzing wabt wasm validation against [Fizzy](https://github.com/wasmx/fizzy).

Resubmit of #1230.