### PR TITLE
[test] Fix alignment of i32.store instruction in binary test

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -641,7 +641,7 @@
     "\41\00"                   ;; i32.const 0
     "\41\03"                   ;; i32.const 3
     "\36"                      ;; i32.store
-    "\03"                      ;; alignment 2
+    "\02"                      ;; alignment 2
     "\82\80\80\80\10"          ;; offset 2 with unused bits set
     "\0b"                      ;; end
   )


### PR DESCRIPTION
The same problem was already fixed once in https://github.com/WebAssembly/spec/pull/1261, but then was reintroduced in https://github.com/WebAssembly/spec/pull/1287.