### PR TITLE
[spec] exec/instructions.rst: fix missing immediate on table.set

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1191,8 +1191,8 @@ Table Instructions
 
 .. _exec-table.set:
 
-:math:`\TABLESET`
-.................
+:math:`\TABLESET~x`
+...................
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 


### PR DESCRIPTION
The table.set instruction was missing its immediate `x` in the execution spec heading.