### PR TITLE
[docs] Switch to 'Furo' theme for core docs

### DIFF
--- a/document/core/conf.py
+++ b/document/core/conf.py
@@ -140,36 +140,42 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-html_theme = 'alabaster'
+
+# ====== Old theme and config =============================
+# html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-html_theme_options = {
-  'logo': logo,
-  'logo_name': 'WebAssembly',
-  'description': 'WebAssembly Specification',
-  'fixed_sidebar': True,
-  'sidebar_width': '260px',
-  'sidebar_collapse': True,
-  'show_powered_by': False,
-  'extra_nav_links': {
-    'Index': 'BASEDIR/genindex.html',
-    'Download as PDF': 'BASEDIR/_download/' + name + '.pdf'
-  },
-}
+# html_theme_options = {
+#   'logo': logo,
+#   'logo_name': 'WebAssembly',
+#   'description': 'WebAssembly Specification',
+#   'fixed_sidebar': True,
+#   'sidebar_width': '260px',
+#   'sidebar_collapse': True,
+#   'show_powered_by': False,
+#   'extra_nav_links': {
+#     'Index': 'BASEDIR/genindex.html',
+#     'Download as PDF': 'BASEDIR/_download/' + name + '.pdf'
+#   },
+# }
 
-html_sidebars = {
-  '**': [
-    # 'about.html',
-    'navigation.html',
-    # 'relations.html',
-    'searchbox.html',
-  ]
-}
+# html_sidebars = {
+#   '**': [
+#     # 'about.html',
+#     'navigation.html',
+#     # 'relations.html',
+#     'searchbox.html',
+#   ]
+# }
+# ==============================================================
 
+# New mobile friendly theme with dark mode
+html_theme = 'furo'
+
+html_logo = logo
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
Closes #1573

### Problem
Current ['Alabaster'](https://sphinx-themes.org/) theme does not support mobile and dark mode

### Proposed solution
Use ['Furo'](https://sphinx-themes.org/sample-sites/furo/) theme.
No particular technical reason for this specific theme, apart from esthetics  

### Todo
- Since I'm not very familiar with Sphinx, I might have missed something. Needs checking.
- Testing required

### Building
HTML builds with same command on WSL2 setup: `make html`

### Preview
https://eeqt3-riaaa-aaaal-qbsva-cai.ic0.app/

### Screenshots
Desktop light
![Index-of-Types-WebAssembly-2-0-Draft-2023-01-25-](https://user-images.githubusercontent.com/109237888/214710497-29a65ff5-f787-4717-88ec-46e9d7c3c70f.png)

Desktop dark
![Values-WebAssembly-2-0-Draft-2023-01-25-](https://user-images.githubusercontent.com/109237888/214710501-1f99b737-a45d-48b4-a06a-b0eb8bf57694.png)

Mobile
![Index-of-Types-WebAssembly-2-0-Draft-2023-01-25- (1)](https://user-images.githubusercontent.com/109237888/214710493-5e62b0d3-133b-475b-baf1-a4f5480fedcf.png)

