### PR TITLE
Add `print_i64` to generated spec tests

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -37,6 +37,7 @@ let spectest = {
   eq_funcref: eq_funcref,
   print: console.log.bind(console),
   print_i32: console.log.bind(console),
+  print_i64: console.log.bind(console),
   print_i32_f32: console.log.bind(console),
   print_f64_f64: console.log.bind(console),
   print_f32: console.log.bind(console),


### PR DESCRIPTION
https://github.com/WebAssembly/spec/commit/82a613da5ea18515bf6f16593b8f7b608f47380f added `print_i64` to the standalone test files, but not to the ones generated by the spec interpreter.