### PR TITLE
Upgrade Sphinx to 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - opam --version
   - ocaml --version
   - opam install --yes ocamlbuild.0.14.0
-  - pip install Sphinx==2.4.4
+  - pip install Sphinx==3.0.0
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed
   - bikeshed update

--- a/document/README.md
+++ b/document/README.md
@@ -42,7 +42,7 @@ pipenv shell
 Install Python dependencies:
 
 ```
-pipenv install Sphinx==2.4.4
+pipenv install Sphinx==3.0.0
 ```
 
 ### Checking out the repository

--- a/document/core/util/mathdef.py
+++ b/document/core/util/mathdef.py
@@ -1,9 +1,9 @@
-from sphinx.ext.mathbase import math
 from sphinx.directives.patches import MathDirective
 from sphinx.util.texescape import tex_replace_map
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.writers.latex import LaTeXTranslator
 from docutils import nodes
+from docutils.nodes import math
 from docutils.parsers.rst.directives.misc import Replace
 from six import text_type
 import re

--- a/document/core/util/mathdefbs.py
+++ b/document/core/util/mathdefbs.py
@@ -3,12 +3,12 @@
 # TODO(bradnelson): Figure out a way to merge this back into
 # mathdef.py controlled by buildername.
 
-from sphinx.ext.mathbase import math
 from sphinx.directives.patches import MathDirective
 from sphinx.ext.mathjax import html_visit_math
 from sphinx.ext.mathjax import html_visit_displaymath
 from sphinx.writers.html5 import HTML5Translator
 from docutils import nodes
+from docutils.nodes import math
 from docutils.parsers.rst.directives.misc import Replace
 import re
 


### PR DESCRIPTION
It comes with some nice fixes:

- genindex.html "abstract syntax" currently points to
"https://webassembly.github.io/spec/core/appendix/implementation.html#index-1",
which looks incorrect

The different files are:

$ diff -u -r _build/ _golden/ -q
Files _build/core/appendix/index-instructions.html and
_golden/core/appendix/index-instructions.html differ
Files _build/core/bikeshed/index.html and
_golden/core/bikeshed/index.html differ
Files _build/core/_download/WebAssembly.pdf and
_golden/core/_download/WebAssembly.pdf differ
Files _build/core/genindex.html and _golden/core/genindex.html differ
Files _build/core/objects.inv and _golden/core/objects.inv differ
Files _build/core/search.html and _golden/core/search.html differ
Files _build/core/searchindex.js and _golden/core/searchindex.js differ
Files _build/core/_static/documentation_options.js and
_golden/core/_static/documentation_options.js differ
Files _build/core/_static/searchtools.js and
_golden/core/_static/searchtools.js differ
Files _build/js-api/index.html and _golden/js-api/index.html differ
Files _build/web-api/index.html and _golden/web-api/index.html differ

Most of the index.html are differences in meta content tag.