### PR TITLE
[test] Import v128 global

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18.x
-      - run: cd interpreter && opam exec make all
+      - run: cd interpreter && opam exec make JS=node all
 
   ref-interpreter-js-library:
     runs-on: ubuntu-latest

--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -23,7 +23,7 @@ FLAGS = 	-lexflags -ml -cflags '-w +a-4-27-42-44-45-70 -warn-error +a-3'
 OCBA =		ocamlbuild $(FLAGS) $(DIRS:%=-I %)
 OCB =		$(OCBA) $(LIBS:%=-libs %)
 JSO =		js_of_ocaml -q --opt 3
-JS =		node  # set to JS shell command to run JS tests, empty to skip
+JS =		# set to JS shell command to run JS tests, empty to skip
 
 
 # Main targets

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -130,15 +130,14 @@
 
 
 (module
-  ;; TODO: Reactivate once the fix for https://bugs.chromium.org/p/v8/issues/detail?id=13732
-  ;; has made it to the downstream node.js that we use on CI.
-  ;; (global (export "g-v128") v128 (v128.const i64x2 0 0))
+  (global (export "g-v128") v128 (v128.const i64x2 0 0))
   (global (export "mg-v128") (mut v128) (v128.const i64x2 0 0))
 )
 (register "Mv128")
 
 (module
-  ;; TODO: See above
+  ;; TODO: Reactivate once the fix for https://bugs.chromium.org/p/v8/issues/detail?id=13732
+  ;; has made it to the downstream node.js that we use on CI.
   ;; (import "Mv128" "g-v128" (global v128))
   (import "Mv128" "mg-v128" (global (mut v128)))
 )

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -129,6 +129,16 @@
 )
 
 
+(module
+  (global (export "g-v128") v128 (v128.const i64x2 0 0))
+)
+(register "Mv128")
+
+(module
+  (import "Mv128" "g-v128" (global v128))
+)
+
+
 ;; Tables
 
 (module $Mt

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -130,12 +130,17 @@
 
 
 (module
-  (global (export "g-v128") v128 (v128.const i64x2 0 0))
+  ;; TODO: Reactivate once the fix for https://bugs.chromium.org/p/v8/issues/detail?id=13732
+  ;; has made it to the downstream node.js that we use on CI.
+  ;; (global (export "g-v128") v128 (v128.const i64x2 0 0))
+  (global (export "mg-v128") (mut v128) (v128.const i64x2 0 0))
 )
 (register "Mv128")
 
 (module
-  (import "Mv128" "g-v128" (global v128))
+  ;; TODO: See above
+  ;; (import "Mv128" "g-v128" (global v128))
+  (import "Mv128" "mg-v128" (global (mut v128)))
 )
 
 


### PR DESCRIPTION
Adds a simple test for ex/importing a global of type v128.

@ajklein, @jakobkummerow, this makes V8's InstanceBuilder crash, presumably because v128 isn't handled [here](https://github.com/v8/v8/blob/main/src/wasm/module-instantiate.cc#L1446) (tested with node 18.14.0, the CI failure is caused by that as well).