### PR TITLE
Rename data segment expression test message

### DIFF
--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -83,11 +83,11 @@
 
 (assert_invalid
   (module (memory 1) (global i32 (i32.const 0)) (data (global.get 0) "a"))
-  "unknown global"
+  "const expression required"
 )
 (assert_invalid
   (module (memory 1) (global $g i32 (i32.const 0)) (data (global.get $g) "a"))
-  "unknown global"
+  "const expression required"
 )
 
 


### PR DESCRIPTION
Something small that confused me whilst working on validation, the message "unknown global" or generally "unknown x" elsewhere is used for tests where a global/memory/table is missing. This test however seems to be checking that the expression of the data segment is constrained to just const instructions.