### PR TITLE
[test] Test that atypical folded if conditions are parsed correctly

### DIFF
--- a/test/core/if.wast
+++ b/test/core/if.wast
@@ -524,6 +524,14 @@
     )
     (drop) (drop) (drop)
   )
+
+  ;; Atypical folded condition syntax
+
+  (func (export "atypical-condition")
+    i32.const 0
+    (if (then) (else))
+    (if (i32.const 1) (i32.eqz) (then) (else))
+  )
 )
 
 (assert_return (invoke "empty" (i32.const 0)))
@@ -721,6 +729,8 @@
 )
 
 (assert_return (invoke "type-use"))
+
+(assert_return (invoke "atypical-condition"))
 
 (assert_malformed
   (module quote
@@ -1547,4 +1557,8 @@
 (assert_malformed
   (module quote "(func i32.const 0 if $a else $l end $l)")
   "mismatching label"
+)
+(assert_malformed
+  (module quote "(func (if i32.const 0 (then) (else)))")
+  "unexpected token"
 )


### PR DESCRIPTION
Check that the condition must be a sequence of folded (as opposed to unfolded)
instructions, but also check that having zero or multiple folded instructions is
allowed.