### PR TITLE
Remove use of physical equality on characters

### DIFF
--- a/interpreter/exec/int.ml
+++ b/interpreter/exec/int.ml
@@ -284,7 +284,7 @@ struct
 
   let of_string_u s =
     let n = of_string s in
-    require (s.[0] != '+' && s.[0] != '-');
+    require (s.[0] <> '+' && s.[0] <> '-');
     n
 
   (* String conversion that groups digits for readability *)


### PR DESCRIPTION
The meaning of `!=` is [implementation-dependent](https://www.ocaml.org/api/Stdlib.html) in OCaml. This seems undesirable for a reference interpreter.

This PR switches to to `<>` which checks for structural non-equality rather than physical non-equlity.