### PR TITLE
build.py: generate JS/HTML wrappers for tests in subdirectories

### DIFF
--- a/test/build.py
+++ b/test/build.py
@@ -152,8 +152,15 @@ def build_html_js(out_dir):
 
 def build_html_from_js(tests, html_dir, use_sync):
     for js_file in tests:
+        subdir = os.path.basename(os.path.dirname(js_file))
+       # if subdir == 'js':
+       #     subdir = ''
+       # else:
+       #     FIXME: ensure_empty_dir needs to happen before all of this
+       #     ensure_empty_dir(os.path.join(html_dir, subdir))
         js_filename = os.path.basename(js_file)
         html_filename = js_filename + '.html'
+        #html_file = os.path.join(html_dir, subdir, html_filename)
         html_file = os.path.join(html_dir, html_filename)
         js_harness = "sync_index.js" if use_sync else "async_index.js"
         with open(html_file, 'w+') as f:

--- a/test/build.py
+++ b/test/build.py
@@ -119,9 +119,9 @@ HTML_HEADER = """<!doctype html>
     </head>
     <body>
 
-        <script src={WPT_PREFIX}/testharness.js></script>
-        <script src={WPT_PREFIX}/testharnessreport.js></script>
-        <script src={PREFIX}/{JS_HARNESS}></script>
+        <script src="{WPT_PREFIX}/testharness.js"></script>
+        <script src="{WPT_PREFIX}/testharnessreport.js"></script>
+        <script src="{PREFIX}/{JS_HARNESS}"></script>
 
         <div id=log></div>
 """
@@ -169,7 +169,7 @@ def build_html_from_js(tests, html_dir, use_sync):
             content = HTML_HEADER.replace('{PREFIX}', harness_dir) \
                                  .replace('{WPT_PREFIX}', harness_dir) \
                                  .replace('{JS_HARNESS}', js_harness)
-            content += "        <script src={SCRIPT}></script>".replace('{SCRIPT}', js_filename)
+            content += '        <script src="' + js_filename + '"></script>'
             content += HTML_BOTTOM
             f.write(content)
 

--- a/test/build.py
+++ b/test/build.py
@@ -67,13 +67,19 @@ def convert_wast_to_js(out_js_dir):
 
     inputs = []
 
-    for wast_file in glob.glob(os.path.join(WAST_TESTS_DIR, '*.wast')):
+    for wast_file in glob.glob(os.path.join(WAST_TESTS_DIR, '**/*.wast'),
+                               recursive = True):
         # Don't try to compile tests that are supposed to fail.
         if '.fail.' in wast_file:
             continue
 
+        js_subdir = os.path.basename(os.path.dirname(wast_file))
+        if js_subdir == 'core':
+            js_subdir = ''
+        else:
+            ensure_empty_dir(os.path.join(out_js_dir, js_subdir))
         js_filename = os.path.basename(wast_file) + '.js'
-        js_file = os.path.join(out_js_dir, js_filename)
+        js_file = os.path.join(out_js_dir, js_subdir, js_filename)
         inputs.append((wast_file, js_file))
 
     pool = mp.Pool(processes=8)

--- a/test/build.py
+++ b/test/build.py
@@ -16,7 +16,6 @@ WAST_TESTS_DIR = os.path.join(SCRIPT_DIR, 'core')
 WAST_TEST_SUBDIRS = [os.path.basename(d) for d in
                      filter(os.path.isdir,
                             glob.glob(os.path.join(WAST_TESTS_DIR, '*')))]
-print('ADAMK: WAST_TEST_SUBDIRS =', WAST_TEST_SUBDIRS)
 HARNESS_DIR = os.path.join(SCRIPT_DIR, 'harness')
 
 HARNESS_FILES = ['testharness.js', 'testharnessreport.js', 'testharness.css']
@@ -157,19 +156,20 @@ def build_html_js(out_dir):
 def build_html_from_js(tests, html_dir, use_sync):
     for js_file in tests:
         subdir = os.path.basename(os.path.dirname(js_file))
+        js_prefix = '../js'
         if subdir == 'js':
             subdir = ''
-        print('ADAMK: subdir = ', subdir)
-        js_filename = os.path.basename(js_file)
-        html_filename = js_filename + '.html'
+            js_prefix = './js'
+        js_filename = os.path.join(js_prefix, subdir, os.path.basename(js_file))
+        html_filename = os.path.basename(js_file) + '.html'
         html_file = os.path.join(html_dir, subdir, html_filename)
-        #html_file = os.path.join(html_dir, html_filename)
         js_harness = "sync_index.js" if use_sync else "async_index.js"
+        harness_dir = os.path.join(js_prefix, 'harness')
         with open(html_file, 'w+') as f:
-            content = HTML_HEADER.replace('{PREFIX}', './js/harness') \
-                                 .replace('{WPT_PREFIX}', './js/harness') \
+            content = HTML_HEADER.replace('{PREFIX}', harness_dir) \
+                                 .replace('{WPT_PREFIX}', harness_dir) \
                                  .replace('{JS_HARNESS}', js_harness)
-            content += "        <script src=./js/{SCRIPT}></script>".replace('{SCRIPT}', js_filename)
+            content += "        <script src={SCRIPT}></script>".replace('{SCRIPT}', js_filename)
             content += HTML_BOTTOM
             f.write(content)
 


### PR DESCRIPTION
Fixes #1687 