### PR TITLE
[interpreter]: Add depends to dune-project

### DIFF
--- a/interpreter/dune-project
+++ b/interpreter/dune-project
@@ -3,21 +3,32 @@
 (name wasm)
 
 (generate_opam_files true)
+
 (using menhir 2.1)
+
 (implicit_transitive_deps false)
 
 (license Apache-2.0)
 
 (source
-  (github WebAssembly/spec))
+ (github WebAssembly/spec))
 
 (authors "Andreas Rossberg <rossberg@mpi-sws.org")
+
 (maintainers "Andreas Rossberg <rossberg@mpi-sws.org")
 
 (package
-  (name wasm)
-  (synopsis "Library to read and write WebAssembly (Wasm) files and manipulate their AST")
-  (tags (wasm webassembly spec interpreter))
-  (depends
-    (ocaml (>= 4.12))
-    (menhir (>= 20220210))))
+ (name wasm)
+ (synopsis
+  "Library to read and write WebAssembly (Wasm) files and manipulate their AST")
+ (tags
+  (wasm webassembly spec interpreter))
+ (depends
+  (ocaml
+   (>= 4.12))
+  (menhir
+   (>= 20220210))
+  (js_of_ocaml
+   (>= 5.5.2))
+  (js_of_ocaml-ppx
+   (>= 5.5.2))))

--- a/interpreter/dune-project
+++ b/interpreter/dune-project
@@ -3,32 +3,23 @@
 (name wasm)
 
 (generate_opam_files true)
-
 (using menhir 2.1)
-
 (implicit_transitive_deps false)
 
 (license Apache-2.0)
 
 (source
- (github WebAssembly/spec))
+  (github WebAssembly/spec))
 
 (authors "Andreas Rossberg <rossberg@mpi-sws.org")
-
 (maintainers "Andreas Rossberg <rossberg@mpi-sws.org")
 
 (package
- (name wasm)
- (synopsis
-  "Library to read and write WebAssembly (Wasm) files and manipulate their AST")
- (tags
-  (wasm webassembly spec interpreter))
- (depends
-  (ocaml
-   (>= 4.12))
-  (menhir
-   (>= 20220210))
-  (js_of_ocaml
-   (>= 5.5.2))
-  (js_of_ocaml-ppx
-   (>= 5.5.2))))
+  (name wasm)
+  (synopsis "Library to read and write WebAssembly (Wasm) files and manipulate their AST")
+  (tags (wasm webassembly spec interpreter))
+  (depends
+    (ocaml (>= 4.12))
+    (menhir (>= 20220210))
+    (js_of_ocaml (>= 5.5.2))
+    (js_of_ocaml-ppx (>= 5.5.2))))

--- a/interpreter/wasm.opam
+++ b/interpreter/wasm.opam
@@ -12,6 +12,8 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.12"}
   "menhir" {>= "20220210"}
+  "js_of_ocaml" {>= "5.5.2"}
+  "js_of_ocaml-ppx" {>= "5.5.2"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Add depends to `dune-project` so that dependencies can be installed by calling `opam install . --deps-only --with-doc --with-test` and then build the interpreter from source :)