### PR TITLE
[spec] Show scrolls for overflow math blocks

### DIFF
--- a/document/core/static/custom.css
+++ b/document/core/static/custom.css
@@ -44,6 +44,8 @@ div.admonition p.admonition-title {
 div.math {
   background-color: #F0F0F0;
   padding: 3px 0 3px 0;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 div.relations {


### PR DESCRIPTION
Without scrolls ([text/modules#Abbreviations](https://webassembly.github.io/spec/core/text/modules.html#id7)):

<img width="1054" alt="Screenshot 2023-02-09 at 10 25 52 PM" src="https://user-images.githubusercontent.com/8275026/217825275-4bb1070b-a88b-41fe-915e-8ded7ed60928.png">

With scrolls:

<img width="800" alt="Screenshot 2023-02-09 at 10 26 12 PM" src="https://user-images.githubusercontent.com/8275026/217825291-850afc34-1b5d-4c03-bf13-465e5048fcb7.png">
