### PR TITLE
[test] Add invalid cases with globals access

### DIFF
--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -356,6 +356,68 @@
   "malformed mutability"
 )
 
+;; global.get with invalid index
+(assert_invalid
+  (module (func (result i32) (global.get 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (result i32) (global.get 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (result i32) (global.get 2))
+  )
+  "unknown global"
+)
+
+;; global.set with invalid index
+(assert_invalid
+  (module (func (i32.const 0) (global.set 0)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (func (i32.const 0) (global.set 1))
+  )
+  "unknown global"
+)
+
+(assert_invalid
+  (module
+    (import "spectest" "global_i32" (global i32))
+    (global i32 (i32.const 0))
+    (func (i32.const 0) (global.set 2))
+  )
+  "unknown global"
+)
+
 
 (assert_invalid
   (module

--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -244,6 +244,11 @@
   "global is immutable"
 )
 
+(assert_invalid
+  (module (import "spectest" "global_i32" (global i32)) (func (global.set 0 (i32.const 1))))
+  "global is immutable"
+)
+
 ;; mutable globals can be exported
 (module (global (mut f32) (f32.const 0)) (export "a" (global 0)))
 (module (global (export "a") (mut f32) (f32.const 0)))


### PR DESCRIPTION
This adds some cases with `global.get`/`global.set` with invalid index and a case with `global.set` for immutable imported global.