### PR TITLE
[interpreter] use a correct module_inst /w invoke

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -668,14 +668,14 @@ let rec eval (c : config) : value stack =
 
 (* Functions & Constants *)
 
-let invoke (func : func_inst) (vs : value list) : value list =
+let invoke (mod_inst : module_inst) (func : func_inst) (vs : value list) : value list =
   let at = match func with Func.AstFunc (_, _, f) -> f.at | _ -> no_region in
   let FuncType (ins, out) = Func.type_of func in
   if List.length vs <> List.length ins then
     Crash.error at "wrong number of arguments";
   if not (List.for_all2 (fun v -> (=) (type_of_value v)) vs ins) then
     Crash.error at "wrong types of arguments";
-  let c = config empty_module_inst (List.rev vs) [Invoke func @@ at] in
+  let c = config mod_inst (List.rev vs) [Invoke func @@ at] in
   try List.rev (eval c) with Stack_overflow ->
     Exhaustion.error at "call stack exhausted"
 

--- a/interpreter/exec/eval.mli
+++ b/interpreter/exec/eval.mli
@@ -7,4 +7,4 @@ exception Crash of Source.region * string
 exception Exhaustion of Source.region * string
 
 val init : Ast.module_ -> extern list -> module_inst (* raises Link, Trap *)
-val invoke : func_inst -> value list -> value list (* raises Trap *)
+val invoke : module_inst -> func_inst -> value list -> value list (* raises Trap *)

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -354,7 +354,7 @@ let run_action act : Values.value list =
         if Values.type_of_value v.it <> t then
           Script.error v.at "wrong type of argument"
       ) vs ins;
-      Eval.invoke f (List.map (fun v -> v.it) vs)
+      Eval.invoke inst f (List.map (fun v -> v.it) vs)
     | Some _ -> Assert.error act.at "export is not a function"
     | None -> Assert.error act.at "undefined export"
     )


### PR DESCRIPTION
With an `empty_module_inst` the very first `Invoke` instruction would be
executed with an empty module instance before the handling of the
`Invoke` would grab the instance stored within the function.

Today this isn’t doesn’t produce a wrong result – execution of the
`invoke` does not depend on access to the “correct” module instance.
This is true by the virtue of `Invoke` instruction, and the `invoke`
function, referencing a `func_inst`. However, if they did reference a
`funcaddr` instead, as prescribed in the specification, having an access
to the correct store / module instance would be a hard requirement for the
correct operation.