### PR TITLE
Remove outdated table test

### DIFF
--- a/test/js-api/table/get-set.any.js
+++ b/test/js-api/table/get-set.any.js
@@ -56,7 +56,6 @@ test(() => {
   const argument = { "element": "anyfunc", "initial": 5 };
   const table = new WebAssembly.Table(argument);
   assert_throws_js(TypeError, () => table.set());
-  assert_throws_js(TypeError, () => table.set(0));
 }, "Missing arguments: set");
 
 test(t => {


### PR DESCRIPTION
The spec allows a missing `value` parameter in `WebAssembly.Table.set`, see https://webassembly.github.io/spec/js-api/index.html#dom-table-set.  There is a test, however, that `WebAssembly.Table.set` throws if there is no `value` parameter. This PR deletes that test.