### PR TITLE
[spec/test] Fix scoping of non-imported globals

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1641,7 +1641,7 @@ Constant Expressions
    }
 
 .. note::
-   Currently, constant expressions occurring as initializers of :ref:`globals <syntax-global>` or offsets in :ref:`element <syntax-elem>` or :ref:`data <syntax-data>` segments are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
+   Currently, constant expressions occurring in :ref:`globals <syntax-global>`, :ref:`element <syntax-elem>`, or :ref:`data <syntax-data>` segments are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
    This is enforced in the :ref:`validation rule for modules <valid-module>` by constraining the context :math:`C` accordingly.
 
    The definition of constant expression may be extended in future versions of WebAssembly.

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1641,7 +1641,7 @@ Constant Expressions
    }
 
 .. note::
-   Currently, constant expressions occurring as initializers of :ref:`globals <syntax-global>` are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
+   Currently, constant expressions occurring as initializers of :ref:`globals <syntax-global>` or offsets in :ref:`element <syntax-elem>` or :ref:`data <syntax-data>` segments are further constrained in that contained |GLOBALGET| instructions are only allowed to refer to *imported* globals.
    This is enforced in the :ref:`validation rule for modules <valid-module>` by constraining the context :math:`C` accordingly.
 
    The definition of constant expression may be extended in future versions of WebAssembly.

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -546,30 +546,13 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
   * all other fields are empty.
 
-* Under the context :math:`C`:
+* For each :math:`\functype_i` in :math:`\module.\MTYPES`,
+  the :ref:`function type <syntax-functype>` :math:`\functype_i` must be :ref:`valid <valid-functype>`.
 
-  * For each :math:`\functype_i` in :math:`\module.\MTYPES`,
-    the :ref:`function type <syntax-functype>` :math:`\functype_i` must be :ref:`valid <valid-functype>`.
+* Under the context :math:`C`:
 
   * For each :math:`\func_i` in :math:`\module.\MFUNCS`,
     the definition :math:`\func_i` must be :ref:`valid <valid-func>` with a :ref:`function type <syntax-functype>` :math:`\X{ft}_i`.
-
-  * For each :math:`\table_i` in :math:`\module.\MTABLES`,
-    the definition :math:`\table_i` must be :ref:`valid <valid-table>` with a :ref:`table type <syntax-tabletype>` :math:`\X{tt}_i`.
-
-  * For each :math:`\mem_i` in :math:`\module.\MMEMS`,
-    the definition :math:`\mem_i` must be :ref:`valid <valid-mem>` with a :ref:`memory type <syntax-memtype>` :math:`\X{mt}_i`.
-
-  * For each :math:`\global_i` in :math:`\module.\MGLOBALS`:
-
-    * Under the context :math:`C'`,
-      the definition :math:`\global_i` must be :ref:`valid <valid-global>` with a :ref:`global type <syntax-globaltype>` :math:`\X{gt}_i`.
-
-  * For each :math:`\elem_i` in :math:`\module.\MELEMS`,
-    the segment :math:`\elem_i` must be :ref:`valid <valid-elem>` with :ref:`reference type <syntax-reftype>` :math:`\X{rt}_i`.
-
-  * For each :math:`\data_i` in :math:`\module.\MDATAS`,
-    the segment :math:`\data_i` must be :ref:`valid <valid-data>`.
 
   * If :math:`\module.\MSTART` is non-empty,
     then :math:`\module.\MSTART` must be :ref:`valid <valid-start>`.
@@ -579,6 +562,23 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
   * For each :math:`\export_i` in :math:`\module.\MEXPORTS`,
     the segment :math:`\export_i` must be :ref:`valid <valid-export>` with :ref:`external type <syntax-externtype>` :math:`\X{et}_i`.
