### PR TITLE
[js-api] Remove some anchor definitions

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -37,66 +37,12 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         url: sec-returnifabrupt-shorthands
             text: !
             text: ?
-        text: agent cluster; url: sec-agent-clusters
-        text: agent; url: agent
-        text: data block; url: sec-data-blocks
-        text: Bound Function; url: sec-bound-function-exotic-objects
-        text: NumericLiteral; url: sec-literals-numeric-literals
-        text: surrounding agent; url: surrounding-agent
-        text: ToNumber; url: sec-tonumber
-        text: ToInt32; url: sec-toint32
-        text: ToString; url: sec-tostring
-        url: sec-ecmascript-data-types-and-values
-            text: Type
-            text: Type(x)
-        url: sec-iscallable
-            text: IsCallable
-            text: callable; for: ECMAScript
-        url: sec-well-known-intrinsic-objects
-            text: %ErrorPrototype%
-        text: %ObjectPrototype%; url: sec-properties-of-the-object-prototype-object
-        text: %Promise%; url: sec-promise-constructor
-        text: Property Descriptor; url: sec-property-descriptor-specification-type
-        text: array index; url: sec-array-exotic-objects
-        text: OrdinaryGetOwnProperty; url: sec-ordinarygetownproperty
-        text: OrdinaryDefineOwnProperty; url: sec-ordinarydefineownproperty
-        text: OrdinaryPreventExtensions; url: sec-ordinarypreventextensions
-        text: OrdinarySet; url: sec-ordinaryset
-        text: equally close values; url: sec-ecmascript-language-types-number-type
-        text: internal slot; url: sec-object-internal-methods-and-internal-slots
-        text: JavaScript execution context stack; url: execution-context-stack
-        text: running JavaScript execution context; url: running-execution-context
-        text: GetIterator; url: sec-getiterator
-        text: IteratorStep; url: sec-iteratorstep
-        text: NormalCompletion; url: sec-normalcompletion
-        text: IteratorValue; url: sec-iteratorvalue
-        url: sec-well-known-symbols
-            text: @@iterator
-            text: @@toStringTag
-        text: CreateDataProperty; url: sec-createdataproperty
-        text: DetachArrayBuffer; url: sec-detacharraybuffer
-        text: SetIntegrityLevel; url: sec-setintegritylevel
-        text: Call; url: sec-call
-        text: Get; url: sec-get-o-p
-        text: DefinePropertyOrThrow; url: sec-definepropertyorthrow
+        text: Type; url: sec-ecmascript-data-types-and-values
         text: current Realm; url: current-realm
-        text: ObjectCreate; url: sec-objectcreate
-        text: CreateBuiltinFunction; url: sec-createbuiltinfunction
-        text: SetFunctionName; url: sec-setfunctionname
-        text: SetFunctionLength; url: sec-setfunctionlength
-        text: the Number value; url: sec-ecmascript-language-types-number-type
-        text: NumberToRawBytes; url: sec-numbertorawbytes
         text: Built-in Function Objects; url: sec-built-in-function-objects
         text: NativeError Object Structure; url: sec-nativeerror-object-structure
-        text: CreateArrayFromList; url: sec-createarrayfromlist
-        text: GetMethod; url: sec-getmethod
-        text: IterableToList; url: sec-iterabletolist
-        text: ToBigInt64; url: #sec-tobigint64
-        text: BigInt; url: #sec-ecmascript-language-types-bigint-type
         text: 𝔽; url: #𝔽
         text: ℤ; url: #ℤ
-    type: abstract-op
-        text: CreateMethodProperty; url: sec-createmethodproperty
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     url: valid/modules.html#valid-module
         text: valid
@@ -367,11 +313,11 @@ A {{Module}} object represents a single WebAssembly module. Each {{Module}} obje
     1. If |module|.[=imports=] [=list/is empty|is not empty=], and |importObject| is undefined, throw a {{TypeError}} exception.
     1. Let |imports| be « ».
     1. [=list/iterate|For each=] (|moduleName|, |componentName|, |externtype|) of [=module_imports=](|module|),
-        1. Let |o| be [=?=] [=Get=](|importObject|, |moduleName|).
+        1. Let |o| be [=?=] [$Get$](|importObject|, |moduleName|).
         1. If [=Type=](|o|) is not Object, throw a {{TypeError}} exception.
-        1. Let |v| be [=?=] [=Get=](|o|, |componentName|).
+        1. Let |v| be [=?=] [$Get$](|o|, |componentName|).
         1. If |externtype| is of the form [=func=] |functype|,
-            1. If [=IsCallable=](|v|) is false, throw a {{LinkError}} exception.
+            1. If [$IsCallable$](|v|) is false, throw a {{LinkError}} exception.
             1. If |v| has a \[[FunctionAddress]] internal slot, and therefore is an [=Exported Function=],
                 1. Let |funcaddr| be the value of |v|'s \[[FunctionAddress]] internal slot.
             1. Otherwise,
