### PR TITLE
[spec] Clarify in conventions that atoms can be symbolic

### DIFF
--- a/document/core/syntax/conventions.rst
+++ b/document/core/syntax/conventions.rst
@@ -20,7 +20,7 @@ Grammar Notation
 
 The following conventions are adopted in defining grammar rules for abstract syntax.
 
-* Terminal symbols (atoms) are written in sans-serif font: :math:`\K{i32}, \K{end}`.
+* Terminal symbols (atoms) are written in sans-serif font or in symbolic form: :math:`\K{i32}, \K{end}, {\to}, [, ]`.
 
 * Nonterminal symbols are written in italic font: :math:`\X{valtype}, \X{instr}`.
 


### PR DESCRIPTION
Addresses discussion point [here](https://github.com/WebAssembly/spec/issues/726#issuecomment-1431227194).