### PR TITLE
Rename "master" to "main" in repository URLs that have switched to "main".

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -3,6 +3,6 @@
 Interested in participating? Please follow
 [the same contributing guidelines as the design repository][].
 
-  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/master/Contributing.md
+  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/main/Contributing.md
 
 Also, please be sure to read [the README.md](README.md) for this repository.

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -105,16 +105,16 @@ Added instructions that modify ranges of memory or table entries [#proposal-reft
 
 
 .. [#proposal-signext]
-   https://github.com/WebAssembly/spec/tree/master/proposals/sign-extension-ops/
+   https://github.com/WebAssembly/spec/tree/main/proposals/sign-extension-ops/
 
 .. [#proposal-cvtsat]
-   https://github.com/WebAssembly/spec/tree/master/proposals/nontrapping-float-to-int-conversion/
+   https://github.com/WebAssembly/spec/tree/main/proposals/nontrapping-float-to-int-conversion/
 
 .. [#proposal-multivalue]
-   https://github.com/WebAssembly/spec/tree/master/proposals/multi-value/
+   https://github.com/WebAssembly/spec/tree/main/proposals/multi-value/
 
 .. [#proposal-reftype]
-   https://github.com/WebAssembly/spec/tree/master/proposals/reference-types/
+   https://github.com/WebAssembly/spec/tree/main/proposals/reference-types/
 
 .. [#proposal-bulk]
-   https://github.com/WebAssembly/spec/tree/master/proposals/bulk-memory-operations/
+   https://github.com/WebAssembly/spec/tree/main/proposals/bulk-memory-operations/

--- a/document/deploy.sh
+++ b/document/deploy.sh
@@ -177,7 +177,7 @@ incremental_deploy() {
 		0) echo No changes to files in $deploy_directory. Skipping commit.;;
 		1) commit_and_push;;
 		*)
-			echo git diff exited with code $diff. Aborting. Staying on branch $deploy_branch so you can debug. To switch back to master, use: git symbolic-ref HEAD refs/heads/master && git reset --mixed >&2
+			echo git diff exited with code $diff. Aborting. Staying on branch $deploy_branch so you can debug. To switch back to main, use: git symbolic-ref HEAD refs/heads/main && git reset --mixed >&2
 			return $diff
 			;;
 	esac

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -163,7 +163,7 @@ WebAssemblyText.decode(binary)
 
 ## S-Expression Syntax
 
-The implementation consumes a WebAssembly AST given in S-expression syntax. Here is an overview of the grammar of types, expressions, functions, and modules, mirroring what's described in the [design doc](https://github.com/WebAssembly/design/blob/master/Semantics.md).
+The implementation consumes a WebAssembly AST given in S-expression syntax. Here is an overview of the grammar of types, expressions, functions, and modules, mirroring what's described in the [design doc](https://github.com/WebAssembly/design/blob/main/Semantics.md).
 
 Note: The grammar is shown here for convenience, the definite source is the [specification of the text format](https://webassembly.github.io/spec/core/text/).
 ```
@@ -479,7 +479,7 @@ Moreover, float values are required to be precise, that is, they may not contain
 
 ## Abstract Syntax
 
-The abstract WebAssembly syntax, as described above and in the [design doc](https://github.com/WebAssembly/design/blob/master/Semantics.md), is defined in [ast.ml](syntax/ast.ml).
+The abstract WebAssembly syntax, as described above and in the [design doc](https://github.com/WebAssembly/design/blob/main/Semantics.md), is defined in [ast.ml](syntax/ast.ml).
 
 However, to simplify the implementation, this AST representation represents some of the inner structure of the operators more explicitly. The mapping from the operators as given in the design doc to their structured form is defined in [operators.ml](syntax/operators.ml).
 

--- a/proposals/multi-value/Overview.md
+++ b/proposals/multi-value/Overview.md
@@ -14,7 +14,7 @@
   - can easily be lifted by generalising to value* -> value*
 
 * Generalised semantics is well-understood
-  - https://github.com/WebAssembly/spec/tree/master/papers/pldi2017.pdf
+  - https://github.com/WebAssembly/spec/tree/main/papers/pldi2017.pdf
 
 * Semi-complete implementation of multiple results in V8
 

--- a/proposals/nontrapping-float-to-int-conversion/Overview.md
+++ b/proposals/nontrapping-float-to-int-conversion/Overview.md
@@ -32,7 +32,7 @@ https://github.com/WebAssembly/meetings/pull/3
 
 and
 
-https://github.com/WebAssembly/meetings/blob/master/2017/CG-05.md#non-trapping-float-to-int
+https://github.com/WebAssembly/meetings/blob/main/2017/CG-05.md#non-trapping-float-to-int
 
 which made decisions about which semantics to choose, and which encoding strategy.
 
@@ -43,7 +43,7 @@ https://github.com/WebAssembly/design/pull/1089
 At the CG-07-06 meeting it was decided that a full spec repo fork should be
 created to follow the new process for new features:
 
-https://github.com/WebAssembly/meetings/blob/master/2017/CG-07-06.md#float-to-int-conversion
+https://github.com/WebAssembly/meetings/blob/main/2017/CG-07-06.md#float-to-int-conversion
 
 This led to the creation of the present repo:
 

--- a/proposals/reference-types/Overview.md
+++ b/proposals/reference-types/Overview.md
@@ -6,7 +6,7 @@ TODO: more text, motivation, explanation
 
 Motivation:
 
-* Easier and more efficient interop with host environment (see e.g. the [Interface Types proposal](https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md))
+* Easier and more efficient interop with host environment (see e.g. the [Interface Types proposal](https://github.com/WebAssembly/interface-types/blob/main/proposals/interface-types/Explainer.md))
   - allow host references to be represented directly by type `externref` (see [here](https://github.com/WebAssembly/interface-types/issues/9))
   - without having to go through tables, allocating slots, and maintaining index bijections at the boundaries
 
@@ -19,7 +19,7 @@ by repurposing tables as a general memory for opaque data types
 * Set the stage for later additions:
 
   - Typed function references (see [below](#typed-function-references))
-  - Exception references (see the [exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/Exceptions.md) and [here](https://github.com/WebAssembly/interface-types/issues/10))
+  - Exception references (see the [exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/main/proposals/Exceptions.md) and [here](https://github.com/WebAssembly/interface-types/issues/10))
   - A smoother transition path to GC (see the [GC proposal](https://github.com/WebAssembly/gc/blob/master/proposals/gc/Overview.md))
 
 Get the most important parts soon!

--- a/proposals/sign-extension-ops/Overview.md
+++ b/proposals/sign-extension-ops/Overview.md
@@ -45,7 +45,7 @@ instr ::= ...
         | 0xC4                  =>  i64.extend32_s
 ```
 
-[future sext]: https://github.com/WebAssembly/design/blob/master/FutureFeatures.md#additional-integer-operators
+[future sext]: https://github.com/WebAssembly/design/blob/main/FutureFeatures.md#additional-integer-operators
 [instruction syntax]: https://webassembly.github.io/spec/syntax/instructions.html
 [instruction binary format]: https://webassembly.github.io/spec/binary/instructions.html
 [spec]: https://webassembly.github.io/sign-extension-ops/

--- a/test/Todo.md
+++ b/test/Todo.md
@@ -1,5 +1,5 @@
 This is a rough list of "tests to write". Everything here should either be
-specified in [Semantics.md](https://github.com/WebAssembly/design/blob/master/Semantics.md),
+specified in [Semantics.md](https://github.com/WebAssembly/design/blob/main/Semantics.md),
 have a link to an open issue/PR, or be obvious. Comments/corrections/additions
 welcome.
 

--- a/test/core/README.md
+++ b/test/core/README.md
@@ -1,6 +1,6 @@
-This directory contains tests for the core WebAssembly semantics, as described in [Semantics.md](https://github.com/WebAssembly/design/blob/master/Semantics.md) and specified by the [spec interpreter](https://github.com/WebAssembly/spec/blob/master/interpreter).
+This directory contains tests for the core WebAssembly semantics, as described in [Semantics.md](https://github.com/WebAssembly/design/blob/main/Semantics.md) and specified by the [spec interpreter](https://github.com/WebAssembly/spec/blob/main/interpreter).
 
-Tests are written in the [S-Expression script format](https://github.com/WebAssembly/spec/blob/master/interpreter/README.md#s-expression-syntax) defined by the interpreter.
+Tests are written in the [S-Expression script format](https://github.com/WebAssembly/spec/blob/main/interpreter/README.md#s-expression-syntax) defined by the interpreter.
 
 The test suite can be run with the spec interpreter as follows:
 ```


### PR DESCRIPTION
Several WebAssembly organization repositories have changed their default
branch from "master" to "main": see WebAssembly/design#1417 for details.
This PR updates URLs in the spec repository to point to "main" instead of
"master", for repositories which have done so.