### PR TITLE
[spec] fix markup for ref.func instruction

### DIFF
--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -256,7 +256,7 @@ Each element segment defines an :ref:`reference type <syntax-reftype>` and a cor
 Element segments have a mode that identifies them as either *passive*, *active*, or *declarative*.
 A passive element segment's elements can be copied to a table using the |TABLEINIT| instruction.
 An active element segment copies its elements into a table during :ref:`instantiation <exec-instantiation>`, as specified by a :ref:`table index <syntax-tableidx>` and a :ref:`constant <valid-constant>` :ref:`expression <syntax-expr>` defining an offset into that table.
-A declarative element segment is not available at runtime but merely serves to forward-declare references that are formed in code with instructions like :math:`REFFUNC`.
+A declarative element segment is not available at runtime but merely serves to forward-declare references that are formed in code with instructions like :math:`\REFFUNC`.
 
 .. math::
    \begin{array}{llll}


### PR DESCRIPTION
Before:
<img width="808" alt="Screen Shot 2021-05-13 at 4 15 19 AM" src="https://user-images.githubusercontent.com/10766081/118118528-e51e3200-b3a1-11eb-9b81-05f50eb964f7.png">
After:
<img width="793" alt="Screen Shot 2021-05-13 at 4 15 28 AM" src="https://user-images.githubusercontent.com/10766081/118118535-e64f5f00-b3a1-11eb-9d25-4591b925cab3.png">

