### PR TITLE
Remove old note from runtime.rst

### DIFF
--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -84,10 +84,6 @@ It is either a sequence of :ref:`values <syntax-val>` or a :ref:`trap <syntax-tr
      \TRAP
    \end{array}
 
-.. note::
-   In the current version of WebAssembly, a result can consist of at most one value.
-
-
 .. index:: ! store, function instance, table instance, memory instance, global instance, module, allocation
    pair: abstract syntax; store
 .. _syntax-store:


### PR DESCRIPTION
Since the inclusion of the Multiple Value proposal [https://webassembly.github.io/spec/core/appendix/changes.html#multiple-values] it is no longer true that a result can have at most one value.