### PR TITLE
Adds missing start from overview example

### DIFF
--- a/proposals/bulk-memory-operations/Overview.md
+++ b/proposals/bulk-memory-operations/Overview.md
@@ -386,6 +386,7 @@ implemented as follows:
     ;; be dropped.
     (data.drop 1))
 )
+(start $start)
 ```
 
 ### Instruction encoding


### PR DESCRIPTION
Lost some time not noticing this. While it is possible others will guess sooner than I did
by function name and it isn't exported that they should add it as a start function, better
to be explicit I think.