### PR TITLE
[interpreter/test] Fix inconsistent use of float values in `spectest`

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -44,8 +44,8 @@ let spectest = {
   print_f64: console.log.bind(console),
   global_i32: 666,
   global_i64: 666n,
-  global_f32: 666,
-  global_f64: 666,
+  global_f32: 666.6,
+  global_f64: 666.6,
   table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
   memory: new WebAssembly.Memory({initial: 1, maximum: 2})
 };

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -238,12 +238,18 @@
   (func (export "get-1") (result i32) (global.get 1))
   (func (export "get-x") (result i32) (global.get $x))
   (func (export "get-y") (result i32) (global.get $y))
+  (func (export "get-4") (result i64) (global.get 4))
+  (func (export "get-5") (result f32) (global.get 5))
+  (func (export "get-6") (result f64) (global.get 6))
 )
 
 (assert_return (invoke "get-0") (i32.const 666))
 (assert_return (invoke "get-1") (i32.const 666))
 (assert_return (invoke "get-x") (i32.const 666))
 (assert_return (invoke "get-y") (i32.const 666))
+(assert_return (invoke "get-4") (i64.const 666))
+(assert_return (invoke "get-5") (f32.const 666.6))
+(assert_return (invoke "get-6") (f64.const 666.6))
 
 (module (import "test" "global-i32" (global i32)))
 (module (import "test" "global-f32" (global f32)))

--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -100,8 +100,8 @@ function reinitializeRegistry() {
       print_f64: console.log.bind(console),
       global_i32: 666,
       global_i64: 666n,
-      global_f32: 666,
-      global_f64: 666,
+      global_f32: 666.6,
+      global_f64: 666.6,
       table: new WebAssembly.Table({
         initial: 10,
         maximum: 20,

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -110,8 +110,8 @@ function reinitializeRegistry() {
         print_f64: console.log.bind(console),
         global_i32: 666,
         global_i64: 666n,
-        global_f32: 666,
-        global_f64: 666,
+        global_f32: 666.6,
+        global_f64: 666.6,
         table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
         memory: new WebAssembly.Memory({initial: 1, maximum: 2})
     };


### PR DESCRIPTION
In the file `interpreter/host/spectest.ml`, the global float values for F32 and F64 are 666.6,
but in the file `interpreter/script/js.ml`, the float values are 666.

This pull request changes the float values 666 in `js.ml` into 666.6.

Also, this indicates that the test suite did not contain the test for checking the value of imported global values,

and this pull request also adds new tests in `imports.wast` test file.