### PR TITLE
TypeError for Global constructor with v128

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -916,7 +916,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |mutable| be |descriptor|["mutable"].
     1. Let |valuetype| be [=ToValueType=](|descriptor|["value"]).
     1. If |valuetype| is [=v128=],
-        1. Throw a {{LinkError}} exception.
+        1. Throw a {{TypeError}} exception.
     1. If |v| is missing,
         1. Let |value| be [=DefaultValue=](|valuetype|).
     1. Otherwise,


### PR DESCRIPTION
At the moment the spec requires a `LinkError` to be thrown when the `WebAssembly.Global` constructor is called for type `v128`. This was introduced in https://github.com/WebAssembly/simd/pull/360, but according to the PR description, actually a `TypeError` should be thrown. The PR refers to https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md#javascript-api-and-simd-values, and there a `TypeError` is required.