### PR TITLE
Test the abbreviated forms of table.{get,set,size,grow,fill}

### DIFF
--- a/test/core/table_fill.wast
+++ b/test/core/table_fill.wast
@@ -5,6 +5,10 @@
     (table.fill $t (local.get $i) (local.get $r) (local.get $n))
   )
 
+  (func (export "fill-abbrev") (param $i i32) (param $r externref) (param $n i32)
+    (table.fill (local.get $i) (local.get $r) (local.get $n))
+  )
+
   (func (export "get") (param $i i32) (result externref)
     (table.get $t (local.get $i))
   )
@@ -39,7 +43,7 @@
 (assert_return (invoke "get" (i32.const 8)) (ref.extern 4))
 (assert_return (invoke "get" (i32.const 9)) (ref.extern 4))
 
-(assert_return (invoke "fill" (i32.const 9) (ref.null extern) (i32.const 1)))
+(assert_return (invoke "fill-abbrev" (i32.const 9) (ref.null extern) (i32.const 1)))
 (assert_return (invoke "get" (i32.const 8)) (ref.extern 4))
 (assert_return (invoke "get" (i32.const 9)) (ref.null extern))
 

--- a/test/core/table_get.wast
+++ b/test/core/table_get.wast
@@ -10,7 +10,7 @@
   )
 
   (func (export "get-externref") (param $i i32) (result externref)
-    (table.get $t2 (local.get $i))
+    (table.get (local.get $i))
   )
   (func $f3 (export "get-funcref") (param $i i32) (result funcref)
     (table.get $t3 (local.get $i))

--- a/test/core/table_grow.wast
+++ b/test/core/table_grow.wast
@@ -7,6 +7,9 @@
   (func (export "grow") (param $sz i32) (param $init externref) (result i32)
     (table.grow $t (local.get $init) (local.get $sz))
   )
+  (func (export "grow-abbrev") (param $sz i32) (param $init externref) (result i32)
+    (table.grow (local.get $init) (local.get $sz))
+  )
   (func (export "size") (result i32) (table.size $t))
 )
 
@@ -22,7 +25,7 @@
 (assert_trap (invoke "set" (i32.const 1) (ref.extern 2)) "out of bounds table access")
 (assert_trap (invoke "get" (i32.const 1)) "out of bounds table access")
 
-(assert_return (invoke "grow" (i32.const 4) (ref.extern 3)) (i32.const 1))
+(assert_return (invoke "grow-abbrev" (i32.const 4) (ref.extern 3)) (i32.const 1))
 (assert_return (invoke "size") (i32.const 5))
 (assert_return (invoke "get" (i32.const 0)) (ref.extern 2))
 (assert_return (invoke "set" (i32.const 0) (ref.extern 2)))

--- a/test/core/table_set.wast
+++ b/test/core/table_set.wast
@@ -12,7 +12,7 @@
   )
 
   (func (export "set-externref") (param $i i32) (param $r externref)
-    (table.set $t2 (local.get $i) (local.get $r))
+    (table.set (local.get $i) (local.get $r))
   )
   (func (export "set-funcref") (param $i i32) (param $r funcref)
     (table.set $t3 (local.get $i) (local.get $r))

--- a/test/core/table_size.wast
+++ b/test/core/table_size.wast
@@ -4,7 +4,7 @@
   (table $t2 0 2 externref)
   (table $t3 3 8 externref)
 
-  (func (export "size-t0") (result i32) (table.size $t0))
+  (func (export "size-t0") (result i32) table.size)
   (func (export "size-t1") (result i32) (table.size $t1))
   (func (export "size-t2") (result i32) (table.size $t2))
   (func (export "size-t3") (result i32) (table.size $t3))


### PR DESCRIPTION
These weren't being exercised in the testsuite, and some parsers (including WABT) can't currently parse them.

(The abbreviations for table.copy and table.init are already tested in bulk.wast.)