### PR TITLE
test/meta/generate_*.js: sync upstream JS with tests

### DIFF
--- a/test/meta/generate_memory_copy.js
+++ b/test/meta/generate_memory_copy.js
@@ -103,7 +103,7 @@ function mem_copy(min, max, shared, srcOffs, targetOffs, len) {
     (i32.load8_u (local.get 0))))
 
 (assert_trap (invoke "run" (i32.const ${targetOffs}) (i32.const ${srcOffs}) (i32.const ${len}))
-             "out of bounds")
+             "out of bounds memory access")
 `);
 
     let immediateOOB = copyDown && (srcOffs + len > memLength || targetOffs + len > memLength);
@@ -227,7 +227,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0xFF00) (i32.const 0x8000) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Destination wraparound the end of 32-bit offset space
@@ -236,7 +236,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0xFFFFFF00) (i32.const 0x4000) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Source range invalid
@@ -245,7 +245,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x8000) (i32.const 0xFF00) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Source wraparound the end of 32-bit offset space
@@ -254,7 +254,7 @@ print(
  (memory 1 1)
  (func (export "test")
    (memory.copy (i32.const 0x4000) (i32.const 0xFFFFFF00) (i32.const 257))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Zero len with both offsets in-bounds is a no-op
@@ -286,7 +286,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x20000) (i32.const 0x7000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Zero len with src offset out-of-bounds at the end of memory is allowed
@@ -304,7 +304,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x9000) (i32.const 0x20000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Zero len with both dest and src offsets out-of-bounds at the end of memory is allowed
@@ -322,7 +322,7 @@ print(
   (memory 1 1)
   (func (export "test")
     (memory.copy (i32.const 0x20000) (i32.const 0x20000) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // 100 random fills followed by 100 random copies, in a single-page buffer,

--- a/test/meta/generate_memory_fill.js
+++ b/test/meta/generate_memory_fill.js
@@ -62,7 +62,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.fill (i32.const 0x20000) (i32.const 0x55) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // Very large range
@@ -141,7 +141,7 @@ function mem_fill(min, max, shared, backup, write=backup*2) {
     let val = 37;
     print(
 `(assert_trap (invoke "run" (i32.const ${offs}) (i32.const ${val}) (i32.const ${write}))
-              "out of bounds")
+              "out of bounds memory access")
 `);
     checkRange(0, min, 0);
 }

--- a/test/meta/generate_memory_init.js
+++ b/test/meta/generate_memory_init.js
@@ -65,7 +65,7 @@ print(
    (module
      (func (export "test")
        (data.drop 0)))
-   "unknown memory 0")
+   "unknown data segment")
 `);
 
 // drop with data seg ix out of range
@@ -95,7 +95,7 @@ print(
   (func (export "test")
     (data.drop 0)
     (memory.init 0 (i32.const 1234) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init with data seg ix indicating an active segment
@@ -105,7 +105,7 @@ print(
    (data (i32.const 0) "\\37")
    (func (export "test")
      (memory.init 0 (i32.const 1234) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init with no memory
@@ -143,7 +143,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 0) (i32.const 5))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init: seg ix is valid passive, but implies copying beyond end of seg
@@ -152,7 +152,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 2) (i32.const 3))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init: seg ix is valid passive, but implies copying beyond end of dst
@@ -161,7 +161,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 0xFFFE) (i32.const 1) (i32.const 3))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init: seg ix is valid passive, src offset past the end, zero len is invalid
@@ -170,7 +170,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 1234) (i32.const 4) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init: seg ix is valid passive, zero len, src offset at the end
@@ -188,7 +188,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 0x10001) (i32.const 0) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // init: seg ix is valid passive, zero len, but dst offset at the end
@@ -216,7 +216,7 @@ print(
   ${PREAMBLE}
   (func (export "test")
     (memory.init 0 (i32.const 0x10001) (i32.const 4) (i32.const 0))))
