### PR TITLE
[spec] Fix binary format of data/elem tags to allow LEB

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -327,28 +327,28 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \production{element section} & \Belemsec &::=&
      \X{seg}^\ast{:}\Bsection_9(\Bvec(\Belem)) &\Rightarrow& \X{seg} \\
    \production{element segment} & \Belem &::=&
-     \hex{00}~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
+     0{:}\Bu32~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EACTIVE~\{ \ETABLE~0, \EOFFSET~e \} \} \\ &&|&
-     \hex{01}~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+     1{:}\Bu32~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EPASSIVE \} \\ &&|&
-     \hex{02}~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+     2{:}\Bu32~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\ &&|&
-     \hex{03}~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+     3{:}\Bu32~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EDECLARATIVE \} \\ &&|&
-     \hex{04}~~e{:}\Bexpr~~\X{el}^\ast{:}\Bvec(\Bexpr)
+     4{:}\Bu32~~e{:}\Bexpr~~\X{el}^\ast{:}\Bvec(\Bexpr)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~\FUNCREF, \EINIT~\X{el}^\ast, \EMODE~\EACTIVE~\{ \ETABLE~0, \EOFFSET~e \} \} \\ &&|&
-     \hex{05}~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
+     5{:}\Bu32~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~et, \EINIT~\X{el}^\ast, \EMODE~\EPASSIVE \} \\ &&|&
-     \hex{06}~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
+     6{:}\Bu32~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~et, \EINIT~\X{el}^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\ &&|&
-     \hex{07}~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
+     7{:}\Bu32~~\X{et}:\Breftype~~\X{el}^\ast{:}\Bvec(\Bexpr)
        &\Rightarrow& \\&&&\quad
        \{ \ETYPE~et, \EINIT~\X{el}^\ast, \EMODE~\EDECLARATIVE \} \\
    \production{element kind} & \Belemkind &::=&
@@ -356,7 +356,7 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \end{array}
 
 .. note::
-   The initial byte can be interpreted as a bitfield.
+   The initial integer can be interpreted as a bitfield.
    Bit 0 indicates a passive or declarative segment,
    bit 1 indicates the presence of an explicit table index for an active segment and otherwise distinguishes passive from declarative segments,
    bit 2 indicates the use of element type and element :ref:`expressions <binary-expr>` instead of element kind and element indices.
@@ -440,16 +440,16 @@ It decodes into a vector of :ref:`data segments <syntax-data>` that represent th
    \production{data section} & \Bdatasec &::=&
      \X{seg}^\ast{:}\Bsection_{11}(\Bvec(\Bdata)) &\Rightarrow& \X{seg} \\
    \production{data segment} & \Bdata &::=&
-     \hex{00}~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
+     0{:}\Bu32~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
        &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~0, \DOFFSET~e \} \} \\ &&|&
-     \hex{01}~~b^\ast{:}\Bvec(\Bbyte)
+     1{:}\Bu32~~b^\ast{:}\Bvec(\Bbyte)
        &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DPASSIVE \} \\ &&|&
-     \hex{02}~~x{:}\Bmemidx~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
+     2{:}\Bu32~~x{:}\Bmemidx~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
        &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~x, \DOFFSET~e \} \} \\
    \end{array}
 
 .. note::
-   The initial byte can be interpreted as a bitfield.
+   The initial integer can be interpreted as a bitfield.
    Bit 0 indicates a passive segment,
    bit 1 indicates the presence of an explicit memory index for an active segment.
 

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -140,23 +140,68 @@
   "\41\00\0b\00"                       ;; (i32.const 0) with no elements
 )
 
-;; Data segment memory index can have non-minimal length
+;; Data segment tags and memory index can have non-minimal length
 (module binary
   "\00asm" "\01\00\00\00"
   "\05\03\01"                          ;; Memory section with 1 entry
   "\00\00"                             ;; no max, minimum 0
   "\0b\07\01"                          ;; Data section with 1 entry
-  "\80\00"                             ;; Memory index 0, encoded with 2 bytes
+  "\80\00"                             ;; Active segment, encoded with 2 bytes
+  "\41\00\0b\00"                       ;; (i32.const 0) with contents ""
+)
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\05\03\01"                          ;; Memory section with 1 entry
+  "\00\00"                             ;; no max, minimum 0
+  "\0b\08\01"                          ;; Data section with 1 entry
+  "\82\00"                             ;; Active segment, encoded with 2 bytes
+  "\00"                                ;; explicit memory index
+  "\41\00\0b\00"                       ;; (i32.const 0) with contents ""
+)
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\05\03\01"                          ;; Memory section with 1 entry
+  "\00\00"                             ;; no max, minimum 0
+  "\0b\09\01"                          ;; Data section with 1 entry
+  "\82\00"                             ;; Active segment, encoded with 2 bytes
+  "\80\00"                             ;; explicit memory index, encoded with 2 bytes
   "\41\00\0b\00"                       ;; (i32.const 0) with contents ""
 )
 
-;; Element segment table index can have non-minimal length
+;; Element segment tags and table index can have non-minimal length
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\04\04\01"                          ;; Table section with 1 entry
+  "\70\00\00"                          ;; no max, minimum 0, funcref
+  "\09\07\01"                          ;; Element section with 1 entry
+  "\80\00"                             ;; Active segment
+  "\41\00\0b\00"                       ;; (i32.const 0) with no elements
+)
 (module binary
   "\00asm" "\01\00\00\00"
   "\04\04\01"                          ;; Table section with 1 entry
   "\70\00\00"                          ;; no max, minimum 0, funcref
   "\09\09\01"                          ;; Element section with 1 entry
-  "\02\80\00"                          ;; Table index 0, encoded with 2 bytes
+  "\02"                                ;; Active segment
+  "\80\00"                             ;; explicit table index, encoded with 2 bytes
+  "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
+)
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\04\04\01"                          ;; Table section with 1 entry
+  "\70\00\00"                          ;; no max, minimum 0, funcref
+  "\09\09\01"                          ;; Element section with 1 entry
+  "\82\00"                             ;; Active segment, encoded with 2 bytes
+  "\00"                                ;; explicit table index
+  "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
+)
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\04\04\01"                          ;; Table section with 1 entry
+  "\70\00\00"                          ;; no max, minimum 0, funcref
+  "\09\0a\01"                          ;; Element section with 1 entry
+  "\82\00"                             ;; Active segment, encoded with 2 bytes
+  "\80\00"                             ;; explicit table index, encoded with 2 bytes
   "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
 )
 


### PR DESCRIPTION
Change the encoding of data/element segment tags to be a full LEB u32 instead of a single byte. This matches test suite, reference interpreter, and major engines like V8, JSC(*), Spidermonkey, and Wasmtime. It also reinstantiates backwards compatibility with the Wasm 1.0 format.

Fixes #1439.

(*) With the one exception that JSC [apparently](https://github.com/WebAssembly/spec/issues/1439#issuecomment-1088922572) requires a single byte for element segments but not data segments, an inconsistency that seems more like accident than intent.