### PR TITLE
Small fixes in build instructions, fix warnings

### DIFF
--- a/document/README.md
+++ b/document/README.md
@@ -42,7 +42,7 @@ pipenv shell
 Install Python dependencies:
 
 ```
-pip install Sphinx==2.4.4
+pipenv install Sphinx==2.4.4
 ```
 
 ### Checking out the repository
@@ -80,7 +80,7 @@ To build the [single-page W3C version](https://webassembly.github.io/spec/core/b
 ```
 # cd back to root of git directory
 git clone https://github.com/tabatkins/bikeshed.git
-pip install --editable bikeshed
+pipenv install -e bikeshed
 bikeshed update
 ```
 

--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -186,7 +186,7 @@ html_logo = logo
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static', 'static/custom.css']
+html_static_path = ['static/custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/document/core/util/bikeshed/conf.py
+++ b/document/core/util/bikeshed/conf.py
@@ -130,7 +130,7 @@ todo_include_todos = True
 # a list of builtin themes.
 #
 html_theme = 'classic'
-html_add_permalinks = None
+html_add_permalinks = ''
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -176,7 +176,7 @@ html_logo = logo
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static', 'static/custom.css']
+# html_static_path = ['_static', 'static/custom.css']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/document/core/util/mathdef.py
+++ b/document/core/util/mathdef.py
@@ -1,5 +1,5 @@
 from sphinx.ext.mathbase import math
-from sphinx.ext.mathbase import MathDirective
+from sphinx.directives.patches import MathDirective
 from sphinx.util.texescape import tex_replace_map
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.writers.latex import LaTeXTranslator

--- a/document/core/util/mathdefbs.py
+++ b/document/core/util/mathdefbs.py
@@ -4,7 +4,7 @@
 # mathdef.py controlled by buildername.
 
 from sphinx.ext.mathbase import math
-from sphinx.ext.mathbase import MathDirective
+from sphinx.directives.patches import MathDirective
 from sphinx.ext.mathjax import html_visit_math
 from sphinx.ext.mathjax import html_visit_displaymath
 from sphinx.writers.html5 import HTML5Translator


### PR DESCRIPTION
Since the build instructions suggest using pipenv, we should
consistently use pipenv to install the packages.

Also remove some warnings about unavailable static files.

Fix a Sphinx deprecation warning.