### PR TITLE
Update sphinx to 3.5.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       - run: pip install bikeshed && bikeshed update
       - run: pip install six
       - run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-      - run: pip install sphinx==3.5.2
+      - run: pip install sphinx==3.5.4
       - run: cd document/core && make all
       - uses: actions/upload-artifact@v2
         with:

--- a/document/README.md
+++ b/document/README.md
@@ -42,7 +42,7 @@ pipenv shell
 Install Python dependencies:
 
 ```
-pipenv install Sphinx==3.5.2
+pipenv install Sphinx==3.5.4
 ```
 
 ### Checking out the repository


### PR DESCRIPTION
Our current version of sphinx doesn't limit the supported docutils
versions, and 0.18.0 breaks something
(https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-18-2021-10-26
likely the new meta node)

3.5.4 restricts the docutils versions:
https://www.sphinx-doc.org/en/master/changes.html#release-3-5-4-released-apr-11-2021