### PR TITLE
[test] Fix invalid index cases for local.tee and local.get

### DIFF
--- a/test/core/local_get.wast
+++ b/test/core/local_get.wast
@@ -198,29 +198,29 @@
 ;; Invalid local index
 
 (assert_invalid
-  (module (func $unbound-local (local i32 i64) (local.get 3)))
+  (module (func $unbound-local (local i32 i64) (local.get 3) drop))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-local (local i32 i64) (local.get 14324343)))
-  "unknown local"
-)
-
-(assert_invalid
-  (module (func $unbound-param (param i32 i64) (local.get 2)))
-  "unknown local"
-)
-(assert_invalid
-  (module (func $large-param (param i32 i64) (local.get 714324343)))
+  (module (func $large-local (local i32 i64) (local.get 14324343) drop))
   "unknown local"
 )
 
 (assert_invalid
-  (module (func $unbound-mixed (param i32) (local i32 i64) (local.get 3)))
+  (module (func $unbound-param (param i32 i64) (local.get 2) drop))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-mixed (param i64) (local i32 i64) (local.get 214324343)))
+  (module (func $large-param (param i32 i64) (local.get 714324343) drop))
+  "unknown local"
+)
+
+(assert_invalid
+  (module (func $unbound-mixed (param i32) (local i32 i64) (local.get 3) drop))
+  "unknown local"
+)
+(assert_invalid
+  (module (func $large-mixed (param i64) (local i32 i64) (local.get 214324343) drop))
   "unknown local"
 )
 

--- a/test/core/local_tee.wast
+++ b/test/core/local_tee.wast
@@ -599,29 +599,29 @@
 ;; Invalid local index
 
 (assert_invalid
-  (module (func $unbound-local (local i32 i64) (local.get 3)))
+  (module (func $unbound-local (local i32 i64) (local.tee 3 (i32.const 0))))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-local (local i32 i64) (local.get 14324343)))
-  "unknown local"
-)
-
-(assert_invalid
-  (module (func $unbound-param (param i32 i64) (local.get 2)))
-  "unknown local"
-)
-(assert_invalid
-  (module (func $large-param (local i32 i64) (local.get 714324343)))
+  (module (func $large-local (local i32 i64) (local.tee 14324343 (i32.const 0))))
   "unknown local"
 )
 
 (assert_invalid
-  (module (func $unbound-mixed (param i32) (local i32 i64) (local.get 3)))
+  (module (func $unbound-param (param i32 i64) (local.tee 2 (i32.const 0))))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-mixed (param i64) (local i32 i64) (local.get 214324343)))
+  (module (func $large-param (param i32 i64) (local.tee 714324343 (i32.const 0))))
+  "unknown local"
+)
+
+(assert_invalid
+  (module (func $unbound-mixed (param i32) (local i32 i64) (local.tee 3 (i32.const 0))))
+  "unknown local"
+)
+(assert_invalid
+  (module (func $large-mixed (param i64) (local i32 i64) (local.tee 214324343 (i32.const 0))))
   "unknown local"
 )
 

--- a/test/core/local_tee.wast
+++ b/test/core/local_tee.wast
@@ -595,6 +595,19 @@
   "type mismatch"
 )
 
+(assert_invalid
+  (module (func $type-mixed-arg-num-vs-num (param f32) (local i32) (local.tee 1 (f32.const 0))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func $type-mixed-arg-num-vs-num (param i64 i32) (local f32) (local.tee 1 (f32.const 0))))
+  "type mismatch"
+)
+(assert_invalid
+  (module (func $type-mixed-arg-num-vs-num (param i64) (local f64 i64) (local.tee 1 (i64.const 0))))
+  "type mismatch"
+)
+
 
 ;; Invalid local index
 
@@ -623,17 +636,4 @@
 (assert_invalid
   (module (func $large-mixed (param i64) (local i32 i64) (local.tee 214324343 (i32.const 0)) drop))
   "unknown local"
-)
-
-(assert_invalid
-  (module (func $type-mixed-arg-num-vs-num (param f32) (local i32) (local.tee 1 (f32.const 0))))
-  "type mismatch"
-)
-(assert_invalid
-  (module (func $type-mixed-arg-num-vs-num (param i64 i32) (local f32) (local.tee 1 (f32.const 0))))
-  "type mismatch"
-)
-(assert_invalid
-  (module (func $type-mixed-arg-num-vs-num (param i64) (local f64 i64) (local.tee 1 (i64.const 0))))
-  "type mismatch"
 )

--- a/test/core/local_tee.wast
+++ b/test/core/local_tee.wast
@@ -599,29 +599,29 @@
 ;; Invalid local index
 
 (assert_invalid
-  (module (func $unbound-local (local i32 i64) (local.tee 3 (i32.const 0))))
+  (module (func $unbound-local (local i32 i64) (local.tee 3 (i32.const 0)) drop))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-local (local i32 i64) (local.tee 14324343 (i32.const 0))))
-  "unknown local"
-)
-
-(assert_invalid
-  (module (func $unbound-param (param i32 i64) (local.tee 2 (i32.const 0))))
-  "unknown local"
-)
-(assert_invalid
-  (module (func $large-param (param i32 i64) (local.tee 714324343 (i32.const 0))))
+  (module (func $large-local (local i32 i64) (local.tee 14324343 (i32.const 0)) drop))
   "unknown local"
 )
 
 (assert_invalid
-  (module (func $unbound-mixed (param i32) (local i32 i64) (local.tee 3 (i32.const 0))))
+  (module (func $unbound-param (param i32 i64) (local.tee 2 (i32.const 0)) drop))
   "unknown local"
 )
 (assert_invalid
-  (module (func $large-mixed (param i64) (local i32 i64) (local.tee 214324343 (i32.const 0))))
+  (module (func $large-param (param i32 i64) (local.tee 714324343 (i32.const 0)) drop))
+  "unknown local"
+)
+
+(assert_invalid
+  (module (func $unbound-mixed (param i32) (local i32 i64) (local.tee 3 (i32.const 0)) drop))
+  "unknown local"
+)
+(assert_invalid
+  (module (func $large-mixed (param i64) (local i32 i64) (local.tee 214324343 (i32.const 0)) drop))
   "unknown local"
 )
 


### PR DESCRIPTION
1. Fix cases with invalid index for `local.tee` - they looked to be copy-pasted from `local.get` tests without changing opcode.
2. Add `drop` instruction in the end of functions, otherwise tests might pass for the wrong reason - invalid index not caught, but invalid function return type reported.
3. Move some `type mismatch` tests of `local.tee` from `Invalid local index` section to `Invalid typing of access to parameters` section.