### PR TITLE
Fix mobile margin

### DIFF
--- a/document/core/static/custom.css
+++ b/document/core/static/custom.css
@@ -82,3 +82,9 @@ div.sphinxsidebar a {
 div.sphinxsidebar a:hover {
   border-bottom: 1px dotted;
 }
+
+@media screen and (max-width: 875px) {
+    div.bodywrapper {
+        margin: 0;
+    }
+}


### PR DESCRIPTION
At the moment mobile version of site looks broken. It seems that custom.css overrides alabaster.css, which had good mobile media query.
<img width="376" alt="image" src="https://github.com/user-attachments/assets/491d3637-5efe-41db-9ef2-a008f4852cf1">
This minimal change makes spec readable on mobiles.