### PR TITLE
Test validation when using start with invalid imported function

### DIFF
--- a/test/core/start.wast
+++ b/test/core/start.wast
@@ -103,3 +103,11 @@
   (module quote "(module (func $a (unreachable)) (func $b (unreachable)) (start $a) (start $b))")
   "multiple start sections"
 )
+
+(assert_invalid
+  (module
+    (import "foo" "bar" (func (type 20)))
+    (start 0)
+  )
+  "unknown type"
+)


### PR DESCRIPTION
The documentation states that the start function is validated before
it states that imports are validated. This does not imply a required
ordering to the validation process but some implementations may order
order their validation implementation as stated regardless. If the
start function is validated before the imports, while assuming
the imports are valid without first checking if the imports are valid
then this may trigger a bug.