-(assert_trap (invoke "test") "out of bounds")
+(assert_trap (invoke "test") "out of bounds memory access")
 `);
 
 // invalid argument types.  TODO: can add anyfunc etc here.
@@ -265,7 +265,7 @@ function mem_init(min, max, shared, backup, write) {
     let offs = min*PAGESIZE - backup;
     print(
 `(assert_trap (invoke "run" (i32.const ${offs}) (i32.const ${write}))
-              "out of bounds")
+              "out of bounds memory access")
 `);
     checkRange(0, min, 0);
 }
@@ -309,5 +309,4 @@ print(
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "") (data "") (data "") (data "") (data "") (data "") (data "") (data "")
   (data "")
-  (func (memory.init 64 (i32.const 0) (i32.const 0) (i32.const 0))))
-`)
+  (func (memory.init 64 (i32.const 0) (i32.const 0) (i32.const 0))))`)

--- a/test/meta/generate_table_copy.js
+++ b/test/meta/generate_table_copy.js
@@ -203,22 +203,22 @@ for ( let dest of ["$t0","$t1"] ) {
     // copy: dst range invalid
     tab_test2(`(table.copy ${dest} $t0 (i32.const 28) (i32.const 1) (i32.const 3))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: dst wraparound end of 32 bit offset space
     tab_test2(`(table.copy ${dest} $t0 (i32.const 0xFFFFFFFE) (i32.const 1) (i32.const 2))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: src range invalid
     tab_test2(`(table.copy ${dest} $t0 (i32.const 15) (i32.const 25) (i32.const 6))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: src wraparound end of 32 bit offset space
     tab_test2(`(table.copy ${dest} $t0 (i32.const 15) (i32.const 0xFFFFFFFE) (i32.const 2))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: zero length with both offsets in-bounds is OK
     tab_test_nofail(
@@ -233,7 +233,7 @@ for ( let dest of ["$t0","$t1"] ) {
     // copy: zero length with dst offset out of bounds past the end of the table is not allowed
     tab_test2(`(table.copy ${dest} $t0 (i32.const 31) (i32.const 15) (i32.const 0))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: zero length with src offset out of bounds at the end of the table is allowed
     tab_test2(`(table.copy ${dest} $t0 (i32.const 15) (i32.const 30) (i32.const 0))`,
@@ -243,7 +243,7 @@ for ( let dest of ["$t0","$t1"] ) {
     // copy: zero length with src offset out of bounds past the end of the table is not allowed
     tab_test2(`(table.copy ${dest} $t0 (i32.const 15) (i32.const 31) (i32.const 0))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 
     // copy: zero length with both dst and src offset out of bounds at the end of the table is allowed
     tab_test2(`(table.copy ${dest} $t0 (i32.const 30) (i32.const 30) (i32.const 0))`,
@@ -253,7 +253,7 @@ for ( let dest of ["$t0","$t1"] ) {
     // copy: zero length with both dst and src offset out of bounds past the end of the table is not allowed
     tab_test2(`(table.copy ${dest} $t0 (i32.const 31) (i32.const 31) (i32.const 0))`,
               "",
-              "out of bounds");
+              "out of bounds table access");
 }
 
 // table.copy: out of bounds of the table for the source or target, but should
@@ -320,7 +320,7 @@ function tbl_copy(min, max, srcOffs, targetOffs, len) {
     let immediateOOB = copyDown && (srcOffs + len > tblLength || targetOffs + len > tblLength);
 
     print(`(assert_trap (invoke "run" (i32.const ${targetOffs}) (i32.const ${srcOffs}) (i32.const ${len}))
-             "out of bounds")`);
+             "out of bounds table access")`);
 
     var s = 0;
     var i = 0;

--- a/test/meta/generate_table_init.js
+++ b/test/meta/generate_table_init.js
@@ -113,7 +113,7 @@ print(
   (module
     (func (export "test")
       (elem.drop 0)))
-  "unknown table 0")
+  "unknown elem segment 0")
 `);
 
 // table.init requires a table, minimally
@@ -133,7 +133,7 @@ print(
     (func (result i32) (i32.const 0))
     (func (export "test")
       (elem.drop 4)))
-  "unknown table 0")
+  "unknown elem segment 4")
 `);
 
 // init with elem seg ix out of range
@@ -197,7 +197,7 @@ tab_test1("(elem.drop 2)", 0,
 
 // init with elem seg ix indicating an active segment
 tab_test1("(table.init 2 (i32.const 12) (i32.const 1) (i32.const 1))", 0,
-          "out of bounds");
+          "out of bounds table access");
 
 // init, using an elem seg ix more than once is OK
 tab_test2(
@@ -213,15 +213,15 @@ tab_test2("(elem.drop 1)",
 // drop, then init
 tab_test2("(elem.drop 1)",
           "(table.init 1 (i32.const 12) (i32.const 1) (i32.const 1))",
-          "out of bounds");
+          "out of bounds table access");
 
 // init: seg ix is valid passive, but length to copy > len of seg
 tab_test1("(table.init 1 (i32.const 12) (i32.const 0) (i32.const 5))", 0,
-          "out of bounds");
+          "out of bounds table access");
 
 // init: seg ix is valid passive, but implies copying beyond end of seg
 tab_test1("(table.init 1 (i32.const 12) (i32.const 2) (i32.const 3))", 0,
-          "out of bounds");
+          "out of bounds table access");
 
 // Tables are of different length with t1 shorter than t0, to test that we're not
 // using t0's limit for t1's bound
@@ -230,7 +230,7 @@ for ( let [table, oobval] of [[0,30],[1,28]] ) {
     // init: seg ix is valid passive, but implies copying beyond end of dst
     tab_test1(`(table.init $t${table} 1 (i32.const ${oobval-2}) (i32.const 1) (i32.const 3))`,
               table,
-              "out of bounds");
+              "out of bounds table access");
 
     // init: seg ix is valid passive, zero len, and src offset out of bounds at the
     // end of the table - this is allowed
@@ -242,7 +242,7 @@ for ( let [table, oobval] of [[0,30],[1,28]] ) {
     // end of the table - this is not allowed
     tab_test1(`(table.init $t${table} 1 (i32.const 12) (i32.const 5) (i32.const 0))`,
               table,
-              "out of bounds");
+              "out of bounds table access");
 
     // init: seg ix is valid passive, zero len, and dst offset out of bounds at the
     // end of the table - this is allowed
@@ -254,7 +254,7 @@ for ( let [table, oobval] of [[0,30],[1,28]] ) {
     // end of the table - this is not allowed
     tab_test1(`(table.init $t${table} 1 (i32.const ${oobval+1}) (i32.const 2) (i32.const 0))`,
               table,
-              "out of bounds");
+              "out of bounds table access");
 
     // init: seg ix is valid passive, zero len, and dst and src offsets out of bounds
     // at the end of the table - this is allowed
@@ -266,7 +266,7 @@ for ( let [table, oobval] of [[0,30],[1,28]] ) {
     // end of the table - this is not allowed
     tab_test1(`(table.init $t${table} 1 (i32.const ${oobval+1}) (i32.const 5) (i32.const 0))`,
               table,
-              "out of bounds");
+              "out of bounds table access");
 }
 
 // invalid argument types
