### PR TITLE
Add assert_trap for unreached valid case

### DIFF
--- a/test/core/unreached-valid.wast
+++ b/test/core/unreached-valid.wast
@@ -60,3 +60,4 @@
   )
 )
 
+(assert_trap (invoke "meet-bottom") "unreachable")


### PR DESCRIPTION
This PR adds an overlooked assertion for a valid case of unreachable code is actually callable and traps.