### PR TITLE
Fix syntax error in element segments validation rule

### DIFF
--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -149,7 +149,7 @@ Element segments :math:`\elem` are classified by the :ref:`reference type <synta
 
 * For each :math:`e_i` in :math:`e^\ast`,
 
-  * The expression :math:`e_i` must be :ref:`valid <valid-expr>`.
+  * The expression :math:`e_i` must be valid with :ref:`result type <syntax-resulttype>` :math:`[t]`.
 
   * The expression :math:`e_i` must be :ref:`constant <valid-const>`.
 
@@ -160,7 +160,7 @@ Element segments :math:`\elem` are classified by the :ref:`reference type <synta
 
 .. math::
    \frac{
-     (C \vdashexpr e \ok)^\ast
+     (C \vdashexpr e : [t])^\ast
      \qquad
      (C \vdashexprconst e \const)^\ast
      \qquad


### PR DESCRIPTION
Expressions are valid with a result type and not simply ok. It is also important that elements are well-typed for soundness.