### PR TITLE
Test invalid memory / table import types

### DIFF
--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -318,6 +318,13 @@
   (module (table 10 funcref) (table 10 funcref))
   "multiple tables"
 )
+;; Can't test values above 2^32 because wast parsing will reject them
+(assert_invalid
+  (module
+    (import "" "" (table 1 0 funcref))
+  )
+  "size minimum must not be greater than maximum"
+)
 
 (module (import "test" "table-10-inf" (table 10 funcref)))
 (module (import "test" "table-10-inf" (table 5 funcref)))
@@ -412,6 +419,30 @@
 (assert_invalid
   (module (memory 0) (memory 0))
   "multiple memories"
+)
+(assert_invalid
+  (module
+    (import "" "" (memory 65537 65538))
+  )
+  "memory size must be at most 65536 pages"
+)
+(assert_invalid
+  (module
+    (import "" "" (memory 0 65537))
+  )
+  "memory size must be at most 65536 pages"
+)
+(assert_invalid
+  (module
+    (import "" "" (memory 1 0))
+  )
+  "size minimum must not be greater than maximum"
+)
+(assert_invalid
+  (module
+    (import "" "" (memory 65537))
+  )
+  "memory size must be at most 65536 pages"
 )
 
 (module (import "test" "memory-2-inf" (memory 2)))


### PR DESCRIPTION
The test suite was missing tests that check if the validator reject imports with invalid memory or table types.