### PR TITLE
run.py: Better default for wasm executable

### DIFF
--- a/test/core/run.py
+++ b/test/core/run.py
@@ -12,10 +12,11 @@ import sys
 
 ownDir = os.path.dirname(os.path.abspath(sys.argv[0]))
 inputDir = ownDir
+interpDir = os.path.join(os.path.dirname(os.path.dirname(ownDir)), 'interpreter')
 outputDir = os.path.join(inputDir, "_output")
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--wasm", metavar="<wasm-command>", default=os.path.join(os.getcwd(), "wasm"))
+parser.add_argument("--wasm", metavar="<wasm-command>", default=os.path.join(interpDir, "wasm"))
 parser.add_argument("--js", metavar="<js-command>")
 parser.add_argument("--generate-js-only", action='store_true')
 parser.add_argument("--out", metavar="<out-dir>", default=outputDir)


### PR DESCRIPTION
After this change I can run the following commands from the top level of the repository:

```
$ make -C interpreter/
$ test/core/run.py
```

Without this change `run.py` looks for wasm in my current directory which will fail when run from anywhere except the `interpreter` directory and forces me to run `test/core/run.py --wasm interpreter/wasm`.