### PR TITLE
[test] Add tests ensuring table type is grown in `table.grow`

### DIFF
--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -378,6 +378,26 @@
 (assert_trap (invoke "call" (i32.const 3)) "uninitialized element")
 (assert_trap (invoke "call" (i32.const 100)) "undefined element")
 
+(module $Tgt
+  (table (export "table") 1 funcref) ;; initial size is 1
+  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
+)
+(register "grown-table" $Tgt)
+(assert_return (invoke $Tgt "grow") (i32.const 1)) ;; now size is 2
+(module $Tgit1
+  ;; imported table limits should match, because external table size is 2 now
+  (table (export "table") (import "grown-table" "table") 2 funcref)
+  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
+)
+(register "grown-imported-table" $Tgit1)
+(assert_return (invoke $Tgit1 "grow") (i32.const 2)) ;; now size is 3
+(module $Tgit2
+  ;; imported table limits should match, because external table size is 3 now
+  (import "grown-imported-table" "table" (table 3 funcref))
+  (func (export "size") (result i32) (table.size))
+)
+(assert_return (invoke $Tgit2 "size") (i32.const 3))
+
 
 (module
   (import "spectest" "table" (table 0 funcref))

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -378,27 +378,6 @@
 (assert_trap (invoke "call" (i32.const 3)) "uninitialized element")
 (assert_trap (invoke "call" (i32.const 100)) "undefined element")
 
-(module $Tgt
-  (table (export "table") 1 funcref) ;; initial size is 1
-  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
-)
-(register "grown-table" $Tgt)
-(assert_return (invoke $Tgt "grow") (i32.const 1)) ;; now size is 2
-(module $Tgit1
-  ;; imported table limits should match, because external table size is 2 now
-  (table (export "table") (import "grown-table" "table") 2 funcref)
-  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
-)
-(register "grown-imported-table" $Tgit1)
-(assert_return (invoke $Tgit1 "grow") (i32.const 2)) ;; now size is 3
-(module $Tgit2
-  ;; imported table limits should match, because external table size is 3 now
-  (import "grown-imported-table" "table" (table 3 funcref))
-  (func (export "size") (result i32) (table.size))
-)
-(assert_return (invoke $Tgit2 "size") (i32.const 3))
-
-
 (module
   (import "spectest" "table" (table 0 funcref))
   (import "spectest" "table" (table 0 funcref))
@@ -597,26 +576,6 @@
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
 (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
-
-(module $Mgm
-  (memory (export "memory") 1) ;; initial size is 1
-  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
-)
-(register "grown-memory" $Mgm)
-(assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
-(module $Mgim1
-  ;; imported memory limits should match, because external memory size is 2 now
-  (memory (export "memory") (import "grown-memory" "memory") 2) 
-  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
-)
-(register "grown-imported-memory" $Mgim1)
-(assert_return (invoke $Mgim1 "grow") (i32.const 2)) ;; now size is 3
-(module $Mgim2
-  ;; imported memory limits should match, because external memory size is 3 now
-  (import "grown-imported-memory" "memory" (memory 3))
-  (func (export "size") (result i32) (memory.size))
-)
-(assert_return (invoke $Mgim2 "size") (i32.const 3))
 
 
 ;; Syntax errors

--- a/test/core/memory_grow.wast
+++ b/test/core/memory_grow.wast
@@ -309,6 +309,27 @@
 (assert_return (invoke "as-memory.grow-size") (i32.const 1))
 
 
+(module $Mgm
+  (memory (export "memory") 1) ;; initial size is 1
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-memory" $Mgm)
+(assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
+(module $Mgim1
+  ;; imported memory limits should match, because external memory size is 2 now
+  (memory (export "memory") (import "grown-memory" "memory") 2)
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-imported-memory" $Mgim1)
+(assert_return (invoke $Mgim1 "grow") (i32.const 2)) ;; now size is 3
+(module $Mgim2
+  ;; imported memory limits should match, because external memory size is 3 now
+  (import "grown-imported-memory" "memory" (memory 3))
+  (func (export "size") (result i32) (memory.size))
+)
+(assert_return (invoke $Mgim2 "size") (i32.const 3))
+
+
 (assert_invalid
   (module
     (memory 0)

--- a/test/core/table_grow.wast
+++ b/test/core/table_grow.wast
@@ -108,6 +108,27 @@
 (assert_return (invoke "check-table-null" (i32.const 0) (i32.const 19)) (ref.null func))
 
 
+(module $Tgt
+  (table (export "table") 1 funcref) ;; initial size is 1
+  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
+)
+(register "grown-table" $Tgt)
+(assert_return (invoke $Tgt "grow") (i32.const 1)) ;; now size is 2
+(module $Tgit1
+  ;; imported table limits should match, because external table size is 2 now
+  (table (export "table") (import "grown-table" "table") 2 funcref)
+  (func (export "grow") (result i32) (table.grow (ref.null func) (i32.const 1)))
+)
+(register "grown-imported-table" $Tgit1)
+(assert_return (invoke $Tgit1 "grow") (i32.const 2)) ;; now size is 3
+(module $Tgit2
+  ;; imported table limits should match, because external table size is 3 now
+  (import "grown-imported-table" "table" (table 3 funcref))
+  (func (export "size") (result i32) (table.size))
+)
+(assert_return (invoke $Tgit2 "size") (i32.const 3))
+
+
 ;; Type errors
 
 (assert_invalid


### PR DESCRIPTION
No previous tests check that `table.grow` grows the table instance's type. This was found when implementing LibWasm for the Ladybird browser.