### PR TITLE
chore: fix typos

### DIFF
--- a/document/util/htmldiff.pl
+++ b/document/util/htmldiff.pl
@@ -48,7 +48,7 @@
 # also requires the perl modules Getopt::Std
 #
 # NOTE: The markup created by htmldiff may not validate against the HTML 4.0
-# DTD. This is because the algorithm is realtively simple, and there are
+# DTD. This is because the algorithm is relatively simple, and there are
 # places in the markup content model where the span element is not allowed.
 # Htmldiff is NOT aware of these places.
 #

--- a/proposals/bulk-memory-operations/Overview.md
+++ b/proposals/bulk-memory-operations/Overview.md
@@ -228,7 +228,7 @@ The meaning of the bits of the flag field (a `varuint32`) for element segments i
 | 0   | 0=is active, 1=is passive                        |
 | 1   | if bit 0 clear: 0=table 0, 1=has table index     | 
 |     | if bit 0 set: 0=active, 1=declared               |
-| 2   | 0=carries indicies; 1=carries elemexprs          |
+| 2   | 0=carries indices; 1=carries elemexprs          |
 
 which yields this view, with the fields carried by each flag value:
 
@@ -356,7 +356,7 @@ The bounds check is performed before any data are written.
 
 ### `table.init`, `elem.drop`, and `table.copy` instructions
 
-The `table.*` instructions behave similary to the `memory.*` instructions, with
+The `table.*` instructions behave similarly to the `memory.*` instructions, with
 the difference that they operate on element segments and tables, instead of
 data segments and memories. The offset and length operands of `table.init` and
 `table.copy` have element units instead of bytes as well.

--- a/proposals/multi-value/Overview.md
+++ b/proposals/multi-value/Overview.md
@@ -9,7 +9,7 @@
   - instructions: `value* -> value?`
   - blocks: `[] -> value?`
 
-* In a stack machine, these asymmetries are artifical restrictions
+* In a stack machine, these asymmetries are artificial restrictions
   - were imposed to simplify the initial WebAssembly release (multiple results deferred to post-MVP)
   - can easily be lifted by generalising to value* -> value*
 
@@ -32,7 +32,7 @@
   - loop labels can have arguments
   - can represent phis on backward edges
   - enable future `pick` operator to cross block boundary
-  - macro definability of instructons with inputs
+  - macro definability of instructions with inputs
     * `i32.select3` = `dup if ... else ... end`
 
 

--- a/proposals/reference-types/Overview.md
+++ b/proposals/reference-types/Overview.md
@@ -95,8 +95,8 @@ New/extended instructions:
 * The new instruction `table.fill` fills a range in a table with a value.
   - `table.fill $x : [i32 t i32] -> []`
     - iff `$x : table t`
-  - the first operand is the start index of the range, the third operand its length (analoguous to `memory.fill`)
-  - traps when range+length > size of the table, but only after filling range up to size (analoguous to `memory.fill`)
+  - the first operand is the start index of the range, the third operand its length (analogous to `memory.fill`)
+  - traps when range+length > size of the table, but only after filling range up to size (analogous to `memory.fill`)
 
 * The `table.init` instruction takes an additional table index as immediate.
   - `table.init $x $y : [i32 i32 i32] -> []`

--- a/proposals/simd/SIMD.md
+++ b/proposals/simd/SIMD.md
@@ -18,7 +18,7 @@ packed data in one instruction. These are commonly used to improve performance
 for multimedia applications. The set of SIMD instructions in hardware is large, 
 and varies across different versions of hardware. This proposal is comprised
 of a portable subset of operations that in most cases map to commonly used
-instructions in mordern hardware. 
+instructions in modern hardware. 
 
 
 # Types
@@ -136,14 +136,14 @@ Accessing WebAssembly module imports or exports containing SIMD Type from JavaSc
 
 ### Module Function Imports
 
