### PR TITLE
[spec] Fix typo in module instantiation of execution

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -721,7 +721,7 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^k, \val^\ast, (\reff^\ast)^n) \\
      &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
      &\wedge& (S'; F; \expr_{\F{g}} \stepto^\ast S'; F; \val~\END)^\ast \\
-     &\wedge& ((S'; F; \expr_{\F{e}} \stepto^\ast S'; F; \reff~\END)^\ast)^n \\
+     &\wedge& ((S'; F; \expr_{\F{e}} \stepto^\ast S'; F; \reff~\END)^\ast)^n) \\
    \end{array}
 
 where:


### PR DESCRIPTION
A closing parenthesis seems to be missing for the condition of module instantiation.

![image](https://user-images.githubusercontent.com/44872014/228482673-84649f5d-8f0e-46b0-b7e1-9208f9f0474f.png)

So this pull request simply adds a closing parenthesis for it.