### PR TITLE
[test] Add tests for validating constant expressions

### DIFF
--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -360,6 +360,40 @@
 )
 
 (assert_invalid
+  (module 
+    (memory 1)
+    (data (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (data (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (memory 1)
+    (data (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
   (module
     (memory 1)
     (data (i32.ctz (i32.const 0)))
@@ -396,3 +430,29 @@
 ;;   (module (memory 1) (data (global.get $g)) (global $g (mut i32) (i32.const 0)))
 ;;   "constant expression required"
 ;; )
+
+(assert_invalid
+   (module 
+     (memory 1)
+     (data (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (memory 1)
+     (data (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (memory 1)
+     (data (global.get 0))
+   )
+   "constant expression required"
+)

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -263,6 +263,41 @@
 )
 
 (assert_invalid
+  (module 
+    (table 1 funcref)
+    (elem (offset (;empty instruction sequence;)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (offset (i32.const 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (global.get 0)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (global (import "test" "global-i32") i32)
+    (table 1 funcref)
+    (elem (offset (global.get 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
+
+(assert_invalid
   (module
     (table 1 funcref)
     (elem (i32.ctz (i32.const 0)))
@@ -299,6 +334,32 @@
 ;;   (module (memory 1) (data (global.get $g)) (global $g (mut i32) (i32.const 0)))
 ;;   "constant expression required"
 ;; )
+
+(assert_invalid
+   (module 
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "unknown global 0"
+)
+
+(assert_invalid
+   (module
+     (global (import "test" "global-i32") i32)
+     (table 1 funcref)
+     (elem (global.get 1))
+   )
+   "unknown global 1"
+)
+
+(assert_invalid
+   (module 
+     (global (import "test" "global-mut-i32") (mut i32))
+     (table 1 funcref)
+     (elem (global.get 0))
+   )
+   "constant expression required"
+)
 
 ;; Two elements target the same slot
 

--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -274,6 +274,11 @@
 )
 
 (assert_invalid
+  (module (global i32 (i32.ctz (i32.const 0))))
+  "constant expression required"
+)
+
+(assert_invalid
   (module (global i32 (nop)))
   "constant expression required"
 )
@@ -294,6 +299,16 @@
 )
 
 (assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (i32.const 0) (global.get 0)))
+  "type mismatch"
+)
+
+(assert_invalid
   (module (global i32 (global.get 0)))
   "unknown global"
 )
@@ -301,6 +316,16 @@
 (assert_invalid
   (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
   "unknown global"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-i32") i32) (global i32 (global.get 2)))
+  "unknown global"
+)
+
+(assert_invalid
+  (module (global (import "test" "global-mut-i32") (mut i32)) (global i32 (global.get 0)))
+  "constant expression required"
 )
 
 (module


### PR DESCRIPTION
This adds cases for validation of
1. index of a global used in constant expression
2. immutability of a global used in constant expression
3. that only a single `i32.const` or `global.get` is allowed in constant expression.