### PR TITLE
Use `node` over `spidermonkey` by default in test/meta/Makefile. NFC

### DIFF
--- a/test/meta/Makefile
+++ b/test/meta/Makefile
@@ -1,10 +1,10 @@
 SHARED_MEM=false
 
 # SpiderMonkey shell
-JSSHELL=~/mozilla-central/js/src/build-debug/dist/bin/js -e 'const WITH_SHARED_MEMORY=$(SHARED_MEM);' -f common.js
+#JSSHELL=~/mozilla-central/js/src/build-debug/dist/bin/js -e 'const WITH_SHARED_MEMORY=$(SHARED_MEM);' -f common.js
 
 # Node.js
-#JSSHELL=./noderun.sh $(SHARED_MEM)
+JSSHELL=./noderun.sh $(SHARED_MEM)
 
 TARGETDIR=../core
 


### PR DESCRIPTION
Honestly I'm not sure it worth maintaining the complexity of supporting anything but node here.