### PR TITLE
Unset the width of documents in CSS

### DIFF
--- a/document/core/static/custom.css
+++ b/document/core/static/custom.css
@@ -15,10 +15,16 @@ body {
   font-size: 15px;
 }
 
-div.document { width: unset; }
+div.document {
+  width: unset;
+  max-width: 1000px;
+}
 div.bodywrapper { margin: 0 0 0 200px; }
 div.body { padding: 0 10px 0 10px; }
-div.footer { width: unset; }
+div.footer {
+  width: unset;
+  max-width: 1000px;
+}
 
 div.body h1 { font-size: 200%; }
 div.body h2 { font-size: 150%; }

--- a/document/core/static/custom.css
+++ b/document/core/static/custom.css
@@ -15,10 +15,10 @@ body {
   font-size: 15px;
 }
 
-div.document { width: 1000px; }
+div.document { width: unset; }
 div.bodywrapper { margin: 0 0 0 200px; }
 div.body { padding: 0 10px 0 10px; }
-div.footer { width: 1000px; }
+div.footer { width: unset; }
 
 div.body h1 { font-size: 200%; }
 div.body h2 { font-size: 150%; }


### PR DESCRIPTION
This is to allow that the documents of the specification display well on a narrow viewport. On viewports 100px or more wide, it does nothing, and, on viewports less than 1000px wide, it shrinks the document to the width of the viewport.

The issue is discussed here: #1774