### PR TITLE
Test data count without data segment

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -469,6 +469,28 @@
     "\01\00")                     ;; Passive data section
   "data count and data section have inconsistent lengths")
 
+;; Data count section without data segment section
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section: 1 type
+    "\03\02\01\00"             ;; Function section: 1 function
+    "\05\03\01\00\01"          ;; Memory section: 1 memory
+    "\08\01\00"                ;; Start section: function 0
+    "\0c\01\01"                ;; Data Count section: 1 segment
+    "\0a\0e\01"                ;; Code section: 1 function
+
+    ;; function 0
+    "\0c\00"
+    "\41\00"                   ;; i32.const 0
+    "\41\00"                   ;; i32.const 0
+    "\41\00"                   ;; i32.const 0
+    "\fc\08\00\00"             ;; memory.init dataidx=0 memidx=0
+    "\0b"                      ;; end
+  )
+  "data count and data section have inconsistent lengths"
+)
+
 ;; memory.init requires a datacount section
 (assert_malformed
   (module binary

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -496,3 +496,26 @@
    )
    "constant expression required"
 )
+
+;; Data count without data segment
+
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section: 1 type
+    "\03\02\01\00"             ;; Function section: 1 function
+    "\05\03\01\00\01"          ;; Memory section: 1 memory
+    "\08\01\00"                ;; Start section: function 0
+    "\0c\01\01"                ;; Data Count section: 1 segment
+    "\0a\0e\01"                ;; Code section: 1 function
+
+    ;; function 0
+    "\0c\00"
+    "\41\00"                   ;; i32.const 0
+    "\41\00"                   ;; i32.const 0
+    "\41\00"                   ;; i32.const 0
+    "\fc\08\00\00"             ;; memory.init dataidx=0 memidx=0
+    "\0b"                      ;; end
+  )
+  ""
+)

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -499,7 +499,7 @@
 
 ;; Data count without data segment
 
-(assert_invalid
+(assert_malformed
   (module binary
     "\00asm" "\01\00\00\00"
     "\01\04\01\60\00\00"       ;; Type section: 1 type
@@ -517,5 +517,5 @@
     "\fc\08\00\00"             ;; memory.init dataidx=0 memidx=0
     "\0b"                      ;; end
   )
-  ""
+  "data count and data section have inconsistent lengths"
 )

--- a/test/core/data.wast
+++ b/test/core/data.wast
@@ -496,26 +496,3 @@
    )
    "constant expression required"
 )
-
-;; Data count without data segment
-
-(assert_malformed
-  (module binary
-    "\00asm" "\01\00\00\00"
-    "\01\04\01\60\00\00"       ;; Type section: 1 type
-    "\03\02\01\00"             ;; Function section: 1 function
-    "\05\03\01\00\01"          ;; Memory section: 1 memory
-    "\08\01\00"                ;; Start section: function 0
-    "\0c\01\01"                ;; Data Count section: 1 segment
-    "\0a\0e\01"                ;; Code section: 1 function
-
-    ;; function 0
-    "\0c\00"
-    "\41\00"                   ;; i32.const 0
-    "\41\00"                   ;; i32.const 0
-    "\41\00"                   ;; i32.const 0
-    "\fc\08\00\00"             ;; memory.init dataidx=0 memidx=0
-    "\0b"                      ;; end
-  )
-  "data count and data section have inconsistent lengths"
-)


### PR DESCRIPTION
It's a little more verbose than it needs to be due to originally being minified from a wabt exploit.