-Calling an imported function from JavaScript when the function arguments or result is of type v128 will cause the host function to immidiately throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
+Calling an imported function from JavaScript when the function arguments or result is of type v128 will cause the host function to immediately throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 ### Exported Function Exotic Objects
 
-Invoking the [[Call]] method of an Exported Function Exotic Object when the function type of its [[Closure]] has an argument or result of type v128 will cause the host function to immidiately throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
+Invoking the [[Call]] method of an Exported Function Exotic Object when the function type of its [[Closure]] has an argument or result of type v128 will cause the host function to immediately throw a [`TypeError`](https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror).
 
 
-## WebAssembly Module Instatiation
+## WebAssembly Module Instantiation
 
 Instantiating a WebAssembly Module from a Module moduleObject will throw a LinkError exception, when the global's valtype is v128 and the imported objects type is not WebAssembly.Global. 
 

--- a/test/core/float_exprs.wast
+++ b/test/core/float_exprs.wast
@@ -1986,7 +1986,7 @@
 (assert_return (invoke "f64.xkcd_better_sqrt_5" (f64.const 13.0) (f64.const 4.0) (f64.const 0x1.921fb54442d18p+1) (f64.const 24.0)) (f64.const 0x1.1e3778509a5a3p+1))
 
 ;; Compute the floating-point radix.
-;; M. A. Malcom. Algorithms to reveal properties of floating-point arithmetic.
+;; M. A. Malcolm. Algorithms to reveal properties of floating-point arithmetic.
 ;; Communications of the ACM, 15(11):949-951, November 1972.
 (module
   (func (export "f32.compute_radix") (param $0 f32) (param $1 f32) (result f32)

--- a/test/core/simd/simd_load.wast
+++ b/test/core/simd/simd_load.wast
@@ -1,4 +1,4 @@
-;; v128.load operater with normal argument (e.g. (i8x16, i16x8 i32x4))
+;; v128.load operator with normal argument (e.g. (i8x16, i16x8 i32x4))
 
 (module
   (memory 1)
@@ -13,7 +13,7 @@
 (assert_return (invoke "v128.load") (v128.const i32x4 0x03020100 0x07060504 0x0b0a0908 0x0f0e0d0c))
 
 
-;; v128.load operater as the argument of other SIMD instructions
+;; v128.load operator as the argument of other SIMD instructions
 
 (module (memory 1)
   (data (i32.const 0) "\00\01\02\03\04\05\06\07\08\09\0a\0b\0c\0d\0e\0f\00\01\02\03")

--- a/test/core/simd/simd_store.wast
+++ b/test/core/simd/simd_store.wast
@@ -1,4 +1,4 @@
-;; v128.store operater with normal argument (e.g. (i8x16, i16x8, i32x4, f32x4))
+;; v128.store operator with normal argument (e.g. (i8x16, i16x8, i32x4, f32x4))
 
 (module
   (memory 1)

--- a/test/core/utf8-custom-section-id.wast
+++ b/test/core/utf8-custom-section-id.wast
@@ -136,7 +136,7 @@
   "malformed UTF-8 encoding"
 )
 
-;; byte after (first) 2-byte prefix not a contination byte
+;; byte after (first) 2-byte prefix not a continuation byte
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"

--- a/test/core/utf8-import-field.wast
+++ b/test/core/utf8-import-field.wast
@@ -201,7 +201,7 @@
   "malformed UTF-8 encoding"
 )
 
-;; byte after (first) 2-byte prefix not a contination byte
+;; byte after (first) 2-byte prefix not a continuation byte
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"

--- a/test/core/utf8-import-module.wast
+++ b/test/core/utf8-import-module.wast
@@ -201,7 +201,7 @@
   "malformed UTF-8 encoding"
 )
 
-;; byte after (first) 2-byte prefix not a contination byte
+;; byte after (first) 2-byte prefix not a continuation byte
 (assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"


### PR DESCRIPTION
This PR fixes a couple typos (as well as a citation misspelling 👀) that got flagged by automated checks on my own fork.