### PR TITLE
Add global_i64 to js harness

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -18,6 +18,7 @@ let spectest = {
   print_f32: console.log.bind(console),
   print_f64: console.log.bind(console),
   global_i32: 666,
+  global_i64: 666,
   global_f32: 666,
   global_f64: 666,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -18,7 +18,7 @@ let spectest = {
   print_f32: console.log.bind(console),
   print_f64: console.log.bind(console),
   global_i32: 666,
-  global_i64: 666,
+  global_i64: 666n,
   global_f32: 666,
   global_f64: 666,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),


### PR DESCRIPTION
PR #1288 is the first use of global_i64, but the generated JS did not
yet define this global, which causes the JS test to fail to link.