### PR TITLE
wasm-module-builder: Fix left-over use of kWasmStmt

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -934,7 +934,7 @@ class WasmModuleBuilder {
 
   addTable(type, initial_size, max_size = undefined, init_expr = undefined) {
     if (type == kWasmI32 || type == kWasmI64 || type == kWasmF32 ||
-        type == kWasmF64 || type == kWasmS128 || type == kWasmStmt) {
+        type == kWasmF64 || type == kWasmS128 || type == kWasmVoid) {
       throw new Error('Tables must be of a reference type');
     }
     if (init_expr != undefined) checkExpr(init_expr);


### PR DESCRIPTION
This was renamed to kWasmVoid in
https://github.com/WebAssembly/spec/commit/2f5a7c524fdc4dec280c6a53bc3cc800b6ad1c11.