### PR TITLE
[spec] Fix typo in shape.all_true and txN.bitmask instruction execution

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -685,7 +685,7 @@ Most other vector instructions are defined in terms of numeric operators that ar
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff & i_1^\ast = \lanes_{\shape}(c) \\
+     (\iff & i_1^\ast = \lanes_{\shape}(c_1) \\
      \wedge & i = \bool(\bigwedge(i_1 \neq 0)^\ast))
      \end{array}
    \end{array}

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -700,7 +700,7 @@ Most other vector instructions are defined in terms of numeric operators that ar
 
 2. Pop the value :math:`\V128.\VCONST~c_1` from the stack.
 
-3. Let :math:`i_1^N` be the result of computing :math:`\lanes_{t\K{x}N}(c)`.
+3. Let :math:`i_1^N` be the result of computing :math:`\lanes_{t\K{x}N}(c_1)`.
 
 4. Let :math:`B` be the :ref:`bit width <syntax-valtype>` :math:`|t|` of :ref:`value type <syntax-valtype>` :math:`t`.
 
@@ -715,7 +715,7 @@ Most other vector instructions are defined in terms of numeric operators that ar
 .. math::
    \begin{array}{lcl@{\qquad}l}
    (\V128\K{.}\VCONST~c_1)~t\K{x}N\K{.}\BITMASK &\stepto& (\I32\K{.}\CONST~c)
-     & (\iff c = \ibits_{32}^{-1}(\ilts_{|t|}(\lanes_{t\K{x}N}(c), 0^N)))
+     & (\iff c = \ibits_{32}^{-1}(\ilts_{|t|}(\lanes_{t\K{x}N}(c_1), 0^N)))
      \\
    \end{array}
 

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -669,9 +669,9 @@ Most other vector instructions are defined in terms of numeric operators that ar
 
 1. Assert: due to :ref:`validation <valid-vtestop>`, a value of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
 
-2. Pop the value :math:`\V128.\VCONST~c_1` from the stack.
+2. Pop the value :math:`\V128.\VCONST~c` from the stack.
 
-3. Let :math:`i_1^\ast` be the result of computing :math:`\lanes_{\shape}(c_1)`.
+3. Let :math:`i_1^\ast` be the result of computing :math:`\lanes_{\shape}(c)`.
 
 4. Let :math:`i` be the result of computing :math:`\bool(\bigwedge(i_1 \neq 0)^\ast)`.
 
@@ -681,11 +681,11 @@ Most other vector instructions are defined in terms of numeric operators that ar
 .. math::
    \begin{array}{l}
    \begin{array}{lcl@{\qquad}l}
-   (\V128\K{.}\VCONST~c_1)~\shape\K{.}\ALLTRUE &\stepto& (\I32\K{.}\CONST~i)
+   (\V128\K{.}\VCONST~c)~\shape\K{.}\ALLTRUE &\stepto& (\I32\K{.}\CONST~i)
    \end{array}
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
-     (\iff & i_1^\ast = \lanes_{\shape}(c_1) \\
+     (\iff & i_1^\ast = \lanes_{\shape}(c) \\
      \wedge & i = \bool(\bigwedge(i_1 \neq 0)^\ast))
      \end{array}
    \end{array}
@@ -698,9 +698,9 @@ Most other vector instructions are defined in terms of numeric operators that ar
 
 1. Assert: due to :ref:`validation <valid-vec-bitmask>`, a value of :ref:`value type <syntax-valtype>` |V128| is on the top of the stack.
 
-2. Pop the value :math:`\V128.\VCONST~c_1` from the stack.
+2. Pop the value :math:`\V128.\VCONST~c` from the stack.
 
-3. Let :math:`i_1^N` be the result of computing :math:`\lanes_{t\K{x}N}(c_1)`.
+3. Let :math:`i_1^N` be the result of computing :math:`\lanes_{t\K{x}N}(c)`.
 
 4. Let :math:`B` be the :ref:`bit width <syntax-valtype>` :math:`|t|` of :ref:`value type <syntax-valtype>` :math:`t`.
 
@@ -708,14 +708,14 @@ Most other vector instructions are defined in terms of numeric operators that ar
 
 6. Let :math:`j^\ast` be the concatenation of the two sequences :math:`i_2^N` and :math:`0^{32-N}`.
 
-7. Let :math:`c` be the result of computing :math:`\ibits_{32}^{-1}(j^\ast)`.
+7. Let :math:`i` be the result of computing :math:`\ibits_{32}^{-1}(j^\ast)`.
 
-8. Push the value :math:`\I32.\CONST~c` onto the stack.
+8. Push the value :math:`\I32.\CONST~i` onto the stack.
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   (\V128\K{.}\VCONST~c_1)~t\K{x}N\K{.}\BITMASK &\stepto& (\I32\K{.}\CONST~c)
-     & (\iff c = \ibits_{32}^{-1}(\ilts_{|t|}(\lanes_{t\K{x}N}(c_1), 0^N)))
+   (\V128\K{.}\VCONST~c)~t\K{x}N\K{.}\BITMASK &\stepto& (\I32\K{.}\CONST~i)
+     & (\iff i = \ibits_{32}^{-1}(\ilts_{|t|}(\lanes_{t\K{x}N}(c), 0^N)))
      \\
    \end{array}
 


### PR DESCRIPTION
There seems to be some typos in shape.all_true instruction and txN.bitmask execution.
The parameter is labeled as $c_1$, but the some of the ones used are just labeled $c$.

![image](https://github.com/WebAssembly/spec/assets/101983402/7f7765a3-9473-4152-b146-7cae848e6d79)

This pull request changes all the incorrect $c$ to $c_1$. 