### PR TITLE
Upgrade Sphinx to 3.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - opam --version
   - ocaml --version
   - opam install --yes ocamlbuild.0.14.0
-  - pip install Sphinx==3.0.0
+  - pip install Sphinx==3.5.2
   - git clone https://github.com/tabatkins/bikeshed.git
   - pip install --editable $PWD/bikeshed
   - bikeshed update

--- a/document/README.md
+++ b/document/README.md
@@ -42,7 +42,7 @@ pipenv shell
 Install Python dependencies:
 
 ```
-pipenv install Sphinx==3.0.0
+pipenv install Sphinx==3.5.2
 ```
 
 ### Checking out the repository

--- a/document/core/index.bs
+++ b/document/core/index.bs
@@ -9,7 +9,7 @@ ED: https://webassembly.github.io/spec/core/bikeshed/
 Editor: Andreas Rossberg (Dfinity Stiftung)
 Repository: WebAssembly/spec
 Markup Shorthands: css no, markdown no, algorithm no, idl no
-Abstract: This document describes version 1.0 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
+Abstract: This document describes version 1.1 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
 Prepare For TR: true
 </pre>
 

--- a/document/core/util/bikeshed/conf.py
+++ b/document/core/util/bikeshed/conf.py
@@ -67,7 +67,7 @@ logo = 'static/webassembly.png'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.0'
+version = u'1.1'
 # The full version, including alpha/beta/rc tags.
 release = version + ''
 

--- a/document/core/util/bikeshed/conf.py
+++ b/document/core/util/bikeshed/conf.py
@@ -130,7 +130,7 @@ todo_include_todos = True
 # a list of builtin themes.
 #
 html_theme = 'classic'
-html_add_permalinks = ''
+html_permalinks = False
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -41,8 +41,8 @@ def Main():
     <div class="related" role="navigation" aria-label="related navigation">
       <h3>Navigation</h3>
       <ul>
-        <li class="nav-item nav-item-0"><a href="#">WebAssembly 1.0</a> &#187;</li>
-        <li class="nav-item nav-item-this"><a href="">WebAssembly 1.0</a></li> 
+        <li class="nav-item nav-item-0"><a href="#">WebAssembly 1.1</a> &#187;</li>
+        <li class="nav-item nav-item-this"><a href="">WebAssembly 1.1</a></li> 
       </ul>
     </div>  """, '')
 

--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -41,13 +41,14 @@ def Main():
     <div class="related" role="navigation" aria-label="related navigation">
       <h3>Navigation</h3>
       <ul>
-        <li class="nav-item nav-item-0"><a href="index.html#document-index">WebAssembly 1.0</a> &#187;</li> 
+        <li class="nav-item nav-item-0"><a href="#">WebAssembly 1.0</a> &#187;</li>
+        <li class="nav-item nav-item-this"><a href="">WebAssembly 1.0</a></li> 
       </ul>
-    </div>""", '')
+    </div>  """, '')
 
   # Use bikeshed biblio references for unicode and IEEE754
   data = data.replace(
-      """<a class="reference external" href="http://www.unicode.org/versions/latest/">Unicode</a>""",
+      """<a class="reference external" href="https://www.unicode.org/versions/latest/">Unicode</a>""",
       "[[!UNICODE]]"
   )
 


### PR DESCRIPTION
The html_add_permalinks configuration was changed in 3.5
(https://www.sphinx-doc.org/en/3.x/usage/configuration.html#confval-html_add_permalinks),
we don't want any permalink for the heading (that's the existing
behavior).

Fix up bikeshed_fixup.py, we were not correctly replacing the spurious
"navigation section" and also the Unicode reference.

Most of the changes in the output is:

- adding viewport meta tag (in Sphinx#7695, since 3.1.0)
- sorting order of css files in html
- upgrade mathjax to 2.7.7