### PR TITLE
Escape latex newline commands with extra vertical space

### DIFF
--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -87,6 +87,9 @@ def Main():
                 r'\1',
                 data, flags=re.DOTALL)
 
+  # Escape some latex sequences that Bikeshed interprets as macros
+  data = data.replace(r' \\[1ex]', r' \&#x5c;\[1ex]')
+
   sys.stdout.write(data)
 
 Main()


### PR DESCRIPTION
Fix a sequence that Bikeshed is treating as a macro and rewriting.

This is a workaround for #1823 