@@ -415,7 +361,7 @@ The verification of WebAssembly type requirements is deferred to the
 
 <div algorithm>
   To <dfn>create an exports object</dfn> from a WebAssembly module |module| and instance |instance|, perform the following steps:
-    1. Let |exportsObject| be [=!=] [=ObjectCreate=](null).
+    1. Let |exportsObject| be [=!=] [$OrdinaryObjectCreate$](null).
     1. [=list/iterate|For each=] (|name|, |externtype|) of [=module_exports=](|module|),
         1. Let |externval| be [=instance_export=](|instance|, |name|).
         1. Assert: |externval| is not [=error=].
@@ -439,11 +385,11 @@ The verification of WebAssembly type requirements is deferred to the
             1. Let [=external value|table=] |tableaddr| be |externval|.
             1. Let |table| be [=create a Table object|a new Table object=] created from |tableaddr|.
             1. Let |value| be |table|.
-        1. Let |status| be [=!=] [=CreateDataProperty=](|exportsObject|, |name|, |value|).
+        1. Let |status| be [=!=] [$CreateDataProperty$](|exportsObject|, |name|, |value|).
         1. Assert: |status| is true.
 
         Note: the validity and uniqueness checks performed during [=WebAssembly module validation=] ensure that each property name is valid and no properties are defined twice.
-    1. Perform [=!=] [=SetIntegrityLevel=](|exportsObject|, `"frozen"`).
+    1. Perform [=!=] [$SetIntegrityLevel$](|exportsObject|, `"frozen"`).
     1. Return |exportsObject|.
 </div>
 
@@ -706,7 +652,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. Let |map| be the [=surrounding agent=]'s associated [=Memory object cache=].
     1. Assert: |map|[|memaddr|] [=map/exists=].
     1. Let |memory| be |map|[|memaddr|].
-    1. Perform [=!=] [=DetachArrayBuffer=](|memory|.\[[BufferObject]], "WebAssembly.Memory").
+    1. Perform [=!=] [$DetachArrayBuffer$](|memory|.\[[BufferObject]], "WebAssembly.Memory").
     1. Let |buffer| be the result of [=create a memory buffer|creating a memory buffer=] from |memaddr|.
     1. Set |memory|.\[[BufferObject]] to |buffer|.
 </div>
@@ -990,13 +936,13 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let |funcinst| be |store|.funcs[|funcaddr|].
     1. If |funcinst| is of the form {type <var ignore>functype</var>, hostcode |hostfunc|},
-        1. Assert: |hostfunc| is a JavaScript object and [=IsCallable=](|hostfunc|) is true.
+        1. Assert: |hostfunc| is a JavaScript object and [$IsCallable$](|hostfunc|) is true.
         1. Let |index| be the [=index of the host function=] |funcaddr|.
     1. Otherwise,
         1. Let |moduleinst| be |funcinst|.module.
         1. Assert: |funcaddr| is contained in |moduleinst|.funcaddrs.
         1. Let |index| be the index of |moduleinst|.funcaddrs where |funcaddr| is found.
-    1. Return [=!=] [=ToString=](|index|).
+    1. Return [=!=] [$ToString$](|index|).
 </div>
 
 <div algorithm>
@@ -1012,7 +958,7 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
     1. Let [|paramTypes|] → [<var ignore>resultTypes</var>] be |functype|.
     1. Let |arity| be |paramTypes|'s [=list/size=].
     1. Let |name| be the [=name of the WebAssembly function=] |funcaddr|.
-    1. Let |function| be [=!=] [=CreateBuiltinFunction=](|steps|, |arity|, |name|, « \[[FunctionAddress]] », |realm|).
+    1. Let |function| be [=!=] [$CreateBuiltinFunction$](|steps|, |arity|, |name|, « \[[FunctionAddress]] », |realm|).
     1. Set |function|.\[[FunctionAddress]] to |funcaddr|.
     1. [=map/Set=] |map|[|funcaddr|] to |function|.
     1. Return |function|.
@@ -1044,7 +990,7 @@ This slot holds a [=function address=] relative to the [=surrounding agent=]'s [
         1. Let |values| be « ».
         1. [=list/iterate|For each=] |r| of |ret|,
             1. [=list/Append=] [=ToJSValue=](|r|) to |values|.
-        1. Return [=CreateArrayFromList=](|values|).
+        1. Return [$CreateArrayFromList$](|values|).
 </div>
 
 Note: [=call an Exported Function|Calling an Exported Function=] executes in the \[[Realm]] of the callee Exported Function, as per the definition of [=built-in function objects=].