@@ -338,7 +338,7 @@ function tbl_init(min, max, backup, write, segoffs=0) {
     // A fill reading past the end of the segment should throw *and* have filled
     // table with as much data as was available.
     let offs = min - backup;
-    print(`(assert_trap (invoke "run" (i32.const ${offs}) (i32.const ${write})) "out of bounds")`);
+    print(`(assert_trap (invoke "run" (i32.const ${offs}) (i32.const ${write})) "out of bounds table access")`);
     for (let i=0; i < min; i++) {
         print(`(assert_trap (invoke "test" (i32.const ${i})) "uninitialized element")`);
     }
@@ -383,5 +383,4 @@ print(
   (elem funcref) (elem funcref) (elem funcref) (elem funcref)
   (elem funcref) (elem funcref) (elem funcref) (elem funcref)
   (elem funcref)
-  (func (table.init 64 (i32.const 0) (i32.const 0) (i32.const 0))))
-`)
+  (func (table.init 64 (i32.const 0) (i32.const 0) (i32.const 0))))`)


### PR DESCRIPTION
The error strings in the core testsuite were cleaned up in https://github.com/WebAssembly/reference-types/pull/117 (see https://github.com/WebAssembly/reference-types/issues/113), but some of the tests (for table/memory init and copy, and memory_fill) are auto-generated by upstream JS that wasn't edited at the same time.

The PR syncs the JS scripts so that they will generate the current tests.