### PR TITLE
[interpreter] Make popcnt loop up to bitwidth

### DIFF
--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -199,7 +199,7 @@ struct
 
   let popcnt x =
     let rec loop acc i n =
-      if n = Rep.zero then
+      if i = 0 then
         acc
       else
         let acc' = if and_ n Rep.one = Rep.one then acc + 1 else acc in


### PR DESCRIPTION
This makes it work for Rep.bitwidth < 32. Otherwise it will keep
checking all 32 bits and give the wrong result.