### PR TITLE
[test] Test cases with imports the same name as exports

### DIFF
--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -96,6 +96,26 @@
   "unknown type"
 )
 
+;; Export sharing name with import
+(module
+  (import "spectest" "print_i32" (func $imported_print (param i32)))
+  (func (export "print_i32") (param $i i32)
+    (call $imported_print (local.get $i))
+  )
+)
+
+(assert_return (invoke "print_i32" (i32.const 13)))
+
+;; Export sharing name with import
+(module
+  (import "spectest" "print_i32" (func $imported_print (param i32)))
+  (func (export "print_i32") (param $i i32) (param $j i32) (result i32)
+    (i32.add (local.get $i) (local.get $j))
+  )
+)
+
+(assert_return (invoke "print_i32" (i32.const 5) (i32.const 11)) (i32.const 16))
+
 (module (import "test" "func" (func)))
 (module (import "test" "func-i32" (func (param i32))))
 (module (import "test" "func-f32" (func (param f32))))


### PR DESCRIPTION
While integrating [wasm3](https://github.com/wasm3/wasm3) into [fizzy](https://github.com/wasmx/fizzy)'s benchmarking suite, we found some issues with wasm3. Namely it did not make a distinction between imported and exported functions where the name matches. Since wasm3 passes the spec tests, I think such cases are not covered. The original test case can be seen at https://github.com/wasm3/wasm3/issues/143.