### PR TITLE
[test] Add more invalid cases with nonexistent exports

### DIFF
--- a/test/core/exports.wast
+++ b/test/core/exports.wast
@@ -26,7 +26,15 @@
 (assert_return (invoke $Func "e" (i32.const 42)) (i32.const 43))
 
 (assert_invalid
+  (module (export "a" (func 0)))
+  "unknown function"
+)
+(assert_invalid
   (module (func) (export "a" (func 1)))
+  "unknown function"
+)
+(assert_invalid
+  (module (import "spectest" "print_i32" (func (param i32))) (export "a" (func 1)))
   "unknown function"
 )
 (assert_invalid
@@ -75,7 +83,15 @@
 (assert_return (get $Global "e") (i32.const 42))
 
 (assert_invalid
+  (module (export "a" (global 0)))
+  "unknown global"
+)
+(assert_invalid
   (module (global i32 (i32.const 0)) (export "a" (global 1)))
+  "unknown global"
+)
+(assert_invalid
+  (module (import "spectest" "global_i32" (global i32)) (export "a" (global 1)))
   "unknown global"
 )
 (assert_invalid
@@ -123,7 +139,15 @@
 (; TODO: access table ;)
 
 (assert_invalid
+  (module (export "a" (table 0)))
+  "unknown table"
+)
+(assert_invalid
   (module (table 0 funcref) (export "a" (table 1)))
+  "unknown table"
+)
+(assert_invalid
+  (module  (import "spectest" "table" (table 10 20 funcref)) (export "a" (table 1)))
   "unknown table"
 )
 (assert_invalid
@@ -172,7 +196,15 @@
 (; TODO: access memory ;)
 
 (assert_invalid
+  (module (export "a" (memory 0)))
+  "unknown memory"
+)
+(assert_invalid
   (module (memory 0) (export "a" (memory 1)))
+  "unknown memory"
+)
+(assert_invalid
+  (module  (import "spectest" "memory" (memory 1 2)) (export "a" (memory 1)))
   "unknown memory"
 )
 (assert_invalid


### PR DESCRIPTION
This adds invalid cases with export section references nonexistent indices:
-  no function/global/table/memory is defined and export with index 0;
-  1 import is defined and export with index 1.