### PR TITLE
[spec] Fix table_alloc signature

### DIFF
--- a/document/core/appendix/embedding.rst
+++ b/document/core/appendix/embedding.rst
@@ -323,7 +323,7 @@ Tables
 
 .. _embed-table-alloc:
 
-:math:`\F{table\_alloc}(\store, \tabletype) : (\store, \tableaddr, \reff)`
+:math:`\F{table\_alloc}(\store, \tabletype, \reff) : (\store, \tableaddr)`
 ..........................................................................
 
 1. Pre-condition: :math:`\tabletype` is :ref:`valid <valid-tabletype>`.


### PR DESCRIPTION
While reading over some of the Editor's Draft regarding tables at https://webassembly.github.io/spec/js-api/#tables, I noticed that it links to the core specification `table_alloc` https://webassembly.github.io/spec/core/appendix/embedding.html#embed-table-alloc.

Editor's Draft:
```
Let (store, tableaddr) be table_alloc(store, type, ref).
```

Core specification:
```
table_alloc(store, tabletype) : (store, tableaddr, ref)
...
table_alloc(S, tt, r) = (S', a) (if alloctable(S, tt, r) = S', a)
```

Clearly, it seems like the `ref` in the result 3-tuple should be moved to be the third parameter instead, given the mismatch between the definition and its header.