### PR TITLE
[CI] Adjust JS/Web API build to use latest bikeshed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,29 +25,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build JS API bikeshed
-        uses: netwerk-digitaal-erfgoed/bikeshed-action@v1
-        with:
-          source: "document/js-api/index.bs"
-          destination: "document/js-api/index.html"
+      - run: pip install bikeshed && bikeshed update
+      - run: bikeshed spec "document/js-api/index.bs" "document/js-api/index.html"
       - uses: actions/upload-artifact@v2
         with:
           name: js-api-rendered
-          path: document/js-api
+          path: document/js-api/index.html
 
   build-web-api-spec:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build JS API bikeshed
-        uses: netwerk-digitaal-erfgoed/bikeshed-action@v1
-        with:
-          source: "document/web-api/index.bs"
-          destination: "document/web-api/index.html"
+      - run: pip install bikeshed && bikeshed update
+      - run: bikeshed spec "document/web-api/index.bs" "document/web-api/index.html"
       - uses: actions/upload-artifact@v2
         with:
           name: web-api-rendered
-          path: document/web-api
+          path: document/web-api/index.html
 
   build-core-spec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR addresses some comments in https://github.com/WebAssembly/spec/issues/1342#issuecomment-881284494 about the recently merged CI PR #1344.

  * Uses pip to install the latest bikeshed to use that for JS/Web API docs (instead of a pinned older version)
  * Only publish the `.html`, not the `.bs` or `Makefile`