### PR TITLE
[spec] Check and fix cross-references

### DIFF
--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -98,7 +98,7 @@ GENERATED = appendix/index-instructions.rst
 	(cd `dirname $@`; ./`basename $^`)
 
 .PHONY: macrosok
-macrosok:
+macrosok:	$(GENERATED)
 	sh util/check_macros.sh
 
 .PHONY: pdf

--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -80,7 +80,7 @@ publish-main: clean main bikeshed-keep deploy
 all:	pdf html bikeshed
 
 .PHONY: main
-main:	pdf html
+main:	macrosok pdf html
 
 # Dirty hack to avoid rebuilding the Bikeshed version for every push.
 .PHONY: bikeshed-keep
@@ -96,6 +96,10 @@ GENERATED = appendix/index-instructions.rst
 
 %.rst: %.py
 	(cd `dirname $@`; ./`basename $^`)
+
+.PHONY: macrosok
+macrosok:
+	sh util/check_macros.sh
 
 .PHONY: pdf
 pdf:	$(GENERATED) latexpdf

--- a/document/core/text/lexical.rst
+++ b/document/core/text/lexical.rst
@@ -71,8 +71,9 @@ Any token that does not fall into any of the other categories is considered *res
 
 .. index:: ! white space, character, ASCII
    single: text format; white space
-.. _text-format:
 .. _text-space:
+.. _text-format:
+.. _text-newline:
 
 White Space
 ~~~~~~~~~~~

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -569,7 +569,7 @@ As another abbreviation, element segments may also be specified inline with :ref
    single: data; segment
 .. _text-datastring:
 .. _text-data:
-.. _test-memuse:
+.. _text-memuse:
 
 Data Segments
 ~~~~~~~~~~~~~

--- a/document/core/util/check_macros.sh
+++ b/document/core/util/check_macros.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+cd `dirname $0`/..
+
+FILES=`ls */*.rst`
+ERRORS=0
+
+for XREF in `grep xref util/macros.def`; do
+  if echo $XREF | grep -q "[|]"; then
+    MACRO=`echo $XREF | sed 's/^[^|]*[|]//g' | sed 's/[|].*$//g'`
+  elif echo $XREF | grep -q xref; then
+    FILE=`echo $XREF | sed 's/^.*xref{//g' | sed 's/}.*$//g'`.rst
+    LABEL=`echo $XREF | sed 's/^[^}]*}{//g' | sed 's/}.*$//g'`
+    TARGET=".. _$LABEL:"
+    if ! [ -f $FILE ] || ! grep -q "$TARGET" $FILE; then
+      ERRORS=1
+      echo Undefined cross-reference $FILE:$LABEL in macro "|$MACRO|"
+      if ! [ -f $FILE ]; then
+        echo ...non-existent file $FILE
+      fi
+      if grep -q "$TARGET" $FILES; then
+        echo ...defined in `grep -l "$TARGET" $FILES`
+      fi
+    fi
+  fi
+done
+
+if [ $ERRORS -eq 0 ]; then
+  echo All cross-references okay.
+else
+  exit 1;
+fi

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -177,8 +177,6 @@
 
 .. |to| mathdef:: \xref{syntax/types}{syntax-functype}{\rightarrow}
 
-.. |I8| mathdef:: \xref{exec/runtime}{syntax-storagetype}{\K{i8}}
-.. |I16| mathdef:: \xref{exec/runtime}{syntax-storagetype}{\K{i16}}
 .. |I32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i32}}
 .. |I64| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{i64}}
 .. |F32| mathdef:: \xref{syntax/types}{syntax-valtype}{\K{f32}}
@@ -227,8 +225,8 @@
 
 .. |externtype| mathdef:: \xref{syntax/types}{syntax-externtype}{\X{externtype}}
 
-.. |stacktype| mathdef:: \xref{syntax/types}{syntax-stacktype}{\X{stacktype}}
-.. |opdtype| mathdef:: \xref{syntax/types}{syntax-opdtype}{\X{opdtype}}
+.. |stacktype| mathdef:: \xref{valid/instructions}{syntax-stacktype}{\X{stacktype}}
+.. |opdtype| mathdef:: \xref{valid/instructions}{syntax-opdtype}{\X{opdtype}}
 
 
 .. Types, meta functions
