### PR TITLE
[test] Replace the non-existent "test" module

### DIFF
--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -391,7 +391,7 @@
 )
 
 (assert_invalid
-  (module 
+  (module
     (memory 1)
     (data (offset (;empty instruction sequence;)))
   )
@@ -408,7 +408,7 @@
 
 (assert_invalid
   (module
-    (global (import "test" "global-i32") i32)
+    (global (import "spectest" "global_i32") i32)
     (memory 1)
     (data (offset (global.get 0) (global.get 0)))
   )
@@ -417,7 +417,7 @@
 
 (assert_invalid
   (module
-    (global (import "test" "global-i32") i32)
+    (global (import "spectest" "global_i32") i32)
     (memory 1)
     (data (offset (global.get 0) (i32.const 0)))
   )
@@ -463,7 +463,7 @@
 ;; )
 
 (assert_invalid
-   (module 
+   (module
      (memory 1)
      (data (global.get 0))
    )
@@ -472,15 +472,22 @@
 
 (assert_invalid
    (module
-     (global (import "test" "global-i32") i32)
+     (global (import "spectest" "global_i32") i32)
      (memory 1)
      (data (global.get 1))
    )
    "unknown global 1"
 )
 
+(module
+  (global $g (mut i32) (i32.const 56))
+  (export "global-mut-i32" (global $g))
+)
+
+(register "test")
+
 (assert_invalid
-   (module 
+   (module
      (global (import "test" "global-mut-i32") (mut i32))
      (memory 1)
      (data (global.get 0))

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -359,7 +359,7 @@
 )
 
 (assert_invalid
-  (module 
+  (module
     (table 1 funcref)
     (elem (offset (;empty instruction sequence;)))
   )
@@ -376,7 +376,7 @@
 
 (assert_invalid
   (module
-    (global (import "test" "global-i32") i32)
+    (global (import "spectest" "global_i32") i32)
     (table 1 funcref)
     (elem (offset (global.get 0) (global.get 0)))
   )
@@ -385,7 +385,7 @@
 
 (assert_invalid
   (module
-    (global (import "test" "global-i32") i32)
+    (global (import "spectest" "global_i32") i32)
     (table 1 funcref)
     (elem (offset (global.get 0) (i32.const 0)))
   )
@@ -432,7 +432,7 @@
 ;; )
 
 (assert_invalid
-   (module 
+   (module
      (table 1 funcref)
      (elem (global.get 0))
    )
@@ -441,15 +441,22 @@
 
 (assert_invalid
    (module
-     (global (import "test" "global-i32") i32)
+     (global (import "spectest" "global_i32") i32)
      (table 1 funcref)
      (elem (global.get 1))
    )
    "unknown global 1"
 )
 
+(module
+  (global $g (mut i32) (i32.const 56))
+  (export "global-mut-i32" (global $g))
+)
+
+(register "test")
+
 (assert_invalid
-   (module 
+   (module
      (global (import "test" "global-mut-i32") (mut i32))
      (table 1 funcref)
      (elem (global.get 0))

--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -334,12 +334,12 @@
 )
 
 (assert_invalid
-  (module (global (import "test" "global-i32") i32) (global i32 (global.get 0) (global.get 0)))
+  (module (global (import "spectest" "global_i32") i32) (global i32 (global.get 0) (global.get 0)))
   "type mismatch"
 )
 
 (assert_invalid
-  (module (global (import "test" "global-i32") i32) (global i32 (i32.const 0) (global.get 0)))
+  (module (global (import "spectest" "global_i32") i32) (global i32 (i32.const 0) (global.get 0)))
   "type mismatch"
 )
 
@@ -354,9 +354,16 @@
 )
 
 (assert_invalid
-  (module (global (import "test" "global-i32") i32) (global i32 (global.get 2)))
+  (module (global (import "spectest" "global_i32") i32) (global i32 (global.get 2)))
   "unknown global"
 )
+
+(module
+  (global $g (mut i32) (i32.const 56))
+  (export "global-mut-i32" (global $g))
+)
+
+(register "test")
 
 (assert_invalid
   (module (global (import "test" "global-mut-i32") (mut i32)) (global i32 (global.get 0)))


### PR DESCRIPTION
Fix #1502.

Where possible I used `"spectest"`. In some cases I needed a mutable i32 global which doesn't exists in `"spectest"` so I added a module and registered it.

cc @rossberg 