### PR TITLE
Update document status input for W3C publishing to a choice value

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -5,7 +5,12 @@ on:
     branches: [ main ]
     paths: [ .github/**, document/** ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab, gh CLI tool,
+  # or REST API. THe w3c-status options correspond to the valid options for
+  # Bikeshed's --md-status flag, and refer to the W3C rec-track document
+  # stages described in https://www.w3.org/policies/process/#maturity-stages
+  # (Editor's Draft, Working Draft, Candidiate Recommendation Draft, and
+  # Candidate Recommendation Snapshot).
   workflow_dispatch:
     inputs:
       w3c-status:

--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -10,7 +10,13 @@ on:
     inputs:
       w3c-status:
         required: true
-        type: string
+        type: choice
+        description: W3C Document Status
+        options:
+          - ED
+          - WD
+          - CRD
+          - CR
 
 jobs:
   publish-to-w3c-TR:


### PR DESCRIPTION
The w3c-status options correspond to the valid options for
Bikeshed's --md-status flag (i.e. Status metadata, https://speced.github.io/bikeshed/#metadata),
and refer to the W3C rec-track document
stages described in https://www.w3.org/policies/process/#maturity-stages
(Editor's Draft, Working Draft, Candidiate Recommendation Draft, and
Candidate Recommendation Snapshot).