### PR TITLE
[interpreter] Implement new instance command

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -440,7 +440,7 @@ module:
   ( module definition <name>? binary ... )   ;; uninstantiated module
 
 instance:
-  ( instance <name>? <name>? )               ;; instantiate latter module to former instance
+  ( module instance <name>? <name>? )        ;; instantiate latter module to former instance
 
 action:
   ( invoke <name>? <string> <const>* )       ;; invoke function export
@@ -551,7 +551,7 @@ module:
   ( module definition <name>? binary ... )   ;; uninstantiated module
 
 instance:
-  ( instance <name>? <name>? )               ;; instantiate latter module to former instance
+  ( module instance <name>? <name>? )        ;; instantiate latter module to former instance
 
 action:
   ( invoke <name>? <string> <const>* )       ;; invoke function export

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -437,7 +437,7 @@ module:
   ...
   ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)
   ( module <name>? quote <string>* )         ;; module quoted in text (may be malformed)
-  ( module definition <name>? ... )          ;; = (module <name>? ...) (instance <name>? <name>?)
+  ( module definition <name>? binary ... )   ;; uninstantiated module
 
 instance:
   ( instance <name>? <name>? )               ;; instantiate latter module to former instance
@@ -548,7 +548,7 @@ cmd:
 
 module:
   ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)
-  ( module definition <name>? binary ... )   ;; = (module <name>? binary ...) (instance <name>? <name>?)
+  ( module definition <name>? binary ... )   ;; uninstantiated module
 
 instance:
   ( instance <name>? <name>? )               ;; instantiate latter module to former instance

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -426,8 +426,9 @@ In order to be able to check and run modules for testing purposes, the S-express
 script: <cmd>*
 
 cmd:
-  <module>                                   ;; define, validate, and initialize module
-  ( register <string> <name>? )              ;; register module for imports
+  <module>                                   ;; define, validate, and possibly instantiate module
+  <instance>
+  ( register <string> <name>? )              ;; register module instance for imports
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
   <meta>                                     ;; meta command
@@ -436,6 +437,10 @@ module:
   ...
   ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)
   ( module <name>? quote <string>* )         ;; module quoted in text (may be malformed)
+  ( module definition <name>? ... )          ;; = (module <name>? ...) (instance <name>? <name>?)
+
+instance:
+  ( instance <name>? <name>? )               ;; instantiate latter module to former instance
 
 action:
   ( invoke <name>? <string> <const>* )       ;; invoke function export
@@ -455,8 +460,8 @@ assertion:
   ( assert_exhaustion <action> <failure> )   ;; assert action exhausts system resources
   ( assert_malformed <module> <failure> )    ;; assert module cannot be decoded with given failure string
   ( assert_invalid <module> <failure> )      ;; assert module is invalid with given failure string
-  ( assert_unlinkable <module> <failure> )   ;; assert module fails to link
-  ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
+  ( assert_unlinkable <instance> <failure> ) ;; assert module fails to link
+  ( assert_trap <instance> <failure> )       ;; assert module traps on instantiation
 
 result_pat:
   ( <num_type>.const <num_pat> )
@@ -485,6 +490,11 @@ The script format supports additional syntax for defining modules.
 A module of the form `(module binary <string>*)` is given in binary form and will be decoded from the (concatenation of the) strings.
 A module of the form `(module quote <string>*)` is given in textual form and will be parsed from the (concatenation of the) strings. In both cases, decoding/parsing happens when the command is executed, not when the script is parsed, so that meta commands like `assert_malformed` can be used to check expected errors.
 
+Usually, a module declaration implicitly instantiates the module,
+that is, it defines both a module and an instance (of the same name).
+Instantiation can be suppressed by adding the keyword `definition`.
+A module declared as a definition only can then be instantiated explicitly, and multiple times, using the separate form `(module instance <inst_var> <module_name>)`.
+
 There are also a number of meta commands.
 The `script` command is a simple mechanism to name sub-scripts themselves. This is mainly useful for converting scripts with the `output` command. Commands inside a `script` will be executed normally, but nested meta are expanded in place (`input`, recursively) or elided (`output`) in the named script.
 
@@ -492,6 +502,7 @@ The `input` and `output` meta commands determine the requested file format from 
 
 The interpreter supports a "dry" mode (flag `-d`), in which modules are only validated. In this mode, all actions and assertions are ignored.
 It also supports an "unchecked" mode (flag `-u`), in which module definitions are not validated before use.
+In that mode, execution may fail with a "crash" error message.
 
 
 ### Spectest host module
@@ -537,6 +548,10 @@ cmd:
 
 module:
   ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)
+  ( module definition <name>? binary ... )   ;; = (module <name>? binary ...) (instance <name>? <name>?)
+
+instance:
+  ( instance <name>? <name>? )               ;; instantiate latter module to former instance
 
 action:
   ( invoke <name>? <string> <const>* )       ;; invoke function export
@@ -549,8 +564,8 @@ assertion:
   ( assert_exhaustion <action> <failure> )   ;; assert action exhausts system resources
   ( assert_malformed <module> <failure> )    ;; assert module cannot be decoded with given failure string
   ( assert_invalid <module> <failure> )      ;; assert module is invalid with given failure string
