### PR TITLE
[test] Use still-illegal opcode (func-refs)

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -1258,7 +1258,7 @@
     "\09\07\01"                ;; Element section with one segment
     "\05\70"                   ;; Passive, funcref
     "\01"                      ;; 1 element
-    "\d3\00\0b"                ;; bad opcode, index 0, end
+    "\f3\00\0b"                ;; bad opcode, index 0, end
 
     "\0a\04\01"                ;; Code section
 


### PR DESCRIPTION
The binary.wast test asserts that 0xd3 is an illegal opcode*.   However, in the case of the function references proposal, it becomes a valid opcode.   This PR changes the tested opcode to 0xf3 (which I chose arbitrarily).    I hope this PR is the right thing to do.

In the testsuite repository, the same test / issue occurs two other times:   in the exception-handling proposal and in the multi-memory proposal.    Each has a modified version of the binary.wast file.   I don't know what the next steps are to fix those ones.

\*   it is still not a constant expression, and so still errors in this position, but the error message doesn't match