### PR TITLE
Generate deadline and pass to bikeshed as metadata

### DIFF
--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -12,7 +12,7 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
-DEADLINE      = $(shell python3 ../deadline.py)
+DEADLINE      = $(shell date -d "+30 days" +%Y-%m-%d 2>/dev/null || date -v +30d +%Y-%m-%d)
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -12,6 +12,7 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
+DEADLINE      = $(shell python3 ../deadline.py)
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -155,7 +156,7 @@ bikeshed: $(GENERATED)
 	@echo
 	@echo =========================================================================
 	mkdir -p $(BUILDDIR)/bikeshed_mathjax/
-	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/bikeshed_mathjax/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) --md-deadline=$(DEADLINE) index.bs $(BUILDDIR)/bikeshed_mathjax/index.html
 	mkdir -p $(BUILDDIR)/html/bikeshed/
 	(cd util/katex/ && yarn && yarn build && npm install --only=prod)
 	python3 util/mathjax2katex.py $(BUILDDIR)/bikeshed_mathjax/index.html \

--- a/document/deadline.py
+++ b/document/deadline.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-import datetime
-
-print(datetime.date.today() + datetime.timedelta(days=30))

--- a/document/deadline.py
+++ b/document/deadline.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+import datetime
+
+print(datetime.date.today() + datetime.timedelta(days=30))

--- a/document/js-api/Makefile
+++ b/document/js-api/Makefile
@@ -5,7 +5,7 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
-DEADLINE      = $(shell python3 ../deadline.py)
+DEADLINE      = $(shell date -d "+30 days" +%Y-%m-%d 2>/dev/null || date -v +30d +%Y-%m-%d)
 
 .PHONY: all
 all:

--- a/document/js-api/Makefile
+++ b/document/js-api/Makefile
@@ -5,11 +5,12 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
+DEADLINE      = $(shell python3 ../deadline.py)
 
 .PHONY: all
 all:
 	mkdir -p $(BUILDDIR)/html
-	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) --md-deadline=$(DEADLINE)  index.bs $(BUILDDIR)/html/index.html
 	@echo "Build finished. The HTML pages are in `pwd`/$(BUILDDIR)/html."
 
 .PHONY: publish
@@ -34,7 +35,7 @@ diff: all
 # macOS tar has no “--transform” option (only GNU tar does), so on macOS,
 # do “brew install tar” & run “make” like this: “TAR=gtar make -e WD-tar”
 WD-tar: all
-	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) --md-deadline=$(DEADLINE) index.bs $(BUILDDIR)/html/index.html
 	$(TAR) -C $(BUILDDIR)/html --transform="s/index.html/Overview.html/" -cf $(BUILDDIR)/WD.tar index.html
 	@echo "Built $(BUILDDIR)/WD.tar."
 
@@ -63,4 +64,4 @@ WD-echidna-CI: WD-tar
 		-F "token=$(W3C_ECHIDNA_TOKEN_JSAPI)" \
 		-F "decision=$(DECISION_URL)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	@echo
-	@echo "Published w$(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"

--- a/document/web-api/Makefile
+++ b/document/web-api/Makefile
@@ -5,7 +5,7 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
-DEADLINE      = $(shell python3 ../deadline.py)
+DEADLINE      = $(shell date -d "+30 days" +%Y-%m-%d 2>/dev/null || date -v +30d +%Y-%m-%d)
 
 .PHONY: all
 all:

--- a/document/web-api/Makefile
+++ b/document/web-api/Makefile
@@ -5,11 +5,12 @@ DOWNLOADDIR   = _download
 NAME          = WebAssembly
 DECISION_URL  = https://github.com/WebAssembly/meetings/blob/main/main/2024/WG-06-12.md
 TAR           = tar
+DEADLINE      = $(shell python3 ../deadline.py)
 
 .PHONY: all
 all:
 	mkdir -p $(BUILDDIR)/html
-	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) --md-deadline=$(DEADLINE) index.bs $(BUILDDIR)/html/index.html
 	@echo "Build finished. The HTML pages are in `pwd`/$(BUILDDIR)/html."
 
 .PHONY: publish
@@ -34,7 +35,7 @@ diff: all
 # macOS tar has no “--transform” option (only GNU tar does), so on macOS,
 # do “brew install tar” & run “make” like this: “TAR=gtar make -e WD-tar”
 WD-tar: all
-	bikeshed spec --md-status=$(W3C_STATUS) index.bs $(BUILDDIR)/html/index.html
+	bikeshed spec --md-status=$(W3C_STATUS) --md-deadline=$(DEADLINE) index.bs $(BUILDDIR)/html/index.html
 	$(TAR) -C $(BUILDDIR)/html --transform="s/index.html/Overview.html/" -cf $(BUILDDIR)/WD.tar index.html
 	@echo "Built $(BUILDDIR)/WD.tar."
 


### PR DESCRIPTION
The Makefiles now generate a date 30 days in the future, and pass this date to bikeshed as 
the standard 'Deadline' metadata.

Along with https://github.com/speced/bikeshed-boilerplate/pull/98, this causes the document
status section to generate with a transition deadline always 30 from the generation time.