### PR TITLE
[js-api] Fix link to HTML.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1047,7 +1047,7 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
   To <dfn>create a host function</dfn> from the JavaScript object |func| and type |functype|, perform the following steps:
 
     1. Assert: [=IsCallable=](|func|).
-    1. Let |stored settings| be the [=incumbent settings object=].
+    1. Let |stored settings| be the <a spec=HTML>incumbent settings object</a>.
     1. Let |hostfunc| be a [=host function=] which performs the following steps when called with arguments |arguments|:
         1. Let |realm| be |func|'s [=associated Realm=].
         1. Let |relevant settings| be |realm|'s [=Realm/settings object=].


### PR DESCRIPTION
Although it was un-exported from HTML recently, this is one of the very few specs which has legitimate reason to link to it.