### PR TITLE
Use main in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -78,7 +78,7 @@ jobs:
           name: core-api-rendered
           path: _output/core
       - name: Publish HTML to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           publish_dir: ./_output


### PR DESCRIPTION
Default branch is now main, so all the PRs are based on main, which
means the actions aren't currently triggered, since they only run on
push to master. Update it to main.

Since we have the main->master mirror, we should still be testing, but
it is a bit delayed (only after the mirror I think, and not on the PR).