### PR TITLE
add missing cases in name printing escaping

### DIFF
--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -14,7 +14,9 @@ let nat32 = I32.to_string_u
 let add_hex_char buf c = Printf.bprintf buf "\\%02x" (Char.code c)
 let add_char buf = function
   | '\n' -> Buffer.add_string buf "\\n"
+  | '\r' -> Buffer.add_string buf "\\r"
   | '\t' -> Buffer.add_string buf "\\t"
+  | '\'' -> Buffer.add_string buf "\\'"
   | '\"' -> Buffer.add_string buf "\\\""
   | '\\' -> Buffer.add_string buf "\\\\"
   | c when '\x20' <= c && c < '\x7f' -> Buffer.add_char buf c


### PR DESCRIPTION
According to how names are parsed in `text/lexer.mll`, it looks like some escaping was missing in the text-format printing ?