### PR TITLE
Fix typos

### DIFF
--- a/test/core/unreachable.wast
+++ b/test/core/unreachable.wast
@@ -6,8 +6,8 @@
   (func $dummy3 (param i32 i32 i32))
 
   (func (export "type-i32") (result i32) (unreachable))
-  (func (export "type-i64") (result i32) (unreachable))
-  (func (export "type-f32") (result f64) (unreachable))
+  (func (export "type-i64") (result i64) (unreachable))
+  (func (export "type-f32") (result f32) (unreachable))
   (func (export "type-f64") (result f64) (unreachable))
 
   (func (export "as-func-first") (result i32)


### PR DESCRIPTION
I can't think of any reasons to repeat identical functions with different names here. I guess they are typos.