@@ -523,9 +521,7 @@
 .. |vunop| mathdef:: \xref{syntax/instructions}{syntax-vunop}{\X{vunop}}
 .. |vbinop| mathdef:: \xref{syntax/instructions}{syntax-vbinop}{\X{vbinop}}
 .. |vrelop| mathdef:: \xref{syntax/instructions}{syntax-vrelop}{\X{vrelop}}
-.. |vternop| mathdef:: \xref{syntax/instructions}{syntax-vternop}{\X{vternop}}
 .. |vcvtop| mathdef:: \xref{syntax/instructions}{syntax-vcvtop}{\X{vcvtop}}
-.. |vextmul| mathdef:: \xref{syntax/instructions}{syntax-vextmul}{\X{vextmul}}
 
 .. |laneidx| mathdef:: \xref{syntax/instructions}{syntax-laneidx}{\X{laneidx}}
 .. |vvunop| mathdef:: \xref{syntax/instructions}{syntax-vvunop}{\X{vvunop}}
@@ -797,19 +793,10 @@
 .. |Tlocalidx| mathdef:: \xref{text/modules}{text-localidx}{\T{localidx}}
 .. |Tlabelidx| mathdef:: \xref{text/modules}{text-labelidx}{\T{labelidx}}
 
-.. |Ttypebind| mathdef:: \xref{text/modules}{text-typebind}{\T{typebind}}
-.. |Tfuncbind| mathdef:: \xref{text/modules}{text-funcbind}{\T{funcbind}}
-.. |Ttablebind| mathdef:: \xref{text/modules}{text-tablebind}{\T{tablebind}}
-.. |Tmembind| mathdef:: \xref{text/modules}{text-membind}{\T{membind}}
-.. |Tglobalbind| mathdef:: \xref{text/modules}{text-globalbind}{\T{globalbind}}
-.. |Tlocalbind| mathdef:: \xref{text/modules}{text-localbind}{\T{localbind}}
-.. |Tlabelbind| mathdef:: \xref{text/modules}{text-labelbind}{\T{labelbind}}
-
 
 .. Modules, non-terminals
 
 .. |Tmodule| mathdef:: \xref{text/modules}{text-module}{\T{module}}
-.. |Tmodulebody| mathdef:: \xref{text/modules}{text-modulebody}{\T{modulebody}}
 .. |Tmodulefield| mathdef:: \xref{text/modules}{text-modulefield}{\T{modulefield}}
 .. |Ttype| mathdef:: \xref{text/modules}{text-typedef}{\T{type}}
 .. |Ttypeuse| mathdef:: \xref{text/modules}{text-typeuse}{\T{typeuse}}
@@ -825,7 +812,6 @@
 .. |Telemlist| mathdef:: \xref{text/modules}{text-elemlist}{\T{elemlist}}
 .. |Telemexpr| mathdef:: \xref{text/modules}{text-elemexpr}{\T{elemexpr}}
 .. |Ttableuse| mathdef:: \xref{text/modules}{text-tableuse}{\T{tableuse}}
-.. |Tcode| mathdef:: \xref{text/modules}{text-code}{\T{code}}
 .. |Tlocal| mathdef:: \xref{text/modules}{text-local}{\T{local}}
 .. |Tlocals| mathdef:: \xref{text/modules}{text-local}{\T{locals}}
 .. |Tdata| mathdef:: \xref{text/modules}{text-data}{\T{data}}
@@ -940,10 +926,10 @@
 
 .. Notation
 
-.. |stepto| mathdef:: \xref{exec/conventions}{formal-notation}{\hookrightarrow}
+.. |stepto| mathdef:: \xref{exec/conventions}{exec-notation}{\hookrightarrow}
 .. |extendsto| mathdef:: \xref{appendix/properties}{extend}{\preceq}
