### PR TITLE
[spec] Bump release to 2

### DIFF
--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -7,7 +7,7 @@ Change History
 Since the original release 1.0 of the WebAssembly specification, a number of proposals for extensions have been integrated.
 The following sections provide an overview of what has changed.
 
-Release 1.1
+Release 2.0
 ~~~~~~~~~~~
 
 .. index:: instruction, integer

--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -26,7 +26,7 @@ sys.path.insert(0, pwd)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '1.4'
+needs_sphinx = '2.3'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -60,7 +60,7 @@ master_doc = 'index'
 name = 'WebAssembly'
 project = u'WebAssembly'
 title = u'WebAssembly Specification'
-copyright = u'2017, WebAssembly Community Group'
+copyright = u'2022, WebAssembly Community Group'
 author = u'WebAssembly Community Group'
 editor = u'Andreas Rossberg (editor)'
 logo = 'static/webassembly.png'
@@ -79,7 +79,7 @@ draft = ' (Draft ' + date.today().strftime("%Y-%m-%d") + ')'
 # built documents.
 #
 # The short X.Y version.
-version = u'1.1'
+version = u'2.0'
 # The full version, including alpha/beta/rc tags.
 release = version + ('' if proposal == '' else ' + ') + proposal + draft
 

--- a/document/core/index.bs
+++ b/document/core/index.bs
@@ -3,13 +3,13 @@ Title: WebAssembly Core Specification
 Shortname: wasm-core
 Group: wasm
 Status: ED
-Level: 1
-TR: https://www.w3.org/TR/wasm-core-1/
+Level: 2
+TR: https://www.w3.org/TR/wasm-core-2/
 ED: https://webassembly.github.io/spec/core/bikeshed/
 Editor: Andreas Rossberg (Dfinity Stiftung)
 Repository: WebAssembly/spec
 Markup Shorthands: css no, markdown no, algorithm no, idl no
-Abstract: This document describes version 1.1 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
+Abstract: This document describes version 2.0 of the core WebAssembly standard, a safe, portable, low-level code format designed for efficient execution and compact representation.
 Prepare For TR: true
 </pre>
 

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -3,8 +3,8 @@ Title: WebAssembly JavaScript Interface
 Shortname: wasm-js-api
 Group: wasm
 Status: ED
-Level: 1
-TR: https://www.w3.org/TR/wasm-js-api-1/
+Level: 2
+TR: https://www.w3.org/TR/wasm-js-api-2/
 ED: https://webassembly.github.io/spec/js-api/
 Editor: Ms2ger, Igalia
 Repository: WebAssembly/spec

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -3,8 +3,8 @@ Title: WebAssembly Web API
 Shortname: wasm-web-api
 Group: wasm
 Status: ED
-Level: 1
-TR: https://www.w3.org/TR/wasm-web-api-1/
+Level: 2
+TR: https://www.w3.org/TR/wasm-web-api-2/
 ED: https://webassembly.github.io/spec/web-api/
 Editor: Ms2ger, Igalia
 Repository: WebAssembly/spec

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -1,5 +1,5 @@
 let name = "wasm"
-let version = "1.1"
+let version = "2.0"
 
 let configure () =
   Import.register (Utf8.decode "spectest") Spectest.lookup;


### PR DESCRIPTION
At yesterday's WG meeting, we decided to make a new release, now switching to the Evergreen model. For administrative and technical reasons having to do with W3C procedure, we decided to bump the release number to 2.

From now on, the standard will iterate at *version* 2 from the W3C's official perspective. We use minor *release* numbers internally to distinguish different iterations.

(@ericprud, I hope I understood correctly that the Bikeshed "level" also needed to be bumped to 2.)