@@ -1059,14 +1005,14 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
     1. Let |jsArguments| be « ».
     1. [=list/iterate|For each=] |arg| of |arguments|,
         1. [=list/Append=] [=!=] [=ToJSValue=](|arg|) to |jsArguments|.
-    1. Let |ret| be [=?=] [=Call=](|func|, undefined, |jsArguments|).
+    1. Let |ret| be [=?=] [$Call$](|func|, undefined, |jsArguments|).
     1. Let |resultsSize| be |results|'s [=list/size=].
     1. If |resultsSize| is 0, return « ».
     1. Otherwise, if |resultsSize| is 1, return « [=?=] [=ToWebAssemblyValue=](|ret|, |results|[0]) ».
     1. Otherwise,
-        1. Let |method| be [=?=] [=GetMethod=](|ret|, [=@@iterator=]).
+        1. Let |method| be [=?=] [$GetMethod$](|ret|, {{@@iterator}}).
         1. If |method| is undefined, [=throw=] a {{TypeError}}.
-        1. Let |values| be [=?=] [=IterableToList=](|ret|, |method|).
+        1. Let |values| be [=?=] [$IterableToList$](|ret|, |method|).
         1. Let |wasmValues| be a new, empty [=list=].
         1. If |values|'s [=list/size=] is not |resultsSize|, throw a {{TypeError}} exception.
         1. For each |value| and |resultType| in |values| and |results|, paired linearly,
@@ -1077,11 +1023,11 @@ Note: Exported Functions do not have a \[[Construct]] method and thus it is not 
 <div algorithm>
   To <dfn>create a host function</dfn> from the JavaScript object |func| and type |functype|, perform the following steps:
 
-    1. Assert: [=IsCallable=](|func|).
+    1. Assert: [$IsCallable$](|func|).
     1. Let |stored settings| be the <a spec=HTML>incumbent settings object</a>.
     1. Let |hostfunc| be a [=host function=] which performs the following steps when called with arguments |arguments|:
         1. Let |realm| be |func|'s [=associated Realm=].
-        1. Let |relevant settings| be |realm|'s [=Realm/settings object=].
+        1. Let |relevant settings| be |realm|'s [=realm/settings object=].
         1. [=Prepare to run script=] with |relevant settings|.
         1. [=Prepare to run a callback=] with |stored settings|.
         1. Let |result| be the result of [=run a host function|running a host function=] from |func|, |functype|, and |arguments|.
@@ -1116,7 +1062,7 @@ The algorithm <dfn>ToJSValue</dfn>(|w|) coerces a [=WebAssembly value=] to a Jav
 1. If |w| is of the form [=ref.func=] |funcaddr|, return the result of creating [=a new Exported Function=] from |funcaddr|.
 1. If |w| is of the form [=ref.extern=] |externaddr|, return the result of [=retrieving an extern value=] from |externaddr|.
 
-Note: Number values which are equal to NaN may have various observable NaN payloads; see [=NumberToRawBytes=] for details.
+Note: Number values which are equal to NaN may have various observable NaN payloads; see [$NumericToRawBytes$] for details.
 </div>
 
 <div algorithm>
@@ -1134,13 +1080,13 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
 
 1. Assert: |type| is not [=v128=].
 1. If |type| is [=i64=],
-    1. Let |i64| be [=?=] [=ToBigInt64=](|v|).
+    1. Let |i64| be [=?=] [$ToBigInt64$](|v|).
     1. Return [=i64.const=] |i64|.
 1. If |type| is [=i32=],
-    1. Let |i32| be [=?=] [=ToInt32=](|v|).
+    1. Let |i32| be [=?=] [$ToInt32$](|v|).
     1. Return [=i32.const=] |i32|.
 1. If |type| is [=f32=],
-    1. Let |number| be [=?=] [=ToNumber=](|v|).
+    1. Let |number| be [=?=] [$ToNumber$](|v|).
     1. If |number| is **NaN**,
         1. Let |n| be an implementation-defined integer such that [=canon=]<sub>32</sub> ≤ |n| < 2<sup>[=signif=](32)</sup>.
         1. Let |f32| be [=nan=](n).
@@ -1148,7 +1094,7 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
         1. Let |f32| be |number| rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode. [[IEEE-754]]
     1. Return [=f32.const=] |f32|.
 1. If |type| is [=f64=],
-    1. Let |number| be [=?=] [=ToNumber=](|v|).
+    1. Let |number| be [=?=] [$ToNumber$](|v|).
     1. If |number| is **NaN**,
         1. Let |n| be an implementation-defined integer such that [=canon=]<sub>64</sub> ≤ |n| < 2<sup>[=signif=](64)</sup>.
         1. Let |f64| be [=nan=](n).


### PR DESCRIPTION
WebRef has recently added definitions for ECMAScript, which means most of the explicit anchor definitions are no longer needed. Also, some abstract operations had their names changed.

This change should be entirely editorial.