-.. |matchesexterntype| mathdef:: \xref{exec/modules}{match-externtype}{\leq}
-.. |matcheslimits| mathdef:: \xref{exec/modules}{match-limits}{\leq}
+.. |matchesexterntype| mathdef:: \xref{valid/types}{match-externtype}{\leq}
+.. |matcheslimits| mathdef:: \xref{valid/types}{match-limits}{\leq}
 
 
 .. Allocation
@@ -1081,7 +1067,7 @@
 .. Values & Results, non-terminals
 
 .. |num| mathdef:: \xref{exec/runtime}{syntax-num}{\X{num}}
-.. |vecc| mathdef:: \xref{exec/runtime}{syntax-vec}{\X{vec}}
+.. |vecc| mathdef:: \xref{exec/runtime}{syntax-vecc}{\X{vec}}
 .. |reff| mathdef:: \xref{exec/runtime}{syntax-ref}{\X{ref}}
 .. |val| mathdef:: \xref{exec/runtime}{syntax-val}{\X{val}}
 .. |result| mathdef:: \xref{exec/runtime}{syntax-result}{\X{result}}
@@ -1144,10 +1130,10 @@
 .. |imins| mathdef:: \xref{exec/numerics}{op-imin_s}{\F{imin\_s}}
 .. |imaxu| mathdef:: \xref{exec/numerics}{op-imax_u}{\F{imax\_u}}
 .. |imaxs| mathdef:: \xref{exec/numerics}{op-imax_s}{\F{imax\_s}}
-.. |iaddsatu| mathdef:: \xref{exec/numerics}{op-iaddsat_u}{\F{iaddsat\_u}}
-.. |iaddsats| mathdef:: \xref{exec/numerics}{op-iaddsat_s}{\F{iaddsat\_s}}
-.. |isubsatu| mathdef:: \xref{exec/numerics}{op-isubsat_u}{\F{isubsat\_u}}
-.. |isubsats| mathdef:: \xref{exec/numerics}{op-isubsat_s}{\F{isubsat\_s}}
+.. |iaddsatu| mathdef:: \xref{exec/numerics}{op-iadd_sat_u}{\F{iadd\_sat\_u}}
+.. |iaddsats| mathdef:: \xref{exec/numerics}{op-iadd_sat_s}{\F{iadd\_sat\_s}}
+.. |isubsatu| mathdef:: \xref{exec/numerics}{op-isub_sat_u}{\F{isub\_sat\_u}}
+.. |isubsats| mathdef:: \xref{exec/numerics}{op-isub_sat_s}{\F{isub\_sat\_s}}
 .. |iavgru| mathdef:: \xref{exec/numerics}{op-iavgr_u}{\F{iavgr\_u}}
 .. |iq15mulrsats| mathdef:: \xref{exec/numerics}{op-iq15mulrsat_s}{\F{iq15mulrsat\_s}}
 
@@ -1223,8 +1209,8 @@
 
 .. |vdashexternval| mathdef:: \xref{exec/modules}{valid-externval}{\vdash}
 
-.. |vdashlimitsmatch| mathdef:: \xref{exec/modules}{match-limits}{\vdash}
-.. |vdashexterntypematch| mathdef:: \xref{exec/modules}{match-externtype}{\vdash}
+.. |vdashlimitsmatch| mathdef:: \xref{valid/types}{match-limits}{\vdash}
+.. |vdashexterntypematch| mathdef:: \xref{valid/types}{match-externtype}{\vdash}
 
 
 .. Soundness
@@ -1234,7 +1220,7 @@
 
 .. |vdashadmininstr| mathdef:: \xref{appendix/properties}{valid-instr-admin}{\vdash}
 
-.. |vdashval| mathdef:: \xref{appendix/properties}{valid-val}{\vdash}
+.. |vdashval| mathdef:: \xref{exec/modules}{valid-val}{\vdash}
 .. |vdashresult| mathdef:: \xref{appendix/properties}{valid-result}{\vdash}
 
 .. |vdashfuncinst| mathdef:: \xref{appendix/properties}{valid-funcinst}{\vdash}


### PR DESCRIPTION
Since neither Sphinx nor MathJax provide any diagnostics for it, this PR adds a simple script to check that all xrefs in the macros.def file are well-defined — and fixes various definitions on the way.