### PR TITLE
[interpreter] Support nested invoke/get in test scripts

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -391,10 +391,14 @@ module:
   ( module <name>? quote <string>* )         ;; module quoted in text (may be malformed)
 
 action:
-  ( invoke <name>? <string> <const>* )       ;; invoke function export
+  ( invoke <name>? <string> <arg>* )         ;; invoke function export
   ( get <name>? <string> )                   ;; get global export
 
-const:
+arg:
+  <literal>                                  ;; literal argument
+  <action>                                   ;; expression argument
+
+literal:
   ( <num_type>.const <num> )                 ;; number value
   ( <vec_type> <vec_shape> <num>+ )          ;; vector value
   ( ref.null <ref_kind> )                    ;; null reference
@@ -410,7 +414,7 @@ assertion:
   ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
 
 result:
-  <const>
+  <literal>
   ( <num_type>.const <num_pat> )
   ( <vec_type>.const <vec_shape> <num_pat>+ )
   ( ref.extern )

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -393,6 +393,7 @@ module:
 action:
   ( invoke <name>? <string> <arg>* )         ;; invoke function export
   ( get <name>? <string> )                   ;; get global export
+  ( set <name>? <string> <arg> )             ;; set global export
 
 arg:
   <literal>                                  ;; literal argument

--- a/interpreter/script/js.mli
+++ b/interpreter/script/js.mli
@@ -1,1 +1,3 @@
+exception Error of Source.region * string
+
 val of_script : Script.script -> string

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -15,6 +15,7 @@ type action = action' Source.phrase
 and action' =
   | Invoke of var option * Ast.name * arg list
   | Get of var option * Ast.name
+  | Set of var option * Ast.name * arg
 
 and arg = arg' Source.phrase
 and arg' =

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -13,8 +13,13 @@ and definition' =
 
 type action = action' Source.phrase
 and action' =
-  | Invoke of var option * Ast.name * literal list
+  | Invoke of var option * Ast.name * arg list
   | Get of var option * Ast.name
+
+and arg = arg' Source.phrase
+and arg' =
+  | LiteralArg of literal
+  | ActionArg of action
 
 type nanop = nanop' Source.phrase
 and nanop' = (Lib.void, Lib.void, nan, nan) Values.op

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -702,11 +702,13 @@ let access x_opt n =
 let rec action mode act =
   match act.it with
   | Invoke (x_opt, name, args) ->
-    Node ("invoke" ^ access x_opt name, List.map (arg mode) args)
+    Node ("invoke" ^ access x_opt name, List.map (argument mode) args)
   | Get (x_opt, name) ->
     Node ("get" ^ access x_opt name, [])
+  | Set (x_opt, name, arg) ->
+    Node ("set" ^ access x_opt name, [argument mode arg])
 
-and arg mode arg =
+and argument mode arg =
   match arg.it with
   | LiteralArg lit -> literal mode lit
   | ActionArg act -> action mode act

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -699,12 +699,17 @@ let definition mode x_opt def =
 let access x_opt n =
   String.concat " " [var_opt x_opt; name n]
 
-let action mode act =
+let rec action mode act =
   match act.it with
-  | Invoke (x_opt, name, lits) ->
-    Node ("invoke" ^ access x_opt name, List.map (literal mode) lits)
+  | Invoke (x_opt, name, args) ->
+    Node ("invoke" ^ access x_opt name, List.map (arg mode) args)
   | Get (x_opt, name) ->
     Node ("get" ^ access x_opt name, [])
+
+and arg mode arg =
+  match arg.it with
+  | LiteralArg lit -> literal mode lit
+  | ActionArg act -> action mode act
 
 let nan = function
   | CanonicalNan -> "nan:canonical"

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -678,6 +678,7 @@ rule token = parse
       | "register" -> REGISTER
       | "invoke" -> INVOKE
       | "get" -> GET
+      | "set" -> SET
       | "assert_malformed" -> ASSERT_MALFORMED
       | "assert_invalid" -> ASSERT_INVALID
       | "assert_unlinkable" -> ASSERT_UNLINKABLE

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -1015,7 +1015,7 @@ script_module :
     { $3, Quoted ("quote:" ^ string_of_pos (at()).left, $5) @@ at() }
 
 action :
