### PR TITLE
[test] Exception -> Tag in wasm-module-builder.js

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -65,7 +65,7 @@ let kElementSectionCode = 9;     // Elements section
 let kCodeSectionCode = 10;       // Function code
 let kDataSectionCode = 11;       // Data segments
 let kDataCountSectionCode = 12;  // Data segment count (between Element & Code)
-let kExceptionSectionCode = 13;  // Exception section (between Global & Export)
+let kTagSectionCode = 13;        // Tag section (between Memory & Global)
 
 // Name section types
 let kModuleNameCode = 0;
@@ -104,13 +104,13 @@ let kExternalFunction = 0;
 let kExternalTable = 1;
 let kExternalMemory = 2;
 let kExternalGlobal = 3;
-let kExternalException = 4;
+let kExternalTag = 4;
 
 let kTableZero = 0;
 let kMemoryZero = 0;
 let kSegmentZero = 0;
 
-let kExceptionAttribute = 0;
+let kTagAttribute = 0;
 
 // Useful signatures
 let kSig_i_i = makeSig([kWasmI32], [kWasmI32]);
@@ -681,7 +681,7 @@ class WasmModuleBuilder {
     this.exports = [];
     this.globals = [];
     this.tables = [];
-    this.exceptions = [];
+    this.tags = [];
     this.functions = [];
     this.element_segments = [];
     this.data_segments = [];
@@ -689,7 +689,7 @@ class WasmModuleBuilder {
     this.num_imported_funcs = 0;
     this.num_imported_globals = 0;
     this.num_imported_tables = 0;
-    this.num_imported_exceptions = 0;
+    this.num_imported_tags = 0;
     return this;
   }
 
@@ -752,11 +752,11 @@ class WasmModuleBuilder {
     return table;
   }
 
-  addException(type) {
+  addTag(type) {
     let type_index = (typeof type) == "number" ? type : this.addType(type);
-    let except_index = this.exceptions.length + this.num_imported_exceptions;
-    this.exceptions.push(type_index);
-    return except_index;
+    let tag_index = this.tags.length + this.num_imported_tags;
+    this.tags.push(type_index);
+    return tag_index;
   }
 
   addFunction(name, type) {
@@ -804,14 +804,14 @@ class WasmModuleBuilder {
     return this.num_imported_tables++;
   }
 
-  addImportedException(module, name, type) {
-    if (this.exceptions.length != 0) {
-      throw new Error('Imported exceptions must be declared before local ones');
+  addImportedTag(module, name, type) {
+    if (this.tags.length != 0) {
+      throw new Error('Imported tags must be declared before local ones');
     }
     let type_index = (typeof type) == "number" ? type : this.addType(type);
-    let o = {module: module, name: name, kind: kExternalException, type: type_index};
+    let o = {module: module, name: name, kind: kExternalTag, type: type_index};
     this.imports.push(o);
-    return this.num_imported_exceptions++;
+    return this.num_imported_tags++;
   }
 
   addExport(name, index) {
@@ -938,8 +938,8 @@ class WasmModuleBuilder {
             section.emit_u8(has_max ? 1 : 0); // flags
             section.emit_u32v(imp.initial); // initial
             if (has_max) section.emit_u32v(imp.maximum); // maximum
-          } else if (imp.kind == kExternalException) {
-            section.emit_u32v(kExceptionAttribute);
+          } else if (imp.kind == kExternalTag) {
+            section.emit_u32v(kTagAttribute);
             section.emit_u32v(imp.type);
           } else {
             throw new Error("unknown/unsupported import kind " + imp.kind);
@@ -1036,13 +1036,13 @@ class WasmModuleBuilder {
       });
     }
 
-    // Add exceptions.
-    if (wasm.exceptions.length > 0) {
-      if (debug) print("emitting exceptions @ " + binary.length);
-      binary.emit_section(kExceptionSectionCode, section => {
-        section.emit_u32v(wasm.exceptions.length);
-        for (let type of wasm.exceptions) {
-          section.emit_u32v(kExceptionAttribute);
+    // Add tags.
+    if (wasm.tags.length > 0) {
+      if (debug) print("emitting tags @ " + binary.length);
+      binary.emit_section(kTagSectionCode, section => {
+        section.emit_u32v(wasm.tags.length);
+        for (let type of wasm.tags) {
+          section.emit_u32v(kTagAttribute);
           section.emit_u32v(type);
         }
       });


### PR DESCRIPTION
The section name has changed to the tag section a few years ago. This adds the corresponding changes added in
WebAssembly/exception-handling#252 and
WebAssembly/exception-handling#256.