### PR TITLE
Add integer tests for using nan patterns outside of script

### DIFF
--- a/test/core/i32.wast
+++ b/test/core/i32.wast
@@ -974,3 +974,12 @@
 (assert_invalid (module (func (result i32) (i32.lt_s (i64.const 0) (f32.const 0)))) "type mismatch")
 (assert_invalid (module (func (result i32) (i32.lt_u (i64.const 0) (f32.const 0)))) "type mismatch")
 (assert_invalid (module (func (result i32) (i32.ne (i64.const 0) (f32.const 0)))) "type mismatch")
+
+(assert_malformed
+  (module quote "(func (result i32) (i32.const nan:arithmetic))")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (result i32) (i32.const nan:canonical))")
+  "unexpected token"
+)

--- a/test/core/i64.wast
+++ b/test/core/i64.wast
@@ -483,3 +483,12 @@
 (assert_invalid (module (func (result i64) (i64.lt_s (i32.const 0) (f32.const 0)))) "type mismatch")
 (assert_invalid (module (func (result i64) (i64.lt_u (i32.const 0) (f32.const 0)))) "type mismatch")
 (assert_invalid (module (func (result i64) (i64.ne (i32.const 0) (f32.const 0)))) "type mismatch")
+
+(assert_malformed
+  (module quote "(func (result i64) (i64.const nan:arithmetic))")
+  "unexpected token"
+)
+(assert_malformed
+  (module quote "(func (result i64) (i64.const nan:canonical))")
+  "unexpected token"
+)


### PR DESCRIPTION
Similar to 5893af5bce241fbb074d482a65706126c031b8ed but for integers,
this is also a type mismatch, but should first be caught at parse time.