### PR TITLE
Update Makefiles for easier generation of different document status

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Publish all specs to their https://www.w3.org/TR/ URLs
         run: cd document && make -e WD-echidna-CI
         env:
-          STATUS: --md-status=WD
+          W3C_STATUS: WD
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}

--- a/document/Makefile
+++ b/document/Makefile
@@ -28,21 +28,21 @@ diff: $(DIRS:%=diff-%)
 # macOS: do “brew install tar” & run “make” as: TAR=gtar make -e WD-tar
 .PHONY: WD-tar
 WD-tar:
-	for dir in $(DIRS); \
-		do STATUS=--md-status=WD TAR=$(TAR) $(MAKE) -e -C $$dir $@;\
+	for dir in $(DIRS); do \
+		TAR=$(TAR) $(MAKE) -e -C $$dir $@ || exit 1; \
 	done
 
 # macOS: do “brew install tar” & run “make” as: TAR=gtar make -e WD-echidna
 .PHONY: WD-echidna
 WD-echidna:
-	for dir in $(DIRS); \
-		do $(MAKE) -e -C $$dir $@;\
+	for dir in $(DIRS); do \
+		$(MAKE) -e -C $$dir $@ || exit 1; \
 	done
 
 .PHONY: WD-echidna-CI
 WD-echidna-CI:
-	for dir in $(DIRS); \
-		do $(MAKE) -e -C $$dir $@;\
+	for dir in $(DIRS); do \
+		$(MAKE) -e -C $$dir $@ || exit 1; \
 	done
 
 # Directory-specific targets.

--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -2,6 +2,7 @@
 #
 
 # You can set these variables from the command line.
+W3C_STATUS    = ED
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         = a4
@@ -154,7 +155,7 @@ bikeshed: $(GENERATED)
 	@echo
 	@echo =========================================================================
 	mkdir -p $(BUILDDIR)/bikeshed_mathjax/
-	bikeshed spec $(STATUS) index.bs $(BUILDDIR)/bikeshed_mathjax/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/bikeshed_mathjax/index.html
 	mkdir -p $(BUILDDIR)/html/bikeshed/
 	(cd util/katex/ && yarn && yarn build && npm install --only=prod)
 	python3 util/mathjax2katex.py $(BUILDDIR)/bikeshed_mathjax/index.html \
@@ -196,7 +197,7 @@ WD-echidna: WD-tar
 		-F "tar=@$(BUILDDIR)/WD.tar" \
 		-F "decision=$(DECISION_URL)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	@echo
-	@echo "Published working draft. Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: WD-echidna-CI
 WD-echidna-CI: WD-tar
@@ -210,7 +211,7 @@ WD-echidna-CI: WD-tar
 		-F "token=$(W3C_ECHIDNA_TOKEN_CORE)" \
 		-F "decision=$(DECISION_URL)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	@echo
-	@echo "Published working draft. Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: diff
 diff: bikeshed

--- a/document/js-api/Makefile
+++ b/document/js-api/Makefile
@@ -1,3 +1,4 @@
+W3C_STATUS    = ED
 BUILDDIR      = _build
 STATICDIR     = _static
 DOWNLOADDIR   = _download
@@ -8,7 +9,7 @@ TAR           = tar
 .PHONY: all
 all:
 	mkdir -p $(BUILDDIR)/html
-	bikeshed spec index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
 	@echo "Build finished. The HTML pages are in `pwd`/$(BUILDDIR)/html."
 
 .PHONY: publish
@@ -33,7 +34,7 @@ diff: all
 # macOS tar has no “--transform” option (only GNU tar does), so on macOS,
 # do “brew install tar” & run “make” like this: “TAR=gtar make -e WD-tar”
 WD-tar: all
-	bikeshed spec --md-status=WD index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
 	$(TAR) -C $(BUILDDIR)/html --transform="s/index.html/Overview.html/" -cf $(BUILDDIR)/WD.tar index.html
 	@echo "Built $(BUILDDIR)/WD.tar."
 
@@ -62,4 +63,4 @@ WD-echidna-CI: WD-tar
 		-F "token=$(W3C_ECHIDNA_TOKEN_JSAPI)" \
 		-F "decision=$(DECISION_URL)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	@echo
-	@echo "Published working draft. Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Published w$(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"

--- a/document/web-api/Makefile
+++ b/document/web-api/Makefile
@@ -1,3 +1,4 @@
+W3C_STATUS    = ED
 BUILDDIR      = _build
 STATICDIR     = _static
 DOWNLOADDIR   = _download
@@ -8,7 +9,7 @@ TAR           = tar
 .PHONY: all
 all:
 	mkdir -p $(BUILDDIR)/html
-	bikeshed spec index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
 	@echo "Build finished. The HTML pages are in `pwd`/$(BUILDDIR)/html."
 
 .PHONY: publish
@@ -33,7 +34,7 @@ diff: all
 # macOS tar has no “--transform” option (only GNU tar does), so on macOS,
 # do “brew install tar” & run “make” like this: “TAR=gtar make -e WD-tar”
 WD-tar: all
-	bikeshed spec --md-status=WD index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
 	$(TAR) -C $(BUILDDIR)/html --transform="s/index.html/Overview.html/" -cf $(BUILDDIR)/WD.tar index.html
 	@echo "Built $(BUILDDIR)/WD.tar."
 
@@ -62,4 +63,4 @@ WD-echidna-CI: WD-tar
 		-F "token=$(W3C_ECHIDNA_TOKEN_WEBAPI)" \
 		-F "decision=$(DECISION_URL)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	@echo
-	@echo "Published working draft. Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"


### PR DESCRIPTION
This is derived from #1764 but does not actually change the publication status by default locally or on CI (ED is the default, and the w3c echidna publication action overrides it to WD).
It also includes a fix to the echidna Makefile rules to exit with an error in case an underlying step returns an error.