### PR TITLE
Fix the Editor metadata format

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -6,7 +6,7 @@ Status: ED
 Level: 1
 TR: https://www.w3.org/TR/wasm-js-api-1/
 ED: https://webassembly.github.io/spec/js-api/
-Editor: Ms2ger (Igalia)
+Editor: Ms2ger, Igalia
 Repository: WebAssembly/spec
 Markup Shorthands: css no, markdown yes
 Abstract: This document provides an explicit JavaScript API for interacting with WebAssembly.


### PR DESCRIPTION
Names and affiliations are separated by a comma: https://tabatkins.github.io/bikeshed/#metadata-editor