### PR TITLE
[js-api] Fix links to the core specification.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -93,7 +93,7 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: BigInt; url: #sec-ecmascript-language-types-bigint-type
     type: abstract-op
         text: CreateMethodProperty; url: sec-createmethodproperty
-urlPrefix: https://webassembly.github.io/reference-types/core/; spec: WebAssembly; type: dfn
+urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation


### PR DESCRIPTION
The links were accidentally changed to point to the reference-types fork
when it was merged in 7fa2f20a6df4cf1c114582c8cb60f5bfcdbf1be1.