### PR TITLE
Transfer updated test from WPT

### DIFF
--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -72,7 +72,16 @@ test(() => {
       assert_unreached(`Should not call [[HasProperty]] with ${x}`);
     },
     get(o, x) {
-      return 0;
+      // Due to the requirement not to supply both minimum and initial, we need to ignore one of them.
+      switch (x) {
+        case "shared":
+          return false;
+        case "initial":
+        case "maximum":
+          return 0;
+        default:
+          return undefined;
+      }
     },
   });
   new WebAssembly.Memory(proxy);


### PR DESCRIPTION
In WPT the test was updated to prepare for the type reflection proposal. This PR transfers the changes to the spec tests.
The test in WPT: https://github.com/web-platform-tests/wpt/blob/38413c5570e6f3b2eb3c8abdb32876345f6fce50/wasm/jsapi/memory/constructor.any.js#L69