### PR TITLE
Allow test for module size limit to fail

### DIFF
--- a/test/js-api/limits.any.js
+++ b/test/js-api/limits.any.js
@@ -255,7 +255,7 @@ function testModuleSizeLimit(size, expectPass) {
     buffer = new Uint8Array(size);
   } catch (e) {
     if (e instanceof RangeError) {
-      // 32-bit systems may fail to allocate a big TypedArray.
+      // Allocation of a big TypedArray may fail.
       return;
     }
     throw e;

--- a/test/js-api/limits.any.js
+++ b/test/js-api/limits.any.js
@@ -250,7 +250,16 @@ function testModuleSizeLimit(size, expectPass) {
 
   // Define a WebAssembly module that consists of a single custom section which
   // has an empty name. The module size will be `size`.
-  const buffer = new Uint8Array(size);
+  let buffer;
+  try {
+    buffer = new Uint8Array(size);
+  } catch (e) {
+    if (e instanceof RangeError) {
+      // 32-bit systems may fail to allocate a big TypedArray.
+      return;
+    }
+    throw e;
+  }
   const header = [
     kWasmH0, kWasmH1, kWasmH2, kWasmH3, // magic word
     kWasmV0, kWasmV1, kWasmV2, kWasmV3, // version


### PR DESCRIPTION
Allocating a 1GB Uint8Array can fail. In particular, it will always fail on 32-bit systems in V8, where the maximum size of a TypedArray is 2^30-1, thus 1 byte too little.