### PR TITLE
Add type to elem.drop and element segment store soundness

### DIFF
--- a/document/core/appendix/properties.rst
+++ b/document/core/appendix/properties.rst
@@ -278,8 +278,8 @@ Module instances are classified by *module contexts*, which are regular :ref:`co
 .. index:: element instance, reference
 .. _valid-eleminst:
 
-:ref:`Element Instances <syntax-eleminst>` :math:`\{ \EIELEM~\X{fa}^\ast \}`
-............................................................................
+:ref:`Element Instances <syntax-eleminst>` :math:`\{ \EITYPE~t, \EIELEM~\reff^\ast \}`
+......................................................................................
 
 * For each :ref:`reference <syntax-ref>` :math:`\reff_i` in the elements :math:`\reff^n`:
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1676,15 +1676,9 @@ Table Instructions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
+2. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEMS[F.\AMODULE.\MIELEMS[x]]` exists.
 
-3. Let :math:`a` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[x]`.
-
-4. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEMS[a]` exists.
-
-5. Let :math:`t` be the :ref:`reference type <syntax-reftype>` :math:`S.\SELEMS[a].\EITYPE`.
-
-6. Replace :math:`S.\SELEMS[a]` with the :ref:`element instance <syntax-eleminst>` :math:`\{ \EITYPE~t, \EIELEM~\epsilon \}`.
+3. Replace :math:`S.\SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM` with :math:`\epsilon`.
 
 .. math::
    ~\\[-1ex]
@@ -1693,11 +1687,7 @@ Table Instructions
    S; F; (\ELEMDROP~x) &\stepto& S'; F; \epsilon
    \end{array}
    \\ \qquad
-     \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff & F.\AMODULE.\MIELEMS[x] = a \\
-     \wedge & \X{t} = S.\SELEMS[a].\EITYPE \\
-     \wedge & S' = S \with \SELEMS[a] = \{ \EITYPE~t, \EIELEM~\epsilon \}) \\
-     \end{array}
+     (\iff S' = S \with \SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM = \epsilon) \\
    \end{array}
 
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1676,9 +1676,13 @@ Table Instructions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEMS[F.\AMODULE.\MIELEMS[x]]` exists.
+2. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
 
-3. Replace :math:`S.\SELEMS[F.\AMODULE.\MIELEMS[x]].\EIELEM` with :math:`\epsilon`.
+3. Let :math:`a` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[x]`.
+
+4. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEMS[a]` exists.
+
+5. Replace :math:`S.\SELEMS[a].\EIELEM` with :math:`\epsilon`.
 
 .. math::
    ~\\[-1ex]

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -1682,7 +1682,9 @@ Table Instructions
 
 4. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEMS[a]` exists.
 
-5. Replace :math:`S.\SELEMS[a]` with the :ref:`element instance <syntax-eleminst>` :math:`\{\EIELEM~\epsilon\}`.
+5. Let :math:`t` be the :ref:`reference type <syntax-reftype>` :math:`S.\SELEMS[a].\EITYPE`.
+
+6. Replace :math:`S.\SELEMS[a]` with the :ref:`element instance <syntax-eleminst>` :math:`\{ \EITYPE~t, \EIELEM~\epsilon \}`.
 
 .. math::
    ~\\[-1ex]
@@ -1691,7 +1693,11 @@ Table Instructions
    S; F; (\ELEMDROP~x) &\stepto& S'; F; \epsilon
    \end{array}
    \\ \qquad
-     (\iff S' = S \with \SELEMS[F.\AMODULE.\MIELEMS[x]] = \{ \EIELEM~\epsilon \}) \\
+     \begin{array}[t]{@{}r@{~}l@{}}
+     (\iff & F.\AMODULE.\MIELEMS[x] = a \\
+     \wedge & \X{t} = S.\SELEMS[a].\EITYPE \\
+     \wedge & S' = S \with \SELEMS[a] = \{ \EITYPE~t, \EIELEM~\epsilon \}) \\
+     \end{array}
    \end{array}
 
 


### PR DESCRIPTION
The execution section for `elem.drop` was missing the `type` field of element instances. In addition, the heading of the Element Instances section in the Soundness appendix was also missing the type. I have added the type to both places.

This is my first contribution to the spec repo, so apologies if I got any conventions wrong.

Would close #1663 if it wasn't already closed for some reason.