### PR TITLE
Fix wasm-module-builder.js

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -966,7 +966,7 @@ class WasmModuleBuilder {
     }
     let type_index = (typeof type) == "number" ? type : this.addType(type);
     this.imports.push({module: module, name: name, kind: kExternalFunction,
-                       type: type_index});
+                       type_index: type_index});
     return this.num_imported_funcs++;
   }
 


### PR DESCRIPTION
Rename the function import property from `type` to `type_index` to match the use site (l.1166):

```JS

if (imp.kind == kExternalFunction) {
  section.emit_u32v(imp.type_index);
}
```