### PR TITLE
[spec] Add missing initialization value to table.grow reduction rule

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1312,7 +1312,7 @@ Table Instructions
      \end{array}
    \\[1ex]
    \begin{array}{lcl@{\qquad}l}
-   S; F; (\I32.\CONST~n)~(\TABLEGROW~x) &\stepto& S; F; (\I32.\CONST~\signed_{32}^{-1}(-1))
+   S; F; \val~(\I32.\CONST~n)~(\TABLEGROW~x) &\stepto& S; F; (\I32.\CONST~\signed_{32}^{-1}(-1))
    \end{array}
    \end{array}
 


### PR DESCRIPTION
This rule was probably copied from the (very similar) memory.grow rule when it was introduced by #1287 in c3d5cbc1f7c6b166b7a312adc4efdb7e34746b3d. While memory.grow doesn’t have an initialization value, table.grow does.