### PR TITLE
Only include ref links to index in multi-page html

### DIFF
--- a/document/core/index.rst
+++ b/document/core/index.rst
@@ -29,7 +29,11 @@ WebAssembly Specification
       appendix/index-instructions
       appendix/index-rules
 
-.. only:: html
+..
+   Only include these links when using (multi-page) html builder.
+   (The singlepage html builder is called builder_singlehtml.)
+
+.. only:: builder_html
 
    * :ref:`index-type`
    * :ref:`index-instr`

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -160,19 +160,6 @@ def Main():
   data = data.replace(
       '<li class="nav-item nav-item-0"><a href="index.html#document-index">'
       'WebAssembly 1.0</a> »', '')
-  # Drop Index links.
-  data = data.replace(
-      '<li><a class="reference internal" href="index.html#index-type">'
-      '<span class="std std-ref">Index of Types</span></a>', '')
-  data = data.replace(
-      '<li><a class="reference internal" href="index.html#index-instr">'
-      '<span class="std std-ref">Index of Instructions</span></a>', '')
-  data = data.replace(
-      '<li><a class="reference internal" href="index.html#index-rules">'
-      '<span class="std std-ref">Index of Semantic Rules</span></a>', '')
-  data = data.replace(
-      '<li><a class="reference internal" href="genindex.html">'
-      '<span class="std std-ref">Index</span></a>', '')
   # Drop sphinx css.
   data = data.replace(
       '<link href="_static/classic.css" rel="stylesheet" type="text/css">', '')


### PR DESCRIPTION
This allows us to drop some manual links removal in mathjax2katex.py.