### PR TITLE
Update latex .bib file for citing webassembly specs 2.0

### DIFF
--- a/wasm-specs.bib
+++ b/wasm-specs.bib
@@ -1,9 +1,20 @@
-@report{WebAssemblyCoreSpecification,
+@report{WebAssemblyCoreSpecification1,
   title = {{WebAssembly Core Specification}},
+  version = {1.0},
   editor = {Rossberg, Andreas},
   date = {2019-12-05},
   institution = {{W3C}},
   url = {https://www.w3.org/TR/wasm-core-1/},
+  langid = {english}
+}
+
+@report{WebAssemblyCoreSpecification2,
+  title = {{WebAssembly Core Specification}},
+  version = {2.0},
+  editor = {Rossberg, Andreas},
+  date = {2022-04-19},
+  institution = {{W3C}},
+  url = {https://www.w3.org/TR/wasm-core-2/},
   langid = {english},
   note = {https://webassembly.github.io/spec/core/_download/WebAssembly.pdf}
 }


### PR DESCRIPTION
Dear WebAssembly maintainers and developers,

I propose a small contribution by updating the BibTeX file with the Wasm specs 2.0.

I removed the PDF link (in note) for the Wasm specs 1.0 since this URL is constantly updated with the latest specs. Feel free to propose another URL that would reference the PDF for the first iteration of the specs (if needed).

Do not hesitate to ask for other changes to the BibTeX entries in case you see other enhancements.

Cheers,
Jämes