### PR TITLE
Dont expect indices in validation messages either

### DIFF
--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -219,7 +219,7 @@
 (assert_trap (invoke "init" (i32.const 2) (i32.const 0) (i32.const 2))
     "out of bounds table access")
 (assert_trap (invoke "call" (i32.const 2))
-    "uninitialized element 2")
+    "uninitialized element")
 
 (invoke "init" (i32.const 0) (i32.const 1) (i32.const 2))
 (assert_return (invoke "call" (i32.const 0)) (i32.const 1))


### PR DESCRIPTION
Similar to https://github.com/WebAssembly/spec/pull/1076, don't include index numbers in expected error messages
 from validation.