### PR TITLE
[ci] Use build matrix to run W3C spec builds independently

### DIFF
--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -31,6 +31,10 @@ env:
 
 jobs:
   publish-to-w3c-TR:
+    strategy:
+      fail-fast: false
+      matrix:
+        spec: [core, js-api, web-api]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -44,20 +48,22 @@ jobs:
       - name: Setup Bikeshed
         run: pip install bikeshed && bikeshed update
       - name: Setup TexLive
+        if: ${{ matrix.spec == 'core' }}
         run: sudo apt-get update -y && sudo apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
       - name: Setup Sphinx
+        if: ${{ matrix.spec == 'core' }}
         run: pip install six && pip install sphinx==5.1.0
-      - name: Publish all specs to their https://www.w3.org/TR/ URLs
+      - name: Publish ${{ matrix.spec }} spec to its https://www.w3.org/TR/ URL
         if: env.W3C_ECHIDNA_TOKEN_CORE
-        run: cd document && make -e WD-echidna-CI
+        run: cd document && make -e -C ${{ matrix.spec }} WD-echidna-CI
         env:
           W3C_ECHIDNA_TOKEN_CORE: ${{ secrets.W3C_ECHIDNA_TOKEN_CORE }}
           W3C_ECHIDNA_TOKEN_JSAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_JSAPI }}
           W3C_ECHIDNA_TOKEN_WEBAPI: ${{ secrets.W3C_ECHIDNA_TOKEN_WEBAPI }}
           ECHIDNA_DRYRUN: ${{ !(github.event_name == 'push' && github.repository == 'WebAssembly/spec' && github.ref == 'refs/heads/main') }}
-      - name: Validate all specs with Echidna
+      - name: Validate ${{ matrix.spec }} spec with Echidna
         if: env.W3C_USERNAME
-        run: cd document && make -e WD-echidna
+        run: cd document && make -e -C ${{ matrix.spec }} WD-echidna
         env:
           W3C_USERNAME: ${{ secrets.W3C_USERNAME }}
           W3C_PASSWORD: ${{ secrets.W3C_PASSWORD }}

--- a/document/core/Makefile
+++ b/document/core/Makefile
@@ -201,7 +201,7 @@ WD-echidna: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: WD-echidna-CI
 WD-echidna-CI: WD-tar
@@ -217,7 +217,7 @@ WD-echidna-CI: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: diff
 diff: bikeshed

--- a/document/js-api/Makefile
+++ b/document/js-api/Makefile
@@ -54,7 +54,7 @@ WD-echidna: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: WD-echidna-CI
 WD-echidna-CI: WD-tar
@@ -70,4 +70,4 @@ WD-echidna-CI: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"

--- a/document/web-api/Makefile
+++ b/document/web-api/Makefile
@@ -54,7 +54,7 @@ WD-echidna: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
 
 .PHONY: WD-echidna-CI
 WD-echidna-CI: WD-tar
@@ -70,4 +70,4 @@ WD-echidna-CI: WD-tar
 		-F "dry-run=$(ECHIDNA_DRYRUN)" | tee $(BUILDDIR)/WD-echidna-id.txt
 	python3 ../util/check-echidna-status.py $(BUILDDIR)
 	@echo
-	@echo "Published $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"
+	@echo "Uploaded $(W3C_STATUS). Check its status at https://labs.w3.org/echidna/api/status?id=`cat $(BUILDDIR)/WD-echidna-id.txt`"


### PR DESCRIPTION
This ensures that all 3 specs build and upload even if one fails. Also use 'uploaded' in the status text instead of 'published' to reflect possible dry run or validation failure.