### PR TITLE
Update W3C TR build from WD to CRD

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish all specs to their https://www.w3.org/TR/ URLs
         run: cd document && make -e WD-echidna-CI
         env:
-          W3C_STATUS: ${{ github.event_name == 'push' && 'WD' || inputs.w3c-status }}
+          W3C_STATUS: ${{ github.event_name == 'push' && 'CRD' || inputs.w3c-status }}
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}


### PR DESCRIPTION
This will cause the default build of the W3C/echidna build pipeline (used on each
push) to use the  Candidate Recommendation Draft mode.
CR snapshots or any other document mode can still be selected when
running the workflow manually via the website, CLI or GH API.