### PR TITLE
[test] Check that memory is exported/imported with correct min limit after grow

### DIFF
--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -565,6 +565,26 @@
 (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
 
+(module $Mgm
+  (memory (export "memory") 1) ;; initial size is 1
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-memory" $Mgm)
+(assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
+(module $Mgim1
+  ;; imported memory limits should match, because external memory size is 2 now
+  (memory (export "memory") (import "grown-memory" "memory") 2) 
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-imported-memory" $Mgim1)
+(assert_return (invoke $Mgim1 "grow") (i32.const 2)) ;; now size is 3
+(module $Mgim2
+  ;; imported memory limits should match, because external memory size is 3 now
+  (import "grown-imported-memory" "memory" (memory 3))
+  (func (export "size") (result i32) (memory.size))
+)
+(assert_return (invoke $Mgim2 "size") (i32.const 3))
+
 
 ;; Syntax errors
 


### PR DESCRIPTION
I made this to check my understanding of the [external memory definition in the spec](https://webassembly.github.io/spec/core/exec/modules.html#xref-exec-runtime-syntax-externval-mathsf-mem-a): 

![image](https://user-images.githubusercontent.com/1863135/110102517-2cd27d00-7da5-11eb-9111-72d956c2092b.png)

IIUC it requires imported memory to have `min` limit equal to it's currently allocated size, which means it can be updated after grow, and that has implications on matching this memory limits against import definition in another module.

The test basically creates a module with `(memory 1)`, grows it to 2 pages, then tries to import it into a module with `(memory 2)`.
Then repeats it another time for the memory that is both imported and exported.

(It [fails on WABT](https://github.com/WebAssembly/wabt/issues/1626).)