### PR TITLE
Revert "[spec] Fix variable name typos"

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1412,15 +1412,15 @@ Memory Instructions
 
 10. Assert: due to :ref:`validation <valid-memory.init>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-11. Pop the value :math:`\I32.\CONST~n` from the stack.
+11. Pop the value :math:`\I32.\CONST~cnt` from the stack.
 
 12. Assert: due to :ref:`validation <valid-memory.init>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-13. Pop the value :math:`\I32.\CONST~s` from the stack.
+13. Pop the value :math:`\I32.\CONST~src` from the stack.
 
 14. Assert: due to :ref:`validation <valid-memory.init>`, a value of :ref:`value type <syntax-valtype>` |I32| is on the top of the stack.
 
-15. Pop the value :math:`\I32.\CONST~d` from the stack.
+15. Pop the value :math:`\I32.\CONST~dst` from the stack.
 
 16. If :math:`s + n` is larger than the length of :math:`\X{data}.\DIDATA` or :math:`d + n` is larger than the length of :math:`\X{mem}.\MIDATA`, then:
 


### PR DESCRIPTION
Reverts WebAssembly/spec#1358