### PR TITLE
Add introduction sections to JS API and Web API documents

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -48,6 +48,8 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMASCRIPT
         text: ℤ; url: #ℤ
         text: SameValue; url: sec-samevalue
 urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
+    text: embedding interface; url: appending/embedding.html
+    text: scope; url: intro/introduction.html#scope
     url: valid/modules.html#valid-module
         text: valid
         text: WebAssembly module validation
@@ -174,7 +176,16 @@ emu-const {
 }
 </style>
 
-This API provides a way to access WebAssembly [[WEBASSEMBLY]] through a bridge to explicitly construct modules from JavaScript [[ECMASCRIPT]].
+<h2 id="intro">Introduction</h2>
+
+By design, the [=scope=] of the WebAssembly [[WEBASSEMBLY]] core specification does not include a description of how WebAssembly programs interact
+with their surrounding execution environment. Instead it defines an abstract [=embedding interface=] between WebAssembly and its environment,
+(called the *embedder*). It is only through this interface that an embedder interacts with the semantics of WebAssembly, and the embedder
+implements the connection between its host environment and the embedding API.
+This document describes the embedding of WebAssembly into JavaScript [[ECMASCRIPT]] environments, including how WebAssembly modules
+can be constructed and instantiated, how imported and exported functions are called, how data is exchanged, and how errors are handled.
+When the JavaScript environment is itself embedded in a Web browser, the Web API spec describes additional behavior relevant to the Web environment.
+
 
 <h2 id="sample">Sample API Usage</h2>
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -76,7 +76,11 @@ spec:fetch; type:dfn; text:get
 spec:webidl; type:dfn; text:resolve
 </pre>
 
+
+<h2 id="intro">Introduction</h2>
 This document builds off of the WebAssembly specification [[WEBASSEMBLY]] and the WebAssembly JavaScript embedding [[WASMJS]].
+It describes the integration of WebAssembly into the broader Web platform, for example with
+additional APIs that are implemented by Web user agents but are outside the scope of JavaScript [[ECMA-262]] itself.
 
 <h2 id="streaming-modules">Streaming Module Compilation and Instantiation</h2>
 


### PR DESCRIPTION
These sections provide a bit more background about their relationship to the layer beneath them.
They also solve the problem that the existing minimal introductory text was hidden in the
bottom of the "status of this document" section.