### PR TITLE
[ci] Pin nodejs version to avoid fetching failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "recursive"
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: pip install bikeshed && bikeshed update
       - run: pip install six
       - run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ first, so that this spec repository can remain focused. And please follow the
 # citing
 
 For citing WebAssembly in LaTeX, use [this bibtex file](wasm-specs.bib).
+
+test change

--- a/README.md
+++ b/README.md
@@ -20,5 +20,3 @@ first, so that this spec repository can remain focused. And please follow the
 # citing
 
 For citing WebAssembly in LaTeX, use [this bibtex file](wasm-specs.bib).
-
-test change


### PR DESCRIPTION
Exception handling repo's 'build-core-spec' CI started failing suddenly today (2/17/2023) for no apparent reason and is still failing even after merging with the upstream spec:
https://github.com/WebAssembly/exception-handling/actions/runs/4208125522/jobs/7303774774

This is a test PR to see if the spec repo has the same issue. Will close this after the CI testing. Do not merge.