### PR TITLE
[spec] Fix typo in introduction of element section's bitfield

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -357,7 +357,7 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
 
 .. note::
    The initial integer can be interpreted as a bitfield.
-   Bit 0 indicates a passive or declarative segment,
+   Bit 0 indicates a passive or active segment,
    bit 1 indicates the presence of an explicit table index for an active segment and otherwise distinguishes passive from declarative segments,
    bit 2 indicates the use of element type and element :ref:`expressions <binary-expr>` instead of element kind and element indices.
 


### PR DESCRIPTION
The bit 0 should indicates a passive or active segment.