### PR TITLE
[test] Remove malformed tests that become valid with memory64

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -504,25 +504,6 @@
     "\7f"                      ;; i32
     "\41\00"                   ;; i32.const 0
     "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
-  )
-  "integer representation too long"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
-    ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
     "\82\80\80\80\80\00"       ;; alignment 2 with one byte too many
     "\00"                      ;; offset 0
     "\1a"                      ;; drop
@@ -545,25 +526,6 @@
     "\36"                      ;; i32.store
     "\82\80\80\80\80\00"       ;; alignment 2 with one byte too many
     "\03"                      ;; offset 3
-    "\0b"                      ;; end
-  )
-  "integer representation too long"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\12\01"                ;; Code section
-    ;; function 0
-    "\10\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
     "\0b"                      ;; end
   )
   "integer representation too long"
@@ -636,44 +598,6 @@
     "\03\02\01\00"             ;; Function section
     "\05\03\01\00\01"          ;; Memory section
     "\0a\10\01"                ;; Code section
-    ;; function 0
-    "\0e\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\10"          ;; offset 2 with unused bits set
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
-  )
-  "integer too large"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\10\01"                ;; Code section
-    ;; function 0
-    "\0e\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\40"          ;; offset 2 with some unused bits set
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
-  )
-  "integer too large"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\10\01"                ;; Code section
     "\0e\01\01"                ;; local type count
     "\7f"                      ;; i32
     "\41\00"                   ;; i32.const 0
@@ -738,45 +662,6 @@
     "\36"                      ;; i32.store
     "\82\80\80\80\40"          ;; alignment 2 with some unused bits set
     "\03"                      ;; offset 3
-    "\0b"                      ;; end
-  )
-  "integer too large"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
-    ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\10"          ;; offset 2 with unused bits set
-    "\0b"                      ;; end
-  )
-  "integer too large"
-)
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
-
-    ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\40"          ;; offset 2 with some unused bits set
     "\0b"                      ;; end
   )
   "integer too large"

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -492,6 +492,27 @@
   )
   "integer representation too long"
 )
+;; The memory offset will be decoded as u64 in the memory64 proposal.
+;; TODO: Re-enable this test as assert_trap test in the memory64 repo.
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\11\01"                ;; Code section
+;;     ;; function 0
+;;     "\0f\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\28"                      ;; i32.load
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
+;;     "\1a"                      ;; drop
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer representation too long"
+;; )
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
@@ -530,6 +551,27 @@
   )
   "integer representation too long"
 )
+;; The memory offset will be decoded as u64 in the memory64 proposal.
+;; TODO: Re-enable this test as assert_trap test in the memory64 repo.
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\12\01"                ;; Code section
+;;     ;; function 0
+;;     "\10\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\41\03"                   ;; i32.const 3
+;;     "\36"                      ;; i32.store
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer representation too long"
+;; )
 
 ;; Signed LEB128 must not be overlong
 (assert_malformed
@@ -591,6 +633,46 @@
   )
   "integer too large"
 )
+;; The memory offset will be decoded as u64 in the memory64 proposal.
+;; TODO: Re-enable this test as assert_trap test in the memory64 repo.
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\10\01"                ;; Code section
+;;     ;; function 0
+;;     "\0e\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\28"                      ;; i32.load
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\10"          ;; offset 2 with unused bits set
+;;     "\1a"                      ;; drop
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer too large"
+;; )
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\10\01"                ;; Code section
+;;     ;; function 0
+;;     "\0e\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\28"                      ;; i32.load
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\40"          ;; offset 2 with some unused bits set
+;;     "\1a"                      ;; drop
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer too large"
+;; )
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
@@ -666,6 +748,46 @@
   )
   "integer too large"
 )
+;; The memory offset will be decoded as u64 in the memory64 proposal.
+;; TODO: Re-enable this test as assert_trap test in the memory64 repo.
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\11\01"                ;; Code section
+;;     ;; function 0
+;;     "\0f\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\41\03"                   ;; i32.const 3
+;;     "\36"                      ;; i32.store
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\10"          ;; offset 2 with unused bits set
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer too large"
+;; )
+;; (assert_malformed
+;;   (module binary
+;;     "\00asm" "\01\00\00\00"
+;;     "\01\04\01\60\00\00"       ;; Type section
+;;     "\03\02\01\00"             ;; Function section
+;;     "\05\03\01\00\01"          ;; Memory section
+;;     "\0a\11\01"                ;; Code section
+;;     ;; function 0
+;;     "\0f\01\01"                ;; local type count
+;;     "\7f"                      ;; i32
+;;     "\41\00"                   ;; i32.const 0
+;;     "\41\03"                   ;; i32.const 3
+;;     "\36"                      ;; i32.store
+;;     "\02"                      ;; alignment 2
+;;     "\82\80\80\80\40"          ;; offset 2 with some unused bits set
+;;     "\0b"                      ;; end
+;;   )
+;;   "integer too large"
+;; )
 
 ;; Signed LEB128s sign-extend
 (assert_malformed


### PR DESCRIPTION
With memory64, memory offsets will be decoded as u64. An engine implementing this will fail tests that test that we reject such module. Thus remove those tests from the main spec repo now; they should be added back in the memory64 repo, but changed to `assert_trap` tests.