### PR TITLE
Fix step-by-step guide instruction

### DIFF
--- a/document/README.md
+++ b/document/README.md
@@ -88,7 +88,7 @@ You will also need `npm` and `yarn` for all the LaTeX goodness. `npm` might alre
 
 ```
 npm install -g yarn
-cd document/core
+cd document
 make -C core bikeshed
 ```
 


### PR DESCRIPTION
cd-ed too deep into the tree, it doesn't not work with the next `make -C core` instruction.