-  ( assert_unlinkable <module> <failure> )   ;; assert module fails to link
-  ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
+  ( assert_unlinkable <instance> <failure> ) ;; assert module fails to link
+  ( assert_trap <instance> <failure> )       ;; assert module traps on instantiation
 
 result_pat:
   ( <num_type>.const <num_pat> )

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -68,8 +68,8 @@ function module(bytes, valid = true) {
   return new WebAssembly.Module(buffer);
 }
 
-function instance(bytes, imports = registry) {
-  return new WebAssembly.Instance(module(bytes), imports);
+function instance(mod, imports = registry) {
+  return new WebAssembly.Instance(mod, imports);
 }
 
 function call(instance, name, args) {
@@ -111,16 +111,14 @@ function assert_invalid_custom(bytes) {
   return;
 }
 
-function assert_unlinkable(bytes) {
-  let mod = module(bytes);
+function assert_unlinkable(mod) {
   try { new WebAssembly.Instance(mod, registry) } catch (e) {
     if (e instanceof WebAssembly.LinkError) return;
   }
   throw new Error("Wasm linking failure expected");
 }
 
-function assert_uninstantiable(bytes) {
-  let mod = module(bytes);
+function assert_uninstantiable(mod) {
   try { new WebAssembly.Instance(mod, registry) } catch (e) {
     if (e instanceof WebAssembly.RuntimeError) return;
   }
@@ -216,35 +214,63 @@ module NameMap = Map.Make(struct type t = Ast.name let compare = compare end)
 module Map = Map.Make(String)
 
 type exports = extern_type NameMap.t
-type modules = {mutable env : exports Map.t; mutable current : int}
+type env =
+  { mutable mods : exports Map.t;
+    mutable insts : exports Map.t;
+    mutable current_mod : int;
+    mutable current_inst : int;
+  }
 
 let exports m : exports =
   let ModuleT (_, ets) = module_type_of m in
   List.fold_left (fun map (ExportT (et, name)) -> NameMap.add name et map)
     NameMap.empty ets
 
-let modules () : modules = {env = Map.empty; current = 0}
+let env () : env =
+  { mods = Map.empty;
+    insts = Map.empty;
+    current_mod = 0;
+    current_inst = 0;
+  }
 
-let current_var (mods : modules) = "$" ^ string_of_int mods.current
-let of_var_opt (mods : modules) = function
-  | None -> current_var mods
+let current_mod (env : env) = "$$" ^ string_of_int env.current_mod
+let of_mod_opt (env : env) = function
+  | None -> current_mod env
   | Some x -> x.it
 
-let bind (mods : modules) x_opt m =
-  let exports = exports m in
-  mods.current <- mods.current + 1;
-  mods.env <- Map.add (of_var_opt mods x_opt) exports mods.env;
-  if x_opt <> None then mods.env <- Map.add (current_var mods) exports mods.env
+let current_inst (env : env) = "$" ^ string_of_int env.current_inst
+let of_inst_opt (env : env) = function
+  | None -> current_inst env
+  | Some x -> x.it
 
-let lookup (mods : modules) x_opt name at =
-  let exports =
-    try Map.find (of_var_opt mods x_opt) mods.env with Not_found ->
-      raise (Eval.Crash (at, 
-        if x_opt = None then "no module defined within script"
-        else "unknown module " ^ of_var_opt mods x_opt ^ " within script"))
-  in try NameMap.find name exports with Not_found ->
+let bind_mod (env : env) x_opt m =
+  let exports = exports m in
+  env.current_mod <- env.current_mod + 1;
+  env.mods <- Map.add (of_mod_opt env x_opt) exports env.mods;
+  if x_opt <> None then env.mods <- Map.add (current_mod env) exports env.mods
+
+let bind_inst (env : env) x_opt exports =
+  env.current_inst <- env.current_inst + 1;
+  env.insts <- Map.add (of_inst_opt env x_opt) exports env.insts;
+  if x_opt <> None then env.insts <- Map.add (current_inst env) exports env.insts
+
+let find_mod (env : env) x_opt at =
+  try Map.find (of_mod_opt env x_opt) env.mods with Not_found ->
+    raise (Eval.Crash (at,
+      if x_opt = None then "no module defined within script"
+      else "unknown module " ^ of_mod_opt env x_opt ^ " within script"))
+
+let find_inst (env : env) x_opt at =
+  try Map.find (of_inst_opt env x_opt) env.insts with Not_found ->
+    raise (Eval.Crash (at,
+      if x_opt = None then "no module instance defined within script"
+      else "unknown module instance " ^ of_inst_opt env x_opt ^ " within script"))
+
+let lookup_export (env : env) x_opt name at =
+  let exports = find_inst env x_opt at in
+  try NameMap.find name exports with Not_found ->
     raise (Eval.Crash (at, "unknown export \"" ^
-      string_of_name name ^ "\" within module"))
+      string_of_name name ^ "\" within module isntance"))
 
 
 (* Wrappers *)
@@ -573,37 +599,40 @@ let rec of_definition def =
     try of_definition (snd (Parse.Module.parse_string ~offset:s.at s.it))
     with Parse.Syntax _ | Custom.Syntax _ -> of_bytes "<malformed quote>"
 
-let of_wrapper mods x_opt name wrap_action wrap_assertion at =
-  let x = of_var_opt mods x_opt in
+let of_instance env x_opt =
+  "instance(" ^ of_mod_opt env x_opt ^ ")"
+
+let of_wrapper env x_opt name wrap_action wrap_assertion at =
+  let x = of_inst_opt env x_opt in
   let bs = wrap name wrap_action wrap_assertion at in
-  "call(instance(" ^ of_bytes bs ^ ", " ^
+  "call(instance(module(" ^ of_bytes bs ^ "), " ^
     "exports(" ^ x ^ ")), " ^ " \"run\", [])"
 
-let of_action mods act =
+let of_action env act =
   match act.it with
   | Invoke (x_opt, name, vs) ->
-    "call(" ^ of_var_opt mods x_opt ^ ", " ^ of_name name ^ ", " ^
+    "call(" ^ of_inst_opt env x_opt ^ ", " ^ of_name name ^ ", " ^
       "[" ^ String.concat ", " (List.map of_value vs) ^ "])",
-    (match lookup mods x_opt name act.at with
+    (match lookup_export env x_opt name act.at with
     | ExternFuncT dt ->
       let FuncT (_, out) as ft = as_func_str_type (expand_def_type dt) in
       if is_js_func_type ft then
         None
       else
-        Some (of_wrapper mods x_opt name (invoke ft vs), out)
+        Some (of_wrapper env x_opt name (invoke ft vs), out)
     | _ -> None
     )
   | Get (x_opt, name) ->
-    "get(" ^ of_var_opt mods x_opt ^ ", " ^ of_name name ^ ")",
-    (match lookup mods x_opt name act.at with
+    "get(" ^ of_inst_opt env x_opt ^ ", " ^ of_name name ^ ")",
+    (match lookup_export env x_opt name act.at with
     | ExternGlobalT gt when not (is_js_global_type gt) ->
       let GlobalT (_, t) = gt in
-      Some (of_wrapper mods x_opt name (get gt), [t])
+      Some (of_wrapper env x_opt name (get gt), [t])
     | _ -> None
     )
 
-let of_assertion' mods act name args wrapper_opt =
-  let act_js, act_wrapper_opt = of_action mods act in
+let of_assertion' env act name args wrapper_opt =
+  let act_js, act_wrapper_opt = of_action env act in
   let js = name ^ "(() => " ^ act_js ^ String.concat ", " ("" :: args) ^ ")" in
   match act_wrapper_opt with
   | None -> js ^ ";"
@@ -614,7 +643,7 @@ let of_assertion' mods act name args wrapper_opt =
       | Some wrapper -> "run", wrapper
     in run_name ^ "(() => " ^ act_wrapper (wrapper out) act.at ^ ");  // " ^ js
 
-let of_assertion mods ass =
+let of_assertion env ass =
   match ass.it with
   | AssertMalformed (def, _) ->
     "assert_malformed(" ^ of_definition def ^ ");"
@@ -624,21 +653,21 @@ let of_assertion mods ass =
     "assert_invalid(" ^ of_definition def ^ ");"
   | AssertInvalidCustom (def, _) ->
     "assert_invalid_custom(" ^ of_definition def ^ ");"
-  | AssertUnlinkable (def, _) ->
-    "assert_unlinkable(" ^ of_definition def ^ ");"
-  | AssertUninstantiable (def, _) ->
-    "assert_uninstantiable(" ^ of_definition def ^ ");"
+  | AssertUnlinkable (x_opt, _) ->
+    "assert_unlinkable(" ^ of_instance env x_opt ^ ");"
+  | AssertUninstantiable (x_opt, _) ->
+    "assert_uninstantiable(" ^ of_instance env x_opt ^ ");"
   | AssertReturn (act, ress) ->
-    of_assertion' mods act "assert_return" (List.map of_result ress)
+    of_assertion' env act "assert_return" (List.map of_result ress)
       (Some (assert_return ress))
   | AssertTrap (act, _) ->
-    of_assertion' mods act "assert_trap" [] None
+    of_assertion' env act "assert_trap" [] None
   | AssertExhaustion (act, _) ->
-    of_assertion' mods act "assert_exhaustion" [] None
+    of_assertion' env act "assert_exhaustion" [] None
   | AssertException act ->
-    of_assertion' mods act "assert_exception" [] None
+    of_assertion' env act "assert_exception" [] None
 
-let of_command mods cmd =
+let of_command env cmd =
   "\n// " ^ Filename.basename cmd.at.left.file ^
     ":" ^ string_of_int cmd.at.left.line ^ "\n" ^
   match cmd.it with
@@ -649,18 +678,24 @@ let of_command mods cmd =
       | Encoded (name, bs) -> Decode.decode name bs.it
       | Quoted (_, s) ->
         unquote (snd (Parse.Module.parse_string ~offset:s.at s.it))
-    in bind mods x_opt (unquote def);
-    "let " ^ current_var mods ^ " = instance(" ^ of_definition def ^ ");\n" ^
+    in bind_mod env x_opt (unquote def);
+    "let " ^ current_mod env ^ " = " ^ of_definition def ^ ";\n" ^
     (if x_opt = None then "" else
-    "let " ^ of_var_opt mods x_opt ^ " = " ^ current_var mods ^ ";\n")
+    "let " ^ of_mod_opt env x_opt ^ " = " ^ current_mod env ^ ";\n")
+  | Instance (x1_opt, x2_opt) ->
+    let exports = find_mod env x2_opt cmd.at in
+    bind_inst env x1_opt exports;
+    "let " ^ current_inst env ^ " = instance(" ^ of_mod_opt env x2_opt ^ ");\n" ^
+    (if x1_opt = None then "" else
+    "let " ^ of_inst_opt env x1_opt ^ " = " ^ current_inst env ^ ";\n")
   | Register (name, x_opt) ->
-    "register(" ^ of_name name ^ ", " ^ of_var_opt mods x_opt ^ ")\n"
+    "register(" ^ of_name name ^ ", " ^ of_inst_opt env x_opt ^ ")\n"
   | Action act ->
-    of_assertion' mods act "run" [] None ^ "\n"
+    of_assertion' env act "run" [] None ^ "\n"
   | Assertion ass ->
-    of_assertion mods ass ^ "\n"
+    of_assertion env ass ^ "\n"
   | Meta _ -> assert false
 
 let of_script scr =
   (if !Flags.harness then harness else "") ^
-  String.concat "" (List.map (of_command (modules ())) scr)
+  String.concat "" (List.map (of_command (env ())) scr)

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -308,7 +308,7 @@ let lookup category map x_opt at =
 
 let lookup_script = lookup "script" scripts
 let lookup_module = lookup "module" modules
-let lookup_instance = lookup "module" instances
+let lookup_instance = lookup "module instance" instances
 
 let lookup_registry module_name item_name _t =
   match Instance.export (Map.find module_name !registry) item_name with
@@ -474,9 +474,9 @@ let run_assertion ass =
     | _ -> Assert.error ass.at "expected custom validation error"
     )
 
-  | AssertUnlinkable (def, re) ->
+  | AssertUnlinkable (x_opt, re) ->
     trace "Asserting unlinkable...";
-    let m, cs = run_definition def in
+    let m, cs = lookup_module x_opt ass.at in
     if not !Flags.unchecked then Valid.check_module_with_custom (m, cs);
     (match
       let imports = Import.link m in
@@ -487,9 +487,9 @@ let run_assertion ass =
     | _ -> Assert.error ass.at "expected linking error"
     )
 
-  | AssertUninstantiable (def, re) ->
+  | AssertUninstantiable (x_opt, re) ->
     trace "Asserting trap...";
-    let m, cs = run_definition def in
+    let m, cs = lookup_module x_opt ass.at in
     if not !Flags.unchecked then Valid.check_module_with_custom (m, cs);
     (match
       let imports = Import.link m in
@@ -542,12 +542,16 @@ let rec run_command cmd =
       end
     end;
     bind "module" modules x_opt (m, cs);
-    bind "script" scripts x_opt [cmd];
+    bind "script" scripts x_opt [cmd]
+
+  | Instance (x1_opt, x2_opt) ->
+    quote := cmd :: !quote;
+    let m, cs = lookup_module x2_opt cmd.at in
     if not !Flags.dry then begin
       trace "Initializing...";
       let imports = Import.link m in
       let inst = Eval.init m imports in
-      bind "instance" instances x_opt inst
+      bind "instance" instances x1_opt inst
     end
 
   | Register (name, x_opt) ->

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -44,8 +44,8 @@ and assertion' =
   | AssertMalformedCustom of definition * string
   | AssertInvalid of definition * string
   | AssertInvalidCustom of definition * string
-  | AssertUnlinkable of definition * string
-  | AssertUninstantiable of definition * string
+  | AssertUnlinkable of var option * string
+  | AssertUninstantiable of var option * string
   | AssertReturn of action * result list
   | AssertException of action
   | AssertTrap of action * string
@@ -54,6 +54,7 @@ and assertion' =
 type command = command' Source.phrase
 and command' =
   | Module of var option * definition
+  | Instance of var option * var option
   | Register of Ast.name * var option
   | Action of action
   | Assertion of assertion

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -735,21 +735,25 @@ let custom m mnode (module S : Custom.Section) =
   S.Handler.arrange m mnode S.it
 
 
+let var x =
+  if String.for_all (fun c -> Lib.Char.is_alphanum_ascii c || c = '_') x.it then
+    "$" ^ x.it
+  else
+    "$" ^ name (Utf8.decode x.it)
+
 let var_opt = function
   | None -> ""
-  | Some x when
-    String.for_all (fun c -> Lib.Char.is_alphanum_ascii c || c = '_') x.it ->
-    " $" ^ x.it
-  | Some x -> " $" ^ name (Utf8.decode x.it)
+  | Some x -> " " ^ var x
 
-let module_with_var_opt x_opt (m, cs) =
+let module_with_var_opt isdef x_opt (m, cs) =
   let fx = ref 0 in
   let tx = ref 0 in
   let mx = ref 0 in
   let tgx = ref 0 in
   let gx = ref 0 in
   let imports = list (import fx tx mx tgx gx) m.it.imports in
-  let ret = Node ("module" ^ var_opt x_opt,
+  let head = if isdef then "module definition" else "module" in
+  let ret = Node (head ^ var_opt x_opt,
     List.rev (fst (List.fold_left type_ ([], 0) m.it.types)) @
     imports @
     listi (table !tx) m.it.tables @
@@ -765,13 +769,15 @@ let module_with_var_opt x_opt (m, cs) =
   List.fold_left (custom m) ret cs
 
 
-let binary_module_with_var_opt x_opt bs =
-  Node ("module" ^ var_opt x_opt ^ " binary", break_bytes bs)
+let binary_module_with_var_opt isdef x_opt bs =
+  let head = if isdef then "module definition" else "module" in
+  Node (head ^ var_opt x_opt ^ " binary", break_bytes bs)
 
-let quoted_module_with_var_opt x_opt s =
-  Node ("module" ^ var_opt x_opt ^ " quote", break_string s)
+let quoted_module_with_var_opt isdef x_opt s =
+  let head = if isdef then "module definition" else "module" in
+  Node (head ^ var_opt x_opt ^ " quote", break_string s)
 
-let module_with_custom = module_with_var_opt None
+let module_with_custom = module_with_var_opt false None
 let module_ m = module_with_custom (m, [])
 
 
@@ -792,7 +798,7 @@ let literal mode lit =
   | Vec v -> Node (vec_constop v ^ " " ^ vec mode v, [])
   | Ref r -> ref_ r
 
-let definition mode x_opt def =
+let definition mode isdef x_opt def =
   try
     match mode with
     | `Textual ->
@@ -802,7 +808,7 @@ let definition mode x_opt def =
         | Encoded (name, bs) -> Decode.decode_with_custom name bs.it
         | Quoted (_, s) ->
           unquote (snd (Parse.Module.parse_string ~offset:s.at s.it))
-      in module_with_var_opt x_opt (unquote def)
+      in module_with_var_opt isdef x_opt (unquote def)
     | `Binary ->
       let rec unquote def =
         match def.it with
@@ -811,14 +817,14 @@ let definition mode x_opt def =
           Encode.encode_with_custom (Decode.decode_with_custom name bs.it)
         | Quoted (_, s) ->
           unquote (snd (Parse.Module.parse_string ~offset:s.at s.it))
-      in binary_module_with_var_opt x_opt (unquote def)
+      in binary_module_with_var_opt isdef x_opt (unquote def)
     | `Original ->
       match def.it with
-      | Textual (m, cs) -> module_with_var_opt x_opt (m, cs)
-      | Encoded (_, bs) -> binary_module_with_var_opt x_opt bs.it
-      | Quoted (_, s) -> quoted_module_with_var_opt x_opt s.it
+      | Textual (m, cs) -> module_with_var_opt isdef x_opt (m, cs)
+      | Encoded (_, bs) -> binary_module_with_var_opt isdef x_opt bs.it
+      | Quoted (_, s) -> quoted_module_with_var_opt isdef x_opt s.it
   with Parse.Syntax _ ->
-    quoted_module_with_var_opt x_opt "<invalid module>"
+    quoted_module_with_var_opt isdef x_opt "<invalid module>"
 
 let access x_opt n =
   String.concat " " [var_opt x_opt; name n]
@@ -869,28 +875,31 @@ let result mode res =
   | VecResult vp -> vec_pat mode vp
   | RefResult rp -> ref_pat rp
 
+let instance (x1_opt, x2_opt) =
+  Node ("module instance" ^ var_opt x1_opt ^ var_opt x2_opt, [])
+
 let assertion mode ass =
   match ass.it with
   | AssertMalformed (def, re) ->
     (match mode, def.it with
     | `Binary, Quoted _ -> []
     | _ ->
-      [Node ("assert_malformed", [definition `Original None def; Atom (string re)])]
+      [Node ("assert_malformed", [definition `Original false None def; Atom (string re)])]
     )
   | AssertMalformedCustom (def, re) ->
     (match mode, def.it with
     | `Binary, Quoted _ -> []
     | _ ->
-      [Node ("assert_malformed_custom", [definition `Original None def; Atom (string re)])]
+      [Node ("assert_malformed_custom", [definition `Original false None def; Atom (string re)])]
     )
   | AssertInvalid (def, re) ->
-    [Node ("assert_invalid", [definition mode None def; Atom (string re)])]
+    [Node ("assert_invalid", [definition mode false None def; Atom (string re)])]
   | AssertInvalidCustom (def, re) ->
-    [Node ("assert_invalid_custom", [definition mode None def; Atom (string re)])]
-  | AssertUnlinkable (def, re) ->
-    [Node ("assert_unlinkable", [definition mode None def; Atom (string re)])]
-  | AssertUninstantiable (def, re) ->
-    [Node ("assert_trap", [definition mode None def; Atom (string re)])]
+    [Node ("assert_invalid_custom", [definition mode false None def; Atom (string re)])]
+  | AssertUnlinkable (x_opt, re) ->
+    [Node ("assert_unlinkable", [instance (None, x_opt); Atom (string re)])]
+  | AssertUninstantiable (x_opt, re) ->
+    [Node ("assert_trap", [instance (None, x_opt); Atom (string re)])]
   | AssertReturn (act, results) ->
     [Node ("assert_return", action mode act :: List.map (result mode) results)]
   | AssertTrap (act, re) ->
@@ -902,7 +911,8 @@ let assertion mode ass =
 
 let command mode cmd =
   match cmd.it with
-  | Module (x_opt, def) -> [definition mode x_opt def]
+  | Module (x_opt, def) -> [definition mode true x_opt def]
+  | Instance (x1_opt, x2_opt) -> [instance (x1_opt, x2_opt)]
   | Register (n, x_opt) -> [Node ("register " ^ name n ^ var_opt x_opt, [])]
   | Action act -> [action mode act]
   | Assertion ass -> assertion mode ass

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -763,6 +763,8 @@ rule token = parse
       | "module" -> MODULE
       | "binary" -> BIN
       | "quote" -> QUOTE
+      | "definition" -> DEFINITION
+      | "instance" -> INSTANCE
 
       | "script" -> SCRIPT
       | "register" -> REGISTER

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -10,6 +10,8 @@ open Script
 
 let error at msg = raise (Parse_error.Syntax (at, msg))
 
+let thd (_, _, x) = x
+
 
 (* Position handling *)
 
@@ -333,7 +335,7 @@ let parse_annots (m : module_) : Custom.section list =
 %token<int -> Ast.instr'> VEC_EXTRACT VEC_REPLACE
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY TAG DATA DECLARE OFFSET ITEM IMPORT EXPORT
-%token MODULE BIN QUOTE
+%token MODULE BIN QUOTE DEFINITION INSTANCE
 %token SCRIPT REGISTER INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXCEPTION ASSERT_EXHAUSTION
@@ -1415,49 +1417,82 @@ inline_module1 :  /* Sugar */
 script_var :
   | VAR { var $1 $sloc }  /* Sugar */
 
+instance_var :
+  | VAR { var $1 $sloc }  /* Sugar */
+
+definition_opt :
+  | DEFINITION { true }
+  | /* empty */ { false }
+
 script_module :
-  | module_ { $1 }
-  | LPAR MODULE option(module_var) BIN string_list RPAR
-    { let s = $5 @@ $loc($5) in
-      $3, Encoded ("binary:" ^ string_of_pos (at $sloc).left, s) @@ $sloc }
-  | LPAR MODULE option(module_var) QUOTE string_list RPAR
-    { let s = $5 @@ $loc($5) in
-      $3, Quoted ("quote:" ^ string_of_pos (at $sloc).left, s) @@ $sloc }
+  | LPAR MODULE definition_opt option(module_var) module_fields RPAR
+    { let m = $5 (empty_context ()) () () @@ $sloc in
+      $3, $4, Textual (m, parse_annots m) @@ $sloc }
+  | LPAR MODULE definition_opt option(module_var) BIN string_list RPAR
+    { let s = $6 @@ $loc($5) in
+      $3, $4, Encoded ("binary:" ^ string_of_pos (at $sloc).left, s) @@ $sloc }
+  | LPAR MODULE definition_opt option(module_var) QUOTE string_list RPAR
+    { let s = $6 @@ $loc($5) in
+      $3, $4, Quoted ("quote:" ^ string_of_pos (at $sloc).left, s) @@ $sloc }
+
+script_instance :
+  | instance { [], $1 }
+  | script_module  /* sugar */
+    { let isdef, var_opt, m = $1 in
+      if isdef then error (at $sloc) "misplaced module definition";
+      [Module (None, m) @@ $sloc], (var_opt, None) }
+
+instance :
+  | LPAR MODULE INSTANCE instance_var module_var RPAR
+    { Some $4, Some $5 }
+  | LPAR MODULE INSTANCE module_var RPAR
+    { None, Some $4 }
+  | LPAR MODULE INSTANCE RPAR
+    { None, None }
 
 action :
-  | LPAR INVOKE option(module_var) name list(literal) RPAR
+  | LPAR INVOKE option(instance_var) name list(literal) RPAR
     { Invoke ($3, $4, $5) @@ $sloc }
-  | LPAR GET option(module_var) name RPAR
+  | LPAR GET option(instance_var) name RPAR
     { Get ($3, $4) @@ $sloc }
 
 assertion :
   | LPAR ASSERT_MALFORMED script_module STRING RPAR
-    { AssertMalformed (snd $3, $4) @@ $sloc }
+    { [], AssertMalformed (thd $3, $4) @@ $sloc }
   | LPAR ASSERT_INVALID script_module STRING RPAR
-    { AssertInvalid (snd $3, $4) @@ $sloc }
+    { [], AssertInvalid (thd $3, $4) @@ $sloc }
   | LPAR ASSERT_MALFORMED_CUSTOM script_module STRING RPAR
-    { AssertMalformedCustom (snd $3, $4) @@ $sloc }
+    { [], AssertMalformedCustom (thd $3, $4) @@ $sloc }
   | LPAR ASSERT_INVALID_CUSTOM script_module STRING RPAR
-    { AssertInvalidCustom (snd $3, $4) @@ $sloc }
-  | LPAR ASSERT_UNLINKABLE script_module STRING RPAR
-    { AssertUnlinkable (snd $3, $4) @@ $sloc }
-  | LPAR ASSERT_TRAP script_module STRING RPAR
-    { AssertUninstantiable (snd $3, $4) @@ $sloc }
-  | LPAR ASSERT_RETURN action list(result) RPAR { AssertReturn ($3, $4) @@ $sloc }
+    { [], AssertInvalidCustom (thd $3, $4) @@ $sloc }
+  | LPAR ASSERT_UNLINKABLE script_instance STRING RPAR
+    { fst $3, AssertUnlinkable (snd (snd $3), $4) @@ $sloc }
+  | LPAR ASSERT_TRAP script_instance STRING RPAR
+    { fst $3, AssertUninstantiable (snd (snd $3), $4) @@ $sloc }
+  | LPAR ASSERT_RETURN action list(result) RPAR
+    { [], AssertReturn ($3, $4) @@ $sloc }
   | LPAR ASSERT_EXCEPTION action RPAR
-    { AssertException $3 @@ $sloc }
-  | LPAR ASSERT_TRAP action STRING RPAR { AssertTrap ($3, $4) @@ $sloc }
-  | LPAR ASSERT_EXHAUSTION action STRING RPAR { AssertExhaustion ($3, $4) @@ $sloc }
+    { [], AssertException $3 @@ $sloc }
+  | LPAR ASSERT_TRAP action STRING RPAR
+    { [], AssertTrap ($3, $4) @@ $sloc }
+  | LPAR ASSERT_EXHAUSTION action STRING RPAR
+    { [], AssertExhaustion ($3, $4) @@ $sloc }
 
 cmd :
-  | action { Action $1 @@ $sloc }
-  | assertion { Assertion $1 @@ $sloc }
-  | script_module { Module (fst $1, snd $1) @@ $sloc }
-  | LPAR REGISTER name option(module_var) RPAR { Register ($3, $4) @@ $sloc }
-  | meta { Meta $1 @@ $sloc }
+  | action { [Action $1 @@ $sloc] }
+  | assertion { fst $1 @ [Assertion (snd $1) @@ $sloc] }
+  | script_module
+    { let isdef, var_opt, m = $1 in
+      if isdef then
+        [Module (var_opt, m) @@ $sloc]
+      else (* sugar *)
+        [Module (var_opt, m) @@ $sloc; Instance (var_opt, var_opt) @@ $sloc] }
+  | instance { [Instance (fst $1, snd $1) @@ $sloc] }
+  | LPAR REGISTER name option(instance_var) RPAR { [Register ($3, $4) @@ $sloc] }
+  | meta { [Meta $1 @@ $sloc] }
 
 meta :
-  | LPAR SCRIPT option(script_var) list(cmd) RPAR { Script ($3, $4) @@ $sloc }
+  | LPAR SCRIPT option(script_var) list(cmd) RPAR { Script ($3, List.concat $4) @@ $sloc }
   | LPAR INPUT option(script_var) STRING RPAR { Input ($3, $4) @@ $sloc }
   | LPAR OUTPUT option(script_var) STRING RPAR { Output ($3, Some $4) @@ $sloc }
   | LPAR OUTPUT option(script_var) RPAR { Output ($3, None) @@ $sloc }
@@ -1502,11 +1537,11 @@ result :
         (Value.V128 ($3, List.map (fun lit -> lit $3) $4))) @@ $sloc }
 
 script :
-  | list(cmd) EOF { $1 }
+  | list(cmd) EOF { List.concat $1 }
   | inline_module1 EOF { [Module (None, $1) @@ $sloc] }  /* Sugar */
 
 script1 :
-  | cmd { [$1] }
+  | cmd { $1 }
 
 module1 :
   | module_ EOF { $1 }

--- a/test/core/instance.wast
+++ b/test/core/instance.wast
@@ -1,0 +1,170 @@
+;; Instantiation is generative
+
+(module definition $M
+  (global (export "glob") (mut i32) (i32.const 0))
+  (table (export "tab") 10 funcref (ref.null func))
+  (memory (export "mem") 1)
+  (tag (export "tag"))
+)
+
+(module instance $I1 $M)
+(module instance $I2 $M)
+(register "I1" $I1)
+(register "I2" $I2)
+
+(module
+  (import "I1" "glob" (global $glob1 (mut i32)))
+  (import "I2" "glob" (global $glob2 (mut i32)))
+  (import "I1" "tab" (table $tab1 10 funcref))
+  (import "I2" "tab" (table $tab2 10 funcref))
+  (import "I1" "mem" (memory $mem1 1))
+  (import "I2" "mem" (memory $mem2 1))
+  (import "I1" "tag" (tag $tag1))
+  (import "I2" "tag" (tag $tag2))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+  (func (export "tag") (result i32)
+    (block $on_tag1
+      (block $on_other
+        (try_table (catch $tag1 $on_tag1) (catch_all $on_other)
+          (throw $tag2)
+        )
+        (unreachable)
+      )
+      (return (i32.const 0))
+    )
+    (return (i32.const 1))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 0))
+(assert_return (invoke "tab") (ref.null))
+(assert_return (invoke "mem") (i32.const 0))
+(assert_return (invoke "tag") (i32.const 0))
+
+
+;; Import is not generative
+
+(module
+  (import "I1" "glob" (global $glob1 (mut i32)))
+  (import "I1" "glob" (global $glob2 (mut i32)))
+  (import "I1" "tab" (table $tab1 10 funcref))
+  (import "I1" "tab" (table $tab2 10 funcref))
+  (import "I1" "mem" (memory $mem1 1))
+  (import "I1" "mem" (memory $mem2 1))
+  (import "I1" "tag" (tag $tag1))
+  (import "I1" "tag" (tag $tag2))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+  (func (export "tag") (result i32)
+    (block $on_tag1
+      (block $on_other
+        (try_table (catch $tag1 $on_tag1) (catch_all $on_other)
+          (throw $tag2)
+        )
+        (unreachable)
+      )
+      (return (i32.const 0))
+    )
+    (return (i32.const 1))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 1))
+(assert_return (invoke "tab") (ref.func))
+(assert_return (invoke "mem") (i32.const 1))
+(assert_return (invoke "tag") (i32.const 1))
+
+
+;; Export is not generative
+
+(module definition $N
+  (global $glob (mut i32) (i32.const 0))
+  (table $tab 10 funcref (ref.null func))
+  (memory $mem 1)
+  (tag $tag)
+
+  (export "glob1" (global $glob))
+  (export "glob2" (global $glob))
+  (export "tab1" (table $tab))
+  (export "tab2" (table $tab))
+  (export "mem1" (memory $mem))
+  (export "mem2" (memory $mem))
+  (export "tag1" (tag $tag))
+  (export "tag2" (tag $tag))
+)
+
+(module instance $I $N)
+(register "I" $I)
+
+(module
+  (import "I" "glob1" (global $glob1 (mut i32)))
+  (import "I" "glob2" (global $glob2 (mut i32)))
+  (import "I" "tab1" (table $tab1 10 funcref))
+  (import "I" "tab2" (table $tab2 10 funcref))
+  (import "I" "mem1" (memory $mem1 1))
+  (import "I" "mem2" (memory $mem2 1))
+  (import "I" "tag1" (tag $tag1))
+  (import "I" "tag2" (tag $tag2))
+
+  (func $f)
+  (elem declare func $f)
+
+  (func (export "glob") (result i32)
+    (global.set $glob1 (i32.const 1))
+    (global.get $glob2)
+  )
+  (func (export "tab") (result funcref)
+    (table.set $tab1 (i32.const 0) (ref.func $f))
+    (table.get $tab2 (i32.const 0))
+  )
+  (func (export "mem") (result i32)
+    (i32.store $mem1 (i32.const 0) (i32.const 1))
+    (i32.load $mem2 (i32.const 0))
+  )
+  (func (export "tag") (result i32)
+    (block $on_tag1
+      (block $on_other
+        (try_table (catch $tag1 $on_tag1) (catch_all $on_other)
+          (throw $tag2)
+        )
+        (unreachable)
+      )
+      (return (i32.const 0))
+    )
+    (return (i32.const 1))
+  )
+)
+
+(assert_return (invoke "glob") (i32.const 1))
+(assert_return (invoke "tab") (ref.func))
+(assert_return (invoke "mem") (i32.const 1))
+(assert_return (invoke "tag") (i32.const 1))


### PR DESCRIPTION
This PR extends the .wast script language such that definition and instantiation of a module can be separated. It makes the following extensions:

* Module declarations may be marked with the `definition` keyword, which suppresses automatic instantiation.
* A new command `(module instance <inst-name> <mod-name>)` allows explicit instantiation of such modules. 
* The assertions `assert_unlinkable` and `assert_trap` now accept an instance command as argument.

The previous forms of module declaration and assertions are still available, but now treated as a short-hand for a module definition followed by an instantiation or assertion.
 
For example:
```
(module definition $M ...)
(module instance $A $M)
(module instance $B $M)
(assert_trap (module instance $M) "message")
```
Module names and instance names are considered separate name spaces. However, named module declarations not marked as definitions introduce both a module and an instance of the same name.