### PR TITLE
[spec] Clarify binary element bitfield meaning.

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -360,7 +360,7 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
 
 .. note::
    The initial integer can be interpreted as a bitfield.
-   Bit 0 indicates a passive or declarative segment,
+   Bit 0 distinguishes a passive or declarative segment from an active segment,
    bit 1 indicates the presence of an explicit table index for an active segment and otherwise distinguishes passive from declarative segments,
    bit 2 indicates the use of element type and element :ref:`expressions <binary-expr>` instead of element kind and element indices.
 


### PR DESCRIPTION
In the binary format, when treating the number distinguishing different kinds of element sections as a bitfield, the first bit distinguishes active segements from passive/declarative segments.

The previous phrasing used "indicate" to mean that a 1 bit signifies "passive or declarative", however it is easy to misread this as passive and declarative referring to the two possible values of the bit instead.

This change modifies the description of Bit 0 to make it clearer that it is differentiating active from passive or declarative, not passive from declarative, by using the "distinguishes ... from ..." language used in describing bit 1.