### PR TITLE
Factor unreachability tests out of select and br_table

### DIFF
--- a/test/core/br_table.wast
+++ b/test/core/br_table.wast
@@ -1251,17 +1251,6 @@
     )
   )
 
-  (func (export "meet-bottom")
-    (block (result f64)
-      (block (result f32)
-        (unreachable)
-        (br_table 0 1 1 (i32.const 1))
-      )
-      (drop)
-      (f64.const 0)
-    )
-    (drop)
-  )
 )
 
 (assert_return (invoke "type-i32"))
@@ -1611,20 +1600,6 @@
   "type mismatch"
 )
 
-
-(assert_invalid
-  (module (func $meet-bottom (param i32) (result externref)
-    (block $l1 (result externref)
-      (drop
-        (block $l2 (result i32)
-          (br_table $l2 $l1 $l2 (ref.null extern) (local.get 0))
-        )
-      )
-      (ref.null extern)
-    )
-  ))
-  "type mismatch"
-)
 
 (assert_invalid
   (module (func $unbound-label

--- a/test/core/select.wast
+++ b/test/core/select.wast
@@ -36,31 +36,6 @@
     (select (result externref) (local.get 0) (local.get 1) (local.get 2))
   )
 
-  ;; Check that both sides of the select are evaluated
-  (func (export "select-trap-left") (param $cond i32) (result i32)
-    (select (unreachable) (i32.const 0) (local.get $cond))
-  )
-  (func (export "select-trap-right") (param $cond i32) (result i32)
-    (select (i32.const 0) (unreachable) (local.get $cond))
-  )
-
-  (func (export "select-unreached")
-    (unreachable) (select)
-    (unreachable) (i32.const 0) (select)
-    (unreachable) (i32.const 0) (i32.const 0) (select)
-    (unreachable) (i32.const 0) (i32.const 0) (i32.const 0) (select)
-    (unreachable) (f32.const 0) (i32.const 0) (select)
-    (unreachable)
-  )
-
-  (func (export "select_unreached_result_1") (result i32)
-    (unreachable) (i32.add (select))
-  )
-
-  (func (export "select_unreached_result_2") (result i64)
-    (unreachable) (i64.add (select (i64.const 0) (i32.const 0)))
-  )
-
   ;; As the argument of control constructs and instructions
 
   (func (export "as-select-first") (param i32) (result i32)
@@ -203,19 +178,6 @@
       (i32.wrap_i64 (select (i64.const 1) (i64.const 0) (local.get 0)))
     )
   )
-
-  (func (export "unreachable-num")
-    (unreachable)
-    (select)
-    (i32.eqz)
-    (drop)
-  )
-  (func (export "unreachable-ref")
-    (unreachable)
-    (select)
-    (ref.is_null)
-    (drop)
-  )
 )
 
 (assert_return (invoke "select-i32" (i32.const 1) (i32.const 2) (i32.const 1)) (i32.const 1))
@@ -277,11 +239,6 @@
 (assert_return (invoke "select-f64-t" (f64.const 2) (f64.const nan:0x20304) (i32.const 1)) (f64.const 2))
 (assert_return (invoke "select-f64-t" (f64.const 2) (f64.const nan) (i32.const 0)) (f64.const nan))
 (assert_return (invoke "select-f64-t" (f64.const 2) (f64.const nan:0x20304) (i32.const 0)) (f64.const nan:0x20304))
-
-(assert_trap (invoke "select-trap-left" (i32.const 1)) "unreachable")
-(assert_trap (invoke "select-trap-left" (i32.const 0)) "unreachable")
-(assert_trap (invoke "select-trap-right" (i32.const 1)) "unreachable")
-(assert_trap (invoke "select-trap-right" (i32.const 0)) "unreachable")
 
 (assert_return (invoke "as-select-first" (i32.const 0)) (i32.const 1))
 (assert_return (invoke "as-select-first" (i32.const 1)) (i32.const 0))
