### PR TITLE
add explicit bounds checks and do not catch Invalid_argument anymore

### DIFF
--- a/interpreter/exec/eval_num.ml
+++ b/interpreter/exec/eval_num.ml
@@ -195,4 +195,3 @@ let eval_binop = op I32Op.binop I64Op.binop F32Op.binop F64Op.binop
 let eval_testop = op I32Op.testop I64Op.testop F32Op.testop F64Op.testop
 let eval_relop = op I32Op.relop I64Op.relop F32Op.relop F64Op.relop
 let eval_cvtop = op I32CvtOp.cvtop I64CvtOp.cvtop F32CvtOp.cvtop F64CvtOp.cvtop
-

--- a/interpreter/exec/v128.ml
+++ b/interpreter/exec/v128.ml
@@ -477,7 +477,7 @@ let to_hex_string s =
 
 let of_strings shape ss =
   if List.length ss <> num_lanes shape then
-    raise (Invalid_argument "wrong length");
+    invalid_arg "wrong length";
   let open Bytes in
   let b = create bytewidth in
   (match shape with

--- a/interpreter/runtime/data.ml
+++ b/interpreter/runtime/data.ml
@@ -1,7 +1,15 @@
 type data = string ref
 type t = data
 
+exception Bounds
+
 let alloc bs = ref bs
+
 let size seg = I64.of_int_u (String.length !seg)
-let load seg i = (!seg).[Int64.to_int i]
+
+let load seg i =
+  let i' = Int64.to_int i in
+  if i' < 0 || i' >= String.length !seg then raise Bounds;
+  !seg.[i']
+
 let drop seg = seg := ""

--- a/interpreter/runtime/elem.ml
+++ b/interpreter/runtime/elem.ml
@@ -1,7 +1,13 @@
 type elem = Values.ref_ list ref
 type t = elem
 
+exception Bounds
+
 let alloc rs = ref rs
 let size seg = Lib.List32.length !seg
-let load seg i = Lib.List32.nth !seg i
+
+let load seg i =
+  if i < 0l || i >= Lib.List32.length !seg then raise Bounds;
+  Lib.List32.nth !seg i
+
 let drop seg = seg := []

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -62,10 +62,12 @@ let grow mem delta =
   mem.content <- after
 
 let load_byte mem a =
-  try Array1_64.get mem.content a with Invalid_argument _ -> raise Bounds
+  if a < 0L || a >= Array1_64.dim mem.content then raise Bounds;
+  Array1_64.get mem.content a
 
 let store_byte mem a b =
-  try Array1_64.set mem.content a b with Invalid_argument _ -> raise Bounds
+  if a < 0L || a >= Array1_64.dim mem.content then raise Bounds;
+  Array1_64.set mem.content a b
 
 let load_bytes mem a n =
   let buf = Buffer.create n in

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -47,14 +47,17 @@ let grow tab delta r =
   tab.content <- after
 
 let load tab i =
-  try Lib.Array32.get tab.content i with Invalid_argument _ -> raise Bounds
+  if i < 0l || i >= Lib.Array32.length tab.content then raise Bounds;
+  Lib.Array32.get tab.content i
 
 let store tab i r =
   let TableType (lim, t) = tab.ty in
   if type_of_ref r <> t then raise Type;
-  try Lib.Array32.set tab.content i r with Invalid_argument _ -> raise Bounds
+  if i < 0l || i >= Lib.Array32.length tab.content then raise Bounds;
+  Lib.Array32.set tab.content i r
 
 let blit tab offset rs =
   let data = Array.of_list rs in
-  try Lib.Array32.blit data 0l tab.content offset (Lib.Array32.length data)
-  with Invalid_argument _ -> raise Bounds
+  let len = Lib.Array32.length data in
+  if offset < 0l || offset > Int32.sub (Lib.Array32.length tab.content) len then raise Bounds;
+  Lib.Array32.blit data 0l tab.content offset len

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -156,7 +156,7 @@ module Array32 =
 struct
   let make n x =
     if n < 0l || Int64.of_int32 n > Int64.of_int max_int then
-      raise (Invalid_argument "Array32.make");
+      invalid_arg "Array32.make";
     Array.make (Int32.to_int n) x
 
   let length a = Int32.of_int (Array.length a)
@@ -179,7 +179,7 @@ struct
   struct
     let create kind layout n =
       if n < 0L || n > Int64.of_int max_int then
-        raise (Invalid_argument "Bigarray.Array1_64.create");
+        invalid_arg "Bigarray.Array1_64.create";
       Array1.create kind layout (Int64.to_int n)
 
     let dim a = Int64.of_int (Array1.dim a)
@@ -204,7 +204,7 @@ struct
   let force o =
     match o with
     | Some y -> y
-    | None -> raise (Invalid_argument "Option.force")
+    | None -> invalid_arg "Option.force"
 
   let map f = function
     | Some x -> Some (f x)


### PR DESCRIPTION
This allows to compile with -unsafe without getting a segfault or a random value.

There's something I don't understand in `interpreter/runtime/table.ml` and I left a comment there. I believe we should simply remove the `Invalid_argument` case.

It's a little bit unrelated but I also replaced all `raise (Invalid_argument s);` by `invalid_arg s;` (so that it's easier to grep for `Invalid_arg` to check if we're catching it).

Also unrelated, but it seems the `Array32.make` function in `interpreter/util/lib.ml` is wrong. IIUC it should check for `Sys.max_array_length` instead of `Int64.of_int max_int` (and `Sys.max_floatarray_length` if the array is made of floats, which is `Sys.max_array length / 2`).