### PR TITLE
Make binary-leb128 test memory64-ready

### DIFF
--- a/test/core/binary-leb128.wast
+++ b/test/core/binary-leb128.wast
@@ -404,19 +404,19 @@
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
+    "\01\04\01\60\00\00"                 ;; Type section
+    "\03\02\01\00"                       ;; Function section
+    "\05\03\01\00\01"                    ;; Memory section
+    "\0a\11\01"                          ;; Code section
     ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
+    "\0f\01\01"                          ;; local type count
+    "\7f"                                ;; i32
+    "\41\00"                             ;; i32.const 0
+    "\28"                                ;; i32.load
+    "\02"                                ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\80\00"  ;; offset 2 with one byte too many
+    "\1a"                                ;; drop
+    "\0b"                                ;; end
   )
   "integer representation too long"
 )
@@ -461,19 +461,19 @@
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\12\01"                ;; Code section
+    "\01\04\01\60\00\00"                 ;; Type section
+    "\03\02\01\00"                       ;; Function section
+    "\05\03\01\00\01"                    ;; Memory section
+    "\0a\12\01"                          ;; Code section
     ;; function 0
-    "\10\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\80\00"       ;; offset 2 with one byte too many
-    "\0b"                      ;; end
+    "\10\01\01"                          ;; local type count
+    "\7f"                                ;; i32
+    "\41\00"                             ;; i32.const 0
+    "\41\03"                             ;; i32.const 3
+    "\36"                                ;; i32.store
+    "\02"                                ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\80\00"  ;; offset 2 with one byte too many
+    "\0b"                                ;; end
   )
   "integer representation too long"
 )
@@ -730,40 +730,42 @@
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\10\01"                ;; Code section
+    "\01\04\01\60\00\00"              ;; Type section
+    "\03\02\01\00"                    ;; Function section
+    "\05\03\01\00\01"                 ;; Memory section
+    "\0a\10\01"                       ;; Code section
     ;; function 0
-    "\0e\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\10"          ;; offset 2 with unused bits set
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
+    "\0e\01\01"                       ;; local type count
+    "\7f"                             ;; i32
+    "\41\00"                          ;; i32.const 0
+    "\28"                             ;; i32.load
+    "\02"                             ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\10"  ;; offset 2 with unused bits set
+    "\1a"                             ;; drop
+    "\0b"                             ;; end
   )
-  "integer too large"
+  ;; TODO: This changes to "integer too large" with memory64.
+  "integer representation too long"
 )
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\10\01"                ;; Code section
+    "\01\04\01\60\00\00"              ;; Type section
+    "\03\02\01\00"                    ;; Function section
+    "\05\03\01\00\01"                 ;; Memory section
+    "\0a\10\01"                       ;; Code section
     ;; function 0
-    "\0e\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\28"                      ;; i32.load
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\40"          ;; offset 2 with some unused bits set
-    "\1a"                      ;; drop
-    "\0b"                      ;; end
+    "\0e\01\01"                       ;; local type count
+    "\7f"                             ;; i32
+    "\41\00"                          ;; i32.const 0
+    "\28"                             ;; i32.load
+    "\02"                             ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\40"  ;; offset 2 with some unused bits set
+    "\1a"                             ;; drop
+    "\0b"                             ;; end
   )
-  "integer too large"
+  ;; TODO: This changes to "integer too large" with memory64.
+  "integer representation too long"
 )
 (assert_malformed
   (module binary
@@ -843,41 +845,42 @@
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
+    "\01\04\01\60\00\00"              ;; Type section
+    "\03\02\01\00"                    ;; Function section
+    "\05\03\01\00\01"                 ;; Memory section
+    "\0a\11\01"                       ;; Code section
     ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\10"          ;; offset 2 with unused bits set
-    "\0b"                      ;; end
+    "\0f\01\01"                       ;; local type count
+    "\7f"                             ;; i32
+    "\41\00"                          ;; i32.const 0
+    "\41\03"                          ;; i32.const 3
+    "\36"                             ;; i32.store
+    "\02"                             ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\10"  ;; offset 2 with unused bits set
+    "\0b"                             ;; end
   )
-  "integer too large"
+  ;; TODO: This changes to "integer too large" with memory64.
+  "integer representation too long"
 )
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section
-    "\03\02\01\00"             ;; Function section
-    "\05\03\01\00\01"          ;; Memory section
-    "\0a\11\01"                ;; Code section
-
+    "\01\04\01\60\00\00"              ;; Type section
+    "\03\02\01\00"                    ;; Function section
+    "\05\03\01\00\01"                 ;; Memory section
+    "\0a\11\01"                       ;; Code section
     ;; function 0
-    "\0f\01\01"                ;; local type count
-    "\7f"                      ;; i32
-    "\41\00"                   ;; i32.const 0
-    "\41\03"                   ;; i32.const 3
-    "\36"                      ;; i32.store
-    "\02"                      ;; alignment 2
-    "\82\80\80\80\40"          ;; offset 2 with some unused bits set
-    "\0b"                      ;; end
+    "\0f\01\01"                       ;; local type count
+    "\7f"                             ;; i32
+    "\41\00"                          ;; i32.const 0
+    "\41\03"                          ;; i32.const 3
+    "\36"                             ;; i32.store
+    "\02"                             ;; alignment 2
+    "\82\80\80\80\80\80\80\80\80\40"  ;; offset 2 with some unused bits set
+    "\0b"                             ;; end
   )
-  "integer too large"
+  ;; TODO: This changes to "integer too large" with memory64.
+  "integer representation too long"
 )
 
 ;; Signed LEB128s sign-extend


### PR DESCRIPTION
This merges part of WebAssembly/memory64#14 to make the tests fail both before and after memory64. This allows engines to enable memory64 without failing spec tests.