### PR TITLE
[js-api] Fix up missing preconditions on allocations

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -51,6 +51,8 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation
+    text: valid memtype; url: valid/types.html#valid-memtype
+    text: valid tabletype; url: valid/types.html#valid-tabletype
     text: module grammar; url: binary/modules.html#binary-module
     text: custom section; url: binary/modules.html#custom-section
     text: customsec; url: binary/modules.html#binary-customsec
@@ -101,6 +103,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: table type; url: syntax/types.html#syntax-tabletype
     text: table address; url: exec/runtime.html#syntax-tableaddr
     text: function address; url: exec/runtime.html#syntax-funcaddr
+    text: memory type; url: syntax/types.html#syntax-memtype
     text: memory address; url: exec/runtime.html#syntax-memaddr
     text: global address; url: exec/runtime.html#syntax-globaladdr
     text: extern address; url: exec/runtime.html#syntax-externaddr
@@ -658,8 +661,8 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     The <dfn constructor for="Memory">Memory(|descriptor|)</dfn> constructor, when invoked, performs the following steps:
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
-    1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
-    1. Let |memtype| be { min |initial|, max |maximum| }.
+    1. Let |memtype| be the [=memory type=] { **min** |initial|, **max** |maximum| }.
+    1. If |memtype| is not [=valid memtype|valid=], throw a {{RangeError}} exception.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
@@ -819,14 +822,14 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
         1. [=Throw=] a {{TypeError}} exception.
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
-    1. If |maximum| is not empty and |maximum| &lt; |initial|, throw a {{RangeError}} exception.
+    1. Let |type| be the [=table type=] { **min** |initial|, **max** |maximum| } |elementType|.
+    1. If |type| is not [=valid tabletype|valid=], throw a {{RangeError}} exception.
     1. If |value| is missing,
         1. Let |ref| be [=DefaultValue=](|elementType|).
     1. Otherwise,
         1. Let |ref| be [=?=] [=ToWebAssemblyValue=](|value|, |elementType|).
-    1. Let |type| be the [=table type=] {[=table type|min=] |initial|, [=table type|max=] |maximum|} |elementType|.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
-    1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). <!-- TODO(littledan): Report allocation failure https://github.com/WebAssembly/spec/issues/584 -->
+    1. Let (|store|, |tableaddr|) be [=table_alloc=](|store|, |type|, |ref|). If allocation fails, throw a {{RangeError}} exception.
     1. Set the [=surrounding agent=]'s [=associated store=] to |store|.
     1. [=initialize a table object|Initialize=] **this** from |tableaddr|.
 </div>

--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -51,6 +51,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation
+    text: valid limits; url: valid/types.html#valid-limits
     text: valid memtype; url: valid/types.html#valid-memtype
     text: valid tabletype; url: valid/types.html#valid-tabletype
     text: module grammar; url: binary/modules.html#binary-module
@@ -100,6 +101,7 @@ urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: df
     text: global_write; url: appendix/embedding.html#embed-global-write
     text: error; url: appendix/embedding.html#embed-error
     text: store; url: exec/runtime.html#syntax-store
+    text: limits; url: syntax/types.html#syntax-limits
     text: table type; url: syntax/types.html#syntax-tabletype
     text: table address; url: exec/runtime.html#syntax-tableaddr
     text: function address; url: exec/runtime.html#syntax-funcaddr
@@ -661,7 +663,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     The <dfn constructor for="Memory">Memory(|descriptor|)</dfn> constructor, when invoked, performs the following steps:
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
-    1. Let |memtype| be the [=memory type=] { **min** |initial|, **max** |maximum| }.
+    1. Let |memtype| be the [=memory type=] { <b>[=limits|min=]</b> |initial|, <b>[=limits|max=]</b> |maximum| }.
     1. If |memtype| is not [=valid memtype|valid=], throw a {{RangeError}} exception.
     1. Let |store| be the [=surrounding agent=]'s [=associated store=].
     1. Let (|store|, |memaddr|) be [=mem_alloc=](|store|, |memtype|). If allocation fails, throw a {{RangeError}} exception.
@@ -822,8 +824,10 @@ Each {{Table}} object has a \[[Table]] internal slot, which is a [=table address
         1. [=Throw=] a {{TypeError}} exception.
     1. Let |initial| be |descriptor|["initial"].
     1. If |descriptor|["maximum"] [=map/exists=], let |maximum| be |descriptor|["maximum"]; otherwise, let |maximum| be empty.
-    1. Let |type| be the [=table type=] { **min** |initial|, **max** |maximum| } |elementType|.
+    1. Let |type| be the [=table type=] { <b>[=limits|min=]</b> |initial|, <b>[=limits|max=]</b> |maximum| } |elementType|.
     1. If |type| is not [=valid tabletype|valid=], throw a {{RangeError}} exception.
+
+        Note: Because tables may have up to 2<sup>32</sup> - 1 elements in validation, the checks for [=limits|min=] ≤ 2<sup>32</sup> - 1 and [=limits|max=] ≤ 2<sup>32</sup> - 1 in [=valid limits|limits validation=] cannot fail.
     1. If |value| is missing,
         1. Let |ref| be [=DefaultValue=](|elementType|).
     1. Otherwise,


### PR DESCRIPTION
Adds explicit steps to run memtype and tabletype validation and throw a RangeError on failure. This explicitly satisfies the preconditions from the wasm embedding spec, and removes the need for the `initial <= maximum` check in the JS API spec.

One other small note: allocation failures on tables are now explicitly reported. This captures implementation limits on table length, which also weren't quite handled by the spec. (This removes a TODO referencing #584.)

Fixes #1792.