### PR TITLE
Add --generate-js-only flag to test runner

### DIFF
--- a/test/core/run.py
+++ b/test/core/run.py
@@ -17,6 +17,7 @@ outputDir = os.path.join(inputDir, "_output")
 parser = argparse.ArgumentParser()
 parser.add_argument("--wasm", metavar="<wasm-command>", default=os.path.join(os.getcwd(), "wasm"))
 parser.add_argument("--js", metavar="<js-command>")
+parser.add_argument("--generate-js-only", action='store_true')
 parser.add_argument("--out", metavar="<out-dir>", default=outputDir)
 parser.add_argument("file", nargs='*')
 arguments = parser.parse_args()
@@ -28,6 +29,7 @@ simd_test_files = glob.glob(os.path.join(inputDir, "simd", "*.wast"))
 
 wasmCommand = arguments.wasm
 jsCommand = arguments.js
+generateJsOnly = arguments.generate_js_only
 outputDir = arguments.out
 inputFiles = arguments.file if arguments.file else main_test_files + simd_test_files
 
@@ -64,6 +66,14 @@ class RunTests(unittest.TestCase):
     dir, inputFile = os.path.split(inputPath)
     outputPath = os.path.join(outputDir, inputFile)
 
+    # Generate JS first, then return early if we are only generating JS.
+    jsPath = self._auxFile(outputPath.replace(".wast", ".js"))
+    logPath = self._auxFile(jsPath + ".log")
+    self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, inputPath, jsPath), logPath)
+
+    if generateJsOnly:
+      return
+
     # Run original file
     expectedExitCode = 1 if ".fail." in inputFile else 0
     logPath = self._auxFile(outputPath + ".log")
@@ -96,9 +106,6 @@ class RunTests(unittest.TestCase):
     self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, wasm2Path, wast2Path), logPath)
     self._compareFile(wastPath, wast2Path)
 
-    jsPath = self._auxFile(outputPath.replace(".wast", ".js"))
-    logPath = self._auxFile(jsPath + ".log")
-    self._runCommand(('%s -d "%s" -o "%s"') % (wasmCommand, inputPath, jsPath), logPath)
     if jsCommand != None:
       self._runCommand(('%s "%s"') % (jsCommand, jsPath), logPath)
 


### PR DESCRIPTION
This will return early right after generating JS from the wast test
files. It will not attempt to run the tests, or do the round trip
conversion from wasm <-> wast.

This is convenient for proposals to add tests without having to
update the reference interpreter with implementation, and generate those
tests to JS to run in other Wasm engines.

Fixes #1430.