### PR TITLE
[test] elem.wast: force to use exprs in a element

### DIFF
--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -148,6 +148,25 @@
 (assert_return (invoke "call-7") (i32.const 65))
 (assert_return (invoke "call-9") (i32.const 66))
 
+;; Same as the above, but use ref.null to ensure the elements use exprs.
+;; Note: some tools like wast2json avoid using exprs when possible.
+(module
+  (type $out-i32 (func (result i32)))
+  (table 11 funcref)
+  (elem (i32.const 6) funcref (ref.null func) (ref.func $const-i32-a))
+  (elem (i32.const 9) funcref (ref.func $const-i32-b) (ref.null func))
+  (func $const-i32-a (type $out-i32) (i32.const 65))
+  (func $const-i32-b (type $out-i32) (i32.const 66))
+  (func (export "call-7") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 7))
+  )
+  (func (export "call-9") (type $out-i32)
+    (call_indirect (type $out-i32) (i32.const 9))
+  )
+)
+(assert_return (invoke "call-7") (i32.const 65))
+(assert_return (invoke "call-9") (i32.const 66))
+
 (assert_invalid
   (module (table 1 funcref) (global i32 (i32.const 0)) (elem (global.get 0) $f) (func $f))
   "unknown global"


### PR DESCRIPTION
This change makes the test detect this bug in toywasm. https://github.com/yamt/toywasm/commit/89465d57a8ad07a2e159711c92d3625bf66c41c7

(without this change, all tests were passing even with the bug.)

Note: toywasm CI uses tests converted with wast2json.

Note: wast2json doesn't use exprs unless the element contains exprs other than ref.func.
https://github.com/WebAssembly/wabt/blob/712bb5c908c35de7e4878463bb26ca0c89dac479/src/ir.cc#L680-L682