+
+* Under the context :math:`C'`:
+
+  * For each :math:`\table_i` in :math:`\module.\MTABLES`,
+    the definition :math:`\table_i` must be :ref:`valid <valid-table>` with a :ref:`table type <syntax-tabletype>` :math:`\X{tt}_i`.
+
+  * For each :math:`\mem_i` in :math:`\module.\MMEMS`,
+    the definition :math:`\mem_i` must be :ref:`valid <valid-mem>` with a :ref:`memory type <syntax-memtype>` :math:`\X{mt}_i`.
+
+  * For each :math:`\global_i` in :math:`\module.\MGLOBALS`,
+    the definition :math:`\global_i` must be :ref:`valid <valid-global>` with a :ref:`global type <syntax-globaltype>` :math:`\X{gt}_i`.
+
+  * For each :math:`\elem_i` in :math:`\module.\MELEMS`,
+    the segment :math:`\elem_i` must be :ref:`valid <valid-elem>` with :ref:`reference type <syntax-reftype>` :math:`\X{rt}_i`.
+
+  * For each :math:`\data_i` in :math:`\module.\MDATAS`,
+    the segment :math:`\data_i` must be :ref:`valid <valid-data>`.
 
 * The length of :math:`C.\CMEMS` must not be larger than :math:`1`.
 
@@ -607,15 +607,15 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \quad
      (C \vdashfunc \func : \X{ft})^\ast
      \quad
