### PR TITLE
Don't install ocamlbuild in CI

### DIFF
--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           ocaml-compiler: 4.12.x
       - name: Setup OCaml tools
-        run: opam install --yes ocamlbuild.0.14.0 ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0
+        run: opam install --yes ocamlfind.1.9.5 js_of_ocaml.4.0.0 js_of_ocaml-ppx.4.0.0
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
It ought to not be needed after https://github.com/WebAssembly/spec/pull/1665.