### PR TITLE
Update label to syntax conventions

### DIFF
--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -22,11 +22,6 @@ The following sections group instructions into a number of different categories.
    pair: abstract syntax; instruction
 .. _syntax-sx:
 .. _syntax-const:
-.. _syntax-unop:
-.. _syntax-binop:
-.. _syntax-testop:
-.. _syntax-relop:
-.. _syntax-cvtop:
 .. _syntax-iunop:
 .. _syntax-ibinop:
 .. _syntax-itestop:
@@ -143,6 +138,12 @@ Some integer instructions come in two flavors,
 where a signedness annotation |sx| distinguishes whether the operands are to be :ref:`interpreted <aux-signed>` as :ref:`unsigned <syntax-uint>` or :ref:`signed <syntax-sint>` integers.
 For the other integer instructions, the use of two's complement for the signed interpretation means that they behave the same regardless of signedness.
 
+
+.. _syntax-unop:
+.. _syntax-binop:
+.. _syntax-testop:
+.. _syntax-relop:
+.. _syntax-cvtop:
 
 Conventions
 ...........


### PR DESCRIPTION
When you click on one of these links, you jump to the "Numeric
Instructions" section. But the definition of unop, binop, testop, relop,
and cvtop are in the "Conventions" section.

Move the label for these grouping non-terminals approriately, so
clicking on one of those definitions will go to where there are
defined.