@@ -552,47 +509,6 @@
 
 (assert_invalid
   (module (func (result i32) (select (i64.const 1) (i64.const 1) (i32.const 1))))
-  "type mismatch"
-)
-
-;; Validation after unreachable
-
-;; The first two operands should have the same type as each other
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i64.const 1) (i32.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i64.const 1) (i32.const 1) (i32.const 1)) (drop)))
-  "type mismatch"
-)
-
-;; Third operand must be i32
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i32.const 1) (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-;; Result of select has type of first two operands (type of second operand when first one is omitted)
-(assert_invalid
-  (module (func (result i32) (unreachable) (select (i64.const 1) (i32.const 1))))
-  "type mismatch"
-)
-
-;; select always has non-empty result
-(assert_invalid
-  (module (func (unreachable) (select)))
   "type mismatch"
 )
 

--- a/test/core/unreachability.wast
+++ b/test/core/unreachability.wast
@@ -1,0 +1,115 @@
+(module
+
+  ;; Check that both sides of the select are evaluated
+  (func (export "select-trap-left") (param $cond i32) (result i32)
+    (select (unreachable) (i32.const 0) (local.get $cond))
+  )
+  (func (export "select-trap-right") (param $cond i32) (result i32)
+    (select (i32.const 0) (unreachable) (local.get $cond))
+  )
+
+  (func (export "select-unreached")
+    (unreachable) (select)
+    (unreachable) (i32.const 0) (select)
+    (unreachable) (i32.const 0) (i32.const 0) (select)
+    (unreachable) (i32.const 0) (i32.const 0) (i32.const 0) (select)
+    (unreachable) (f32.const 0) (i32.const 0) (select)
+    (unreachable)
+  )
+
+  (func (export "select_unreached_result_1") (result i32)
+    (unreachable) (i32.add (select))
+  )
+
+  (func (export "select_unreached_result_2") (result i64)
+    (unreachable) (i64.add (select (i64.const 0) (i32.const 0)))
+  )
+
+  (func (export "unreachable-num")
+    (unreachable)
+    (select)
+    (i32.eqz)
+    (drop)
+  )
+  (func (export "unreachable-ref")
+    (unreachable)
+    (select)
+    (ref.is_null)
+    (drop)
+  )
+)
+
+(assert_trap (invoke "select-trap-left" (i32.const 1)) "unreachable")
+(assert_trap (invoke "select-trap-left" (i32.const 0)) "unreachable")
+(assert_trap (invoke "select-trap-right" (i32.const 1)) "unreachable")
+(assert_trap (invoke "select-trap-right" (i32.const 0)) "unreachable")
+
+;; Validation after unreachable
+
+;; The first two operands should have the same type as each other
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i64.const 1) (i32.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i64.const 1) (i32.const 1) (i32.const 1)) (drop)))
+  "type mismatch"
+)
+
+;; Third operand must be i32
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i32.const 1) (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+;; Result of select has type of first two operands (type of second operand when first one is omitted)
+(assert_invalid
+  (module (func (result i32) (unreachable) (select (i64.const 1) (i32.const 1))))
+  "type mismatch"
+)
+
+;; select always has non-empty result
+(assert_invalid
+  (module (func (unreachable) (select)))
+  "type mismatch"
+)
+
+(module
+  (func (export "meet-bottom")
+    (block (result f64)
+      (block (result f32)
+        (unreachable)
+        (br_table 0 1 1 (i32.const 1))
+      )
+      (drop)
+      (f64.const 0)
+    )
+    (drop)
+  )
+)
+
+(assert_invalid
+  (module (func $meet-bottom (param i32) (result externref)
+    (block $l1 (result externref)
+      (drop
+        (block $l2 (result i32)
+          (br_table $l2 $l1 $l2 (ref.null extern) (local.get 0))
+        )
+      )
+      (ref.null extern)
+    )
+  ))
+  "type mismatch"
+)
+

--- a/test/core/unreached-invalid.wast
+++ b/test/core/unreached-invalid.wast
@@ -693,3 +693,58 @@
   )
  "type mismatch"
 )
+
+;; The first two operands should have the same type as each other
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i64.const 1) (i32.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i64.const 1) (i32.const 1) (i32.const 1)) (drop)))
+  "type mismatch"
+)
+
+;; Third operand must be i32
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i32.const 1) (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i32.const 1) (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func (unreachable) (select (i64.const 1)) (drop)))
+  "type mismatch"
+)
+
+;; Result of select has type of first two operands (type of second operand when first one is omitted)
+(assert_invalid
+  (module (func (result i32) (unreachable) (select (i64.const 1) (i32.const 1))))
+  "type mismatch"
+)
+
+
+;; select always has non-empty result
+(assert_invalid
+  (module (func (unreachable) (select)))
+  "type mismatch"
+)
+
+(assert_invalid
+  (module (func $meet-bottom (param i32) (result externref)
+    (block $l1 (result externref)
+      (drop
+        (block $l2 (result i32)
+          (br_table $l2 $l1 $l2 (ref.null extern) (local.get 0))
+        )
+      )
+      (ref.null extern)
+    )
+  ))
+  "type mismatch"
+)
+

--- a/test/core/unreached-valid.wast
+++ b/test/core/unreached-valid.wast
@@ -46,45 +46,6 @@
 
 ;; Validation after unreachable
 
-;; The first two operands should have the same type as each other
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i64.const 1) (i32.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i64.const 1) (i32.const 1) (i32.const 1)) (drop)))
-  "type mismatch"
-)
-
-;; Third operand must be i32
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i32.const 1) (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i32.const 1) (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-(assert_invalid
-  (module (func (unreachable) (select (i64.const 1)) (drop)))
-  "type mismatch"
-)
-
-;; Result of select has type of first two operands (type of second operand when first one is omitted)
-(assert_invalid
-  (module (func (result i32) (unreachable) (select (i64.const 1) (i32.const 1))))
-  "type mismatch"
-)
-
-;; select always has non-empty result
-(assert_invalid
-  (module (func (unreachable) (select)))
-  "type mismatch"
-)
-
 (module
   (func (export "meet-bottom")
     (block (result f64)
@@ -97,19 +58,5 @@
     )
     (drop)
   )
-)
-
-(assert_invalid
-  (module (func $meet-bottom (param i32) (result externref)
-    (block $l1 (result externref)
-      (drop
-        (block $l2 (result i32)
-          (br_table $l2 $l1 $l2 (ref.null extern) (local.get 0))
-        )
-      )
-      (ref.null extern)
-    )
-  ))
-  "type mismatch"
 )
 


### PR DESCRIPTION
This PR factors out tests that deal with validating unreachable code in the presence of the bottom type. Specifically, both `select` and `br_table` have tricky corner cases that probably deserve their own file.

The motivation for this PR is merely to factor out these tricky corner cases into their own test file in anticipation of any more corner cases that are found or any future changes to how unreachable code is validated. This makes it easy to pinpoint the changes introduced and to diagnose the problem in implementations.