-     (C \vdashtable \table : \X{tt})^\ast
+     (C' \vdashtable \table : \X{tt})^\ast
      \quad
-     (C \vdashmem \mem : \X{mt})^\ast
+     (C' \vdashmem \mem : \X{mt})^\ast
      \quad
      (C' \vdashglobal \global : \X{gt})^\ast
      \\
-     (C \vdashelem \elem : \X{rt})^\ast
+     (C' \vdashelem \elem : \X{rt})^\ast
      \quad
-     (C \vdashdata \data \ok)^n
+     (C' \vdashdata \data \ok)^n
      \quad
      (C \vdashstart \start \ok)^?
      \quad
@@ -667,8 +667,8 @@ Instead, the context :math:`C` for validation of the module's content is constru
    However, this recursion is just a specification device.
    All types needed to construct :math:`C` can easily be determined from a simple pre-pass over the module that does not perform any actual validation.
 
-   Globals, however, are not recursive.
-   The effect of defining the limited context :math:`C'` for validating the module's globals is that their initialization expressions can only access functions and imported globals and nothing else.
+   Globals, however, are not recursive and not accessible within :ref:`constant expressions <valid-const>`.
+   The effect of defining the limited context :math:`C'` for validating certain definitions is that these can only access functions and imported globals and nothing else.
 
 .. note::
    The restriction on the number of memories may be lifted in future versions of WebAssembly.

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -667,8 +667,8 @@ Instead, the context :math:`C` for validation of the module's content is constru
    However, this recursion is just a specification device.
    All types needed to construct :math:`C` can easily be determined from a simple pre-pass over the module that does not perform any actual validation.
 
-   Globals, however, are not recursive and not accessible within :ref:`constant expressions <valid-const>`.
-   The effect of defining the limited context :math:`C'` for validating certain definitions is that these can only access functions and imported globals and nothing else.
+   Globals, however, are not recursive and not accessible within :ref:`constant expressions <valid-const>` when they are defined locally.
+   The effect of defining the limited context :math:`C'` for validating certain definitions is that they can only access functions and imported globals and nothing else.
 
 .. note::
    The restriction on the number of memories may be lifted in future versions of WebAssembly.

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -726,10 +726,10 @@ let check_module (m : module_) =
   in
   List.iter check_type types;
   List.iter (check_global c1) globals;
-  List.iter (check_table c1) tables;
-  List.iter (check_memory c1) memories;
-  List.iter (check_elem c1) elems;
-  List.iter (check_data c1) datas;
+  List.iter (check_table c) tables;
+  List.iter (check_memory c) memories;
+  List.iter (check_elem c) elems;
+  List.iter (check_data c) datas;
   List.iter (check_func c) funcs;
   Lib.Option.app (check_start c) start;
   ignore (List.fold_left (check_export c) NameSet.empty exports);

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -726,10 +726,10 @@ let check_module (m : module_) =
   in
   List.iter check_type types;
   List.iter (check_global c1) globals;
-  List.iter (check_table c) tables;
-  List.iter (check_memory c) memories;
-  List.iter (check_elem c) elems;
-  List.iter (check_data c) datas;
+  List.iter (check_table c1) tables;
+  List.iter (check_memory c1) memories;
+  List.iter (check_elem c1) elems;
+  List.iter (check_data c1) datas;
   List.iter (check_func c) funcs;
   Lib.Option.app (check_start c) start;
   ignore (List.fold_left (check_export c) NameSet.empty exports);

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -81,8 +81,14 @@
   (data (global.get $g) "a")
 )
 
-(module (memory 1) (data (global.get 0) "a") (global i32 (i32.const 0)))
-(module (memory 1) (data (global.get $g) "a") (global $g i32 (i32.const 0)))
+(assert_invalid
+  (module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
+  "unknown global"
+)
+(assert_invalid
+  (module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
+  "unknown global"
+)
 
 
 ;; Corner cases
@@ -457,7 +463,11 @@
 )
 
 (assert_invalid
-  (module (memory 1) (data (global.get $g)) (global $g (mut i32) (i32.const 0)))
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (memory 1)
+    (data (global.get $g))
+  )
   "constant expression required"
 )
 

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -81,9 +81,9 @@
   (data (global.get $g) "a")
 )
 
-;; Use of internal globals in constant expressions is not allowed in MVP.
-;; (module (memory 1) (data (global.get 0) "a") (global i32 (i32.const 0)))
-;; (module (memory 1) (data (global.get $g) "a") (global $g i32 (i32.const 0)))
+(module (memory 1) (data (global.get 0) "a") (global i32 (i32.const 0)))
+(module (memory 1) (data (global.get $g) "a") (global $g i32 (i32.const 0)))
+
 
 ;; Corner cases
 
@@ -456,11 +456,10 @@
   "constant expression required"
 )
 
-;; Use of internal globals in constant expressions is not allowed in MVP.
-;; (assert_invalid
-;;   (module (memory 1) (data (global.get $g)) (global $g (mut i32) (i32.const 0)))
-;;   "constant expression required"
-;; )
+(assert_invalid
+  (module (memory 1) (data (global.get $g)) (global $g (mut i32) (i32.const 0)))
+  "constant expression required"
+)
 
 (assert_invalid
    (module 

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -148,8 +148,14 @@
 (assert_return (invoke "call-7") (i32.const 65))
 (assert_return (invoke "call-9") (i32.const 66))
 
-(module (table 1 funcref) (elem (global.get 0) $f) (global i32 (i32.const 0)) (func $f))
-(module (table 1 funcref) (elem (global.get $g) $f) (global $g i32 (i32.const 0)) (func $f))
+(assert_invalid
+  (module (table 1 funcref) (global i32 (i32.const 0)) (elem (global.get 0) $f) (func $f))
+  "unknown global"
+)
+(assert_invalid
+  (module (table 1 funcref) (global $g i32 (i32.const 0)) (elem (global.get $g) $f) (func $f))
+  "unknown global"
+)
 
 
 ;; Corner cases
@@ -430,7 +436,11 @@
 )
 
 (assert_invalid
-  (module (table 1 funcref) (elem (global.get $g)) (global $g (mut i32) (i32.const 0)))
+  (module
+    (global $g (import "test" "g") (mut i32))
+    (table 1 funcref)
+    (elem (global.get $g))
+  )
   "constant expression required"
 )
 

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -148,6 +148,10 @@
 (assert_return (invoke "call-7") (i32.const 65))
 (assert_return (invoke "call-9") (i32.const 66))
 
+(module (table 1 funcref) (elem (global.get 0) $f) (global i32 (i32.const 0)) (func $f))
+(module (table 1 funcref) (elem (global.get $g) $f) (global $g i32 (i32.const 0)) (func $f))
+
+
 ;; Corner cases
 
 (module
@@ -425,11 +429,10 @@
   "constant expression required"
 )
 
-;; Use of internal globals in constant expressions is not allowed in MVP.
-;; (assert_invalid
-;;   (module (table 1 funcref) (elem (global.get $g)) (global $g i32 (i32.const 0)))
-;;   "constant expression required"
-;; )
+(assert_invalid
+  (module (table 1 funcref) (elem (global.get $g)) (global $g (mut i32) (i32.const 0)))
+  "constant expression required"
+)
 
 (assert_invalid
    (module 

--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -349,6 +349,15 @@
 )
 
 (assert_invalid
+  (module (global i32 (i32.const 0)) (global i32 (global.get 0)))
+  "unknown global"
+)
+(assert_invalid
+  (module (global $g i32 (i32.const 0)) (global i32 (global.get $g)))
+  "unknown global"
+)
+
+(assert_invalid
   (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
   "unknown global"
 )


### PR DESCRIPTION
Fix #1522:

* Use restricted context for typing data/elem/memory/table.
* Add corresponding tests.