### PR TITLE
Add action to mirror main to master

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    name: Mirror main branch to master branch
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: google/mirror-branch-action@v1.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'main'
+        dest: 'master'


### PR DESCRIPTION
I created [main branch](https://github.com/WebAssembly/spec/tree/main) on the remote so this should work now.

I don't expect any downstream (forks/proposals) to have issues, since master will still exist. This mirroring will mirror any changes on main to master, so it will be kept up to date.

Follow-up to this will be to update places like https://github.com/WebAssembly/proposals/blob/master/howto.md to refer to main.