### PR TITLE
Remove failure case with ambiguous error options

### DIFF
--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -532,14 +532,6 @@
   "constant expression required"
 )
 
-(assert_invalid
-  (module
-    (table 1 funcref)
-    (elem (i32.const 0) funcref (item (i32.add (i32.const 0) (i32.const 1))))
-  )
-  "constant expression required"
-)
-
 ;; Two elements target the same slot
 
 (module


### PR DESCRIPTION
This failure case could be equally valid as "type mismatch" if a validator is validating one opcode at a time rather than consuming them all then validating the return type.

It wants a `ref.func` but the first opcode it finds is an `i32.const` so a streaming validator should be able to error on the first opcode rather than wait for more to decide that it's not a constant expression.

I can't think of an alternative to replace this with, so I'm suggesting this case is unnecessary and too ambiguous.