### PR TITLE
Fix inconsistent record expression

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -501,7 +501,7 @@ and list of :ref:`reference <syntax-ref>` vectors for the module's :ref:`element
 
 19. Let :math:`\exportinst^\ast` be the concatenation of the :ref:`export instances <syntax-exportinst>` :math:`\exportinst_i` in index order.
 
-20. Let :math:`\moduleinst` be the :ref:`module instance <syntax-moduleinst>` :math:`\{\MITYPES~(\module.\MTYPES),` :math:`\MIFUNCS~\funcaddr_{\F{mod}}^\ast,` :math:`\MITABLES~\tableaddr_{\F{mod}}^\ast,` :math:`\MIMEMS~\memaddr_{\F{mod}}^\ast,` :math:`\MIGLOBALS~\globaladdr_{\F{mod}}^\ast,` :math:`\MIEXPORTS~\exportinst^\ast\}`.
+20. Let :math:`\moduleinst` be the :ref:`module instance <syntax-moduleinst>` :math:`\{\MITYPES~(\module.\MTYPES), \MIFUNCS~\funcaddr_{\F{mod}}^\ast, \MITABLES~\tableaddr_{\F{mod}}^\ast, \MIMEMS~\memaddr_{\F{mod}}^\ast, \MIGLOBALS~\globaladdr_{\F{mod}}^\ast, \MIEXPORTS~\exportinst^\ast\}`.
 
 21. Return :math:`\moduleinst`.
 


### PR DESCRIPTION
```
...

    e. Let :math:`\exportinst_i` be the :ref:`export instance <syntax-exportinst>` :math:`\{\EINAME~(\export_i.\ENAME), \EIVALUE~\externval_i\}`.

19. Let :math:`\exportinst^\ast` be the concatenation of the :ref:`export instances <syntax-exportinst>` :math:`\exportinst_i` in index order.

20. Let :math:`\moduleinst` be the :ref:`module instance <syntax-moduleinst>` :math:`\{\MITYPES~(\module.\MTYPES),` :math:`\MIFUNCS~\funcaddr_{\F{mod}}^\ast,` :math:`\MITABLES~\tableaddr_{\F{mod}}^\ast,` :math:`\MIMEMS~\memaddr_{\F{mod}}^\ast,` :math:`\MIGLOBALS~\globaladdr_{\F{mod}}^\ast,` :math:`\MIEXPORTS~\exportinst^\ast\}`.

...
```
Record expression on step 20 in [Modules](https://webassembly.github.io/spec/core/exec/runtime.html#syntax-moduleinst) should be expressed in a single math.
Other record expression, such as record expression on step 18-e in the same algorithm, is expressed in a single math.