-  | LPAR INVOKE module_var_opt name literal_list RPAR
+  | LPAR INVOKE module_var_opt name arg_list RPAR
     { Invoke ($3, $4, $5) @@ at () }
   | LPAR GET module_var_opt name RPAR
     { Get ($3, $4) @@ at() }
@@ -1065,9 +1065,13 @@ literal :
   | literal_vec { Values.Vec $1 @@ at () }
   | literal_ref { Values.Ref $1 @@ at () }
 
-literal_list :
+arg :
+  | literal { LiteralArg $1 @@ at () }
+  | action { ActionArg $1 @@ at () }
+
+arg_list :
   | /* empty */ { [] }
-  | literal literal_list { $1 :: $2 }
+  | arg arg_list { $1 :: $2 }
 
 numpat :
   | num { fun sh -> vec_lane_lit sh $1.it $1.at }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -232,7 +232,7 @@ let inline_type_explicit (c : context) x ft at =
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY DATA DECLARE OFFSET ITEM IMPORT EXPORT
 %token MODULE BIN QUOTE
-%token SCRIPT REGISTER INVOKE GET
+%token SCRIPT REGISTER INVOKE GET SET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
 %token<Script.nan> NAN
@@ -1019,6 +1019,8 @@ action :
     { Invoke ($3, $4, $5) @@ at () }
   | LPAR GET module_var_opt name RPAR
     { Get ($3, $4) @@ at() }
+  | LPAR SET module_var_opt name arg RPAR
+    { Set ($3, $4, $5) @@ at() }
 
 assertion :
   | LPAR ASSERT_MALFORMED script_module STRING RPAR

