### PR TITLE
[spec] Fix extmul & extadd execution

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -942,7 +942,7 @@ where:
 
 10. Let :math:`k_2^\ast` be the result of computing :math:`\extend^{\sx}_{|t_1|,|t_2|}(j_2^\ast)`.
 
-11. Let :math:`k^\ast` be the result of computing :math:`\imul_{t_2\K{x}N}(k_1^\ast, k_2^\ast)`.
+11. Let :math:`k^\ast` be the result of computing :math:`\imul_{|t_2|}(k_1^\ast, k_2^\ast)`.
 
 12. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t_2\K{x}N}(k^\ast)`.
 
@@ -956,7 +956,7 @@ where:
      \begin{array}[t]{@{}r@{~}l@{}}
      (\iff & i^\ast = \lanes_{t_1\K{x}M}(c_1)[\half(0, N) \slice N] \\
      \wedge & j^\ast = \lanes_{t_1\K{x}M}(c_2)[\half(0, N) \slice N] \\
-     \wedge & c = \lanes^{-1}_{t_2\K{x}N}(\imul_{t_2\K{x}N}(\extend^{\sx}_{|t_1|,|t_2|}(i^\ast), \extend^{\sx}_{|t_1|,|t_2|}(j^\ast))))
+     \wedge & c = \lanes^{-1}_{t_2\K{x}N}(\imul_{|t_2|}(\extend^{\sx}_{|t_1|,|t_2|}(i^\ast), \extend^{\sx}_{|t_1|,|t_2|}(j^\ast))))
      \end{array}
 
 where:
@@ -983,7 +983,7 @@ where:
 
 5. Let :math:`(j_1~j_2)^\ast` be the result of computing :math:`\extend^{\sx}_{|t_1|,|t_2|}(i^\ast)`.
 
-6. Let :math:`k^\ast` be the result of computing :math:`\iadd_{N}(j_1, j_2)^\ast`.
+6. Let :math:`k^\ast` be the result of computing :math:`\iadd_{|t_2|}(j_1, j_2)^\ast`.
 
 7. Let :math:`c` be the result of computing :math:`\lanes^{-1}_{t_2\K{x}N}(k^\ast)`.
 
@@ -997,7 +997,7 @@ where:
    \\ \qquad
      \begin{array}[t]{@{}r@{~}l@{}}
      (\iff & (i_1~i_2)^\ast = \extend^{\sx}_{|t_1|,|t_2|}(\lanes_{t_1\K{x}M}(c_1)) \\
-     \wedge & j^\ast = \iadd_{N}(i_1, i_2)^\ast \\
+     \wedge & j^\ast = \iadd_{|t_2|}(i_1, i_2)^\ast \\
      \wedge & c = \lanes^{-1}_{t_2\K{x}N}(j^\ast))
      \end{array}
    \end{array}


### PR DESCRIPTION
At step 11 of the definition of extmul (below image), there is an expression $`\text{imul}_{t_2 \times N}(k_1^*, k_2^*)`$.
![image](https://github.com/WebAssembly/spec/assets/79245586/fe60a988-2ab2-4c74-8188-aff837b61407)
### First solution
I guess it should be $`\text{imul}_{|t_2|} (k_1^*, k_2^*)`$.
The underscored argument of $`\text{imul}`$, which is $`t_2 \times N`$ is typed wrong. From the definition of $`\text{imul}`$, its argument should be an integer.
![image](https://github.com/WebAssembly/spec/assets/79245586/e452a1a6-8dae-4b9f-af07-26377f5cf63d)
Here, from line 12, $`k^*`$ should be a sequence of length $`N`$ with its elements typed $`t_2`$. So I think the argument should be $`|t_2|`$.
Same problem occurs in the definition of extadd (below image).
![image](https://github.com/WebAssembly/spec/assets/79245586/aabb3cb9-62e1-4a48-acc2-cf768b2cb113)
I think the expression $`\text{iadd}_N(j_1, j_2)^*`$ at step 6 should be $`\text{iadd}_{|t_2|} (j_1, j_2)^*`$ instead, and fixed the document.
### Second solution
Another solution (which I'm not so sure of) could be using the lane-wise applying notation.
![image](https://github.com/WebAssembly/spec/assets/79245586/667cafad-25fe-4ea8-aa60-d2096f48ab49)
With this notation, $`\text{lanes}_{t_2 \times N}^{-1}(\text{imul}_{t_2 \times N} (k_1^*, k_2^*))`$ from extmul can be replaced by $`\text{mul}_{t_2 \times N} (k_1^*, k_2^*)`$, and $`\text{lanes}_{t_2 \times N}^{-1}(\text{iadd}_N(j_1, j_2)^*)`$ from extadd by $`\text{add}_{t_2 \times N}(j_1, j_2)^*`$.

I'm not sure about the second solution nor which one is better, so I applied the first one to the document for now.