### PR TITLE
[js-api] editorial: adjust link for v128 type

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -157,6 +157,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
         text: i64
         text: f32
         text: f64
+    url: syntax/types.html#vector-types
         text: v128
     url: syntax/types.html#syntax-reftype
         text: reftype


### PR DESCRIPTION
Right now the text for the "v128" type in the [JS API doc](https://webassembly.github.io/spec/js-api/index.html) links to https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype, but the type is not actually defined there.

This minor PR makes it link to https://webassembly.github.io/spec/core/syntax/types.html#vector-types instead.