--- a/test/core/script.wast
+++ b/test/core/script.wast
@@ -7,7 +7,7 @@
 )
 
 (module $m2
-  (global (export "g") i32 (i32.const 42))
+  (global (export "g") (mut i32) (i32.const 42))
   (func (export "f") (result i32) (i32.const 42))
   (func (export "add3") (param i32 i32 i32) (result i32)
     (i32.add (i32.add (local.get 0) (local.get 1)) (local.get 2))
@@ -21,17 +21,25 @@
 (assert_return (get $m1 "g") (i32.const 41))
 (assert_return (get $m2 "g") (i32.const 42))
 
+(set "g" (i32.const 43))
+(assert_return (set "g" (i32.const 43)))
+(assert_return (get "g") (i32.const 43))
+(set $m2 "g" (i32.const 44))
+(assert_return (get "g") (i32.const 44))
+(set "g" (invoke $m1 "inc" (get "g")))
+(assert_return (get "g") (i32.const 45))
+
 (assert_return (invoke "f") (i32.const 42))
 (assert_return (invoke $m1 "f") (i32.const 41))
 (assert_return (invoke $m2 "f") (i32.const 42))
 
 (assert_return (invoke $m1 "inc" (i32.const 2)) (i32.const 3))
 (assert_return (invoke $m1 "inc" (get $m1 "g")) (i32.const 42))
-(assert_return (invoke $m1 "inc" (get $m2 "g")) (i32.const 43))
-(assert_return (invoke $m1 "inc" (invoke $m1 "inc" (get "g"))) (i32.const 44))
+(assert_return (invoke $m1 "inc" (get $m2 "g")) (i32.const 46))
+(assert_return (invoke $m1 "inc" (invoke $m1 "inc" (get "g"))) (i32.const 47))
 
-(assert_return (invoke "add3" (get $m1 "g") (invoke $m1 "inc" (get "g")) (get "g")) (i32.const 126))
-(assert_return (invoke "add3" (invoke "swap" (get $m1 "g") (invoke $m1 "inc" (get "g"))) (i32.const -20)) (i32.const 64))
+(assert_return (invoke "add3" (get $m1 "g") (invoke $m1 "inc" (get "g")) (get "g")) (i32.const 132))
+(assert_return (invoke "add3" (invoke "swap" (get $m1 "g") (invoke $m1 "inc" (get "g"))) (i32.const -20)) (i32.const 67))
 
 
 (module

--- a/test/core/script.wast
+++ b/test/core/script.wast
@@ -1,0 +1,61 @@
+(module $m1
+  (global (export "g") i32 (i32.const 41))
+  (func (export "f") (result i32) (i32.const 41))
+  (func (export "inc") (param $x i32) (result i32)
+    (i32.add (local.get $x) (i32.const 1))
+  )
+)
+
+(module $m2
+  (global (export "g") i32 (i32.const 42))
+  (func (export "f") (result i32) (i32.const 42))
+  (func (export "add3") (param i32 i32 i32) (result i32)
+    (i32.add (i32.add (local.get 0) (local.get 1)) (local.get 2))
+  )
+  (func (export "swap") (param i32 i32) (result i32 i32)
+    (local.get 1) (local.get 0)
+  )
+)
+
+(assert_return (get "g") (i32.const 42))
+(assert_return (get $m1 "g") (i32.const 41))
+(assert_return (get $m2 "g") (i32.const 42))
+
+(assert_return (invoke "f") (i32.const 42))
+(assert_return (invoke $m1 "f") (i32.const 41))
+(assert_return (invoke $m2 "f") (i32.const 42))
+
+(assert_return (invoke $m1 "inc" (i32.const 2)) (i32.const 3))
+(assert_return (invoke $m1 "inc" (get $m1 "g")) (i32.const 42))
+(assert_return (invoke $m1 "inc" (get $m2 "g")) (i32.const 43))
+(assert_return (invoke $m1 "inc" (invoke $m1 "inc" (get "g"))) (i32.const 44))
+
+(assert_return (invoke "add3" (get $m1 "g") (invoke $m1 "inc" (get "g")) (get "g")) (i32.const 126))
+(assert_return (invoke "add3" (invoke "swap" (get $m1 "g") (invoke $m1 "inc" (get "g"))) (i32.const -20)) (i32.const 64))
+
+
+(module
+  (global (export "g-i32") i32 (i32.const 42))
+  (global (export "g-i64") i64 (i64.const 42))
+  (global (export "g-f32") f32 (f32.const 42))
+  (global (export "g-f64") f64 (f64.const 42))
+  (global (export "g-v128") v128 (v128.const i32x4 42 42 42 42))
+  (global (export "g-funcref") funcref (ref.null func))
+  (global (export "g-externref") externref (ref.null extern))
+
+  (func (export "f-i32") (param i32) (result i32) (local.get 0))
+  (func (export "f-i64") (param i64) (result i64) (local.get 0))
+  (func (export "f-f32") (param f32) (result f32) (local.get 0))
+  (func (export "f-f64") (param f64) (result f64) (local.get 0))
+  (func (export "f-v128") (param v128) (result v128) (local.get 0))
+  (func (export "f-funcref") (param funcref) (result funcref) (local.get 0))
+  (func (export "f-externref") (param externref) (result externref) (local.get 0))
+)
+
+(assert_return (invoke "f-i32" (get "g-i32")) (i32.const 42))
+(assert_return (invoke "f-i64" (get "g-i64")) (i64.const 42))
+(assert_return (invoke "f-f32" (get "g-f32")) (f32.const 42))
+(assert_return (invoke "f-f64" (get "g-f64")) (f64.const 42))
+(assert_return (invoke "f-v128" (get "g-v128")) (v128.const i32x4 42 42 42 42))
+(assert_return (invoke "f-funcref" (get "g-funcref")) (ref.null func))
+(assert_return (invoke "f-externref" (get "g-externref")) (ref.null extern))


### PR DESCRIPTION
Also adds `set` action to mutate globals. See script.wast for examples.

@titzer, PTAL. Should fix #1568.

This was straightforward to implement, except for the JS conversion, which caused quite some headache because wrapper modules generated for actions on types inexpressible in JS are no longer closed now but need to take their arguments as imports. This is largely untested.