### PR TITLE
[test] Add tests for out-of-range NaN payloads

### DIFF
--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -510,6 +510,6 @@
   "unknown operator"
 )
 (assert_malformed
-  (module quote "(global f64 (f64.const nan:0x10000000000000))")
+  (module quote "(global f64 (f64.const nan:0x10_0000_0000_0000))")
   "invalid literal"
 )

--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -353,7 +353,7 @@
   "unknown operator"
 )
 (assert_malformed
-  (module quote "(global f32 (f32.const nan:0x800000))")
+  (module quote "(global f32 (f32.const nan:0x80_0000))")
   "constant out of range"
 )
 

--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -352,6 +352,10 @@
   (module quote "(global f32 (f32.const 0x1.0p_+1))")
   "unknown operator"
 )
+(assert_malformed
+  (module quote "(global f32 (f32.const nan:0x800000))")
+  "invalid literal"
+)
 
 (assert_malformed
   (module quote "(global f64 (f64.const _100))")
@@ -504,4 +508,8 @@
 (assert_malformed
   (module quote "(global f64 (f64.const 0x1.0p_+1))")
   "unknown operator"
+)
+(assert_malformed
+  (module quote "(global f64 (f64.const nan:0x10000000000000))")
+  "invalid literal"
 )

--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -511,5 +511,5 @@
 )
 (assert_malformed
   (module quote "(global f64 (f64.const nan:0x10_0000_0000_0000))")
-  "invalid literal"
+  "constant out of range"
 )

--- a/test/core/float_literals.wast
+++ b/test/core/float_literals.wast
@@ -354,7 +354,7 @@
 )
 (assert_malformed
   (module quote "(global f32 (f32.const nan:0x800000))")
-  "invalid literal"
+  "constant out of range"
 )
 
 (assert_malformed


### PR DESCRIPTION
Add `assert_malformed` tests for `f32.const nan:0x800000` and `f64.const nan:0x10000000000000`, which are malformed since the payload values are outside the range supported by the types.