### PR TITLE
Fix html_last_updated_fmt

### DIFF
--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -252,7 +252,7 @@ html_show_copyright = True
 # If this is not None, a ‘Last updated on:’ timestamp is inserted at every
 # page bottom, using the given strftime() format.
 #
-html_last_updated_fmt = '%F'
+html_last_updated_fmt = '%Y-%m-%d'
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
'%F' is not a supported format, see
https://github.com/sphinx-doc/sphinx/blob/4.x/sphinx/util/i18n.py#L133,
it is also not supported in Python's strftime/strptime
https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior.

It is however supported in strftime
(https://man7.org/linux/man-pages/man3/strftime.3.html) and defined to
be "%Y-%m-%d", which is supported by sphinx.