### PR TITLE
[spec] Fixing module typing for active elem/data segments

### DIFF
--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -542,7 +542,12 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
   * :math:`C'.\CFUNCS` is the same as :math:`C.\CFUNCS`,
 
+  * :math:`C'.\CTABLES` is the same as :math:`C.\CTABLES`,
+
+  * :math:`C'.\CMEMS` is the same as :math:`C.\CMEMS`,
+
   * :math:`C'.\CREFS` is the same as :math:`C.\CREFS`,
+
 
   * all other fields are empty.
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -548,7 +548,6 @@ Instead, the context :math:`C` for validation of the module's content is constru
 
   * :math:`C'.\CREFS` is the same as :math:`C.\CREFS`,
 
-
   * all other fields are empty.
 
 * For each :math:`\functype_i` in :math:`\module.\MTYPES`,

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -639,7 +639,7 @@ Instead, the context :math:`C` for validation of the module's content is constru
      \\
      C = \{ \CTYPES~\type^\ast, \CFUNCS~\X{ift}^\ast\,\X{ft}^\ast, \CTABLES~\X{itt}^\ast\,\X{tt}^\ast, \CMEMS~\X{imt}^\ast\,\X{mt}^\ast, \CGLOBALS~\X{igt}^\ast\,\X{gt}^\ast, \CELEMS~\X{rt}^\ast, \CDATAS~{\ok}^n, \CREFS~x^\ast \}
      \\
-     C' = \{ \CGLOBALS~\X{igt}^\ast, \CFUNCS~(C.\CFUNCS), \CREFS~(C.\CREFS) \}
+     C' = \{ \CGLOBALS~\X{igt}^\ast, \CFUNCS~(C.\CFUNCS), \CTABLES~(C.\CTABLES), \CMEMS~(C.\CMEMS), \CREFS~(C.\CREFS) \}
      \qquad
      |C.\CMEMS| \leq 1
      \qquad


### PR DESCRIPTION
Under the current module typing rules, if a module defines any module elem/data segment with an active mode, then it cannot be well-typed: this is because the definition requires each elem/data to be well-typed under the C' context, but no tables and memories exist there.

This proposed change fixes this issue by allowing the module elem and data segments to access the full tables and memories accessible in the module.