### PR TITLE
Add input for workflow dispatch for W3C publish workflow

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish all specs to their https://www.w3.org/TR/ URLs
         run: cd document && make -e WD-echidna-CI
         env:
-          W3C_STATUS: ${{ github.event_name == 'push' && 'WD'|| inputs.w3c-status }}
+          W3C_STATUS: ${{ github.event_name == 'push' && 'WD' || inputs.w3c-status }}
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}

--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -7,6 +7,10 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      w3c-status:
+        required: true
+        type: string
 
 jobs:
   publish-to-w3c-TR:
@@ -30,7 +34,7 @@ jobs:
       - name: Publish all specs to their https://www.w3.org/TR/ URLs
         run: cd document && make -e WD-echidna-CI
         env:
-          W3C_STATUS: WD
+          W3C_STATUS: ${{ github.event_name == 'push' && 'CRD'|| inputs.w3c-status }}
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}

--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish all specs to their https://www.w3.org/TR/ URLs
         run: cd document && make -e WD-echidna-CI
         env:
-          W3C_STATUS: ${{ github.event_name == 'push' && 'CRD'|| inputs.w3c-status }}
+          W3C_STATUS: ${{ github.event_name == 'push' && 'WD'|| inputs.w3c-status }}
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}


### PR DESCRIPTION
When manually dispatching workflows, inputs can be collected from the dispatching user and passed to the workflow. Use this feature to allow manually setting the W3C_STATE of the document. This will let us publish CR drafts on every push (once we update the default state from WD) and CR snapshots on demand.