### PR TITLE
[test] Fix invalid ref.is_null after select

### DIFF
--- a/test/core/unreached-valid.wast
+++ b/test/core/unreached-valid.wast
@@ -33,7 +33,6 @@
   )
   (func (export "unreachable-ref")
     (unreachable)
-    (select)
     (ref.is_null)
     (drop)
   )


### PR DESCRIPTION
`select` without argument produces a numeric or vector type while `ref.is_null` consumes a reference type. Since those types are disjoint, `select` followed by `ref.is_null` can never be well-typed.

The test is fixed by removing the `select` assuming the intent of the test is to check whether `ref.is_null` can be called after `unreachable`.