### PR TITLE
Update references to IEEE 754-2008.

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1213,7 +1213,7 @@ The algorithm <dfn>ToWebAssemblyValue</dfn>(|v|, |type|) coerces a JavaScript va
         1. Let |n| be an implementation-defined integer such that [=canon=]<sub>32</sub> ≤ |n| < 2<sup>[=signif=](32)</sup>.
         1. Let |f32| be [=nan=](n).
     1. Otherwise,
-        1. Let |f32| be |number| rounded to the nearest representable value using IEEE 754-2008 round to nearest, ties to even mode. [[IEEE-754]]
+        1. Let |f32| be |number| rounded to the nearest representable value using IEEE 754-2019 round to nearest, ties to even mode. [[IEEE-754]]
     1. Return [=f32.const=] |f32|.
 1. If |type| is [=f64=],
     1. Let |number| be [=?=] [$ToNumber$](|v|).

--- a/test/core/float_exprs.wast
+++ b/test/core/float_exprs.wast
@@ -35,7 +35,7 @@
 (assert_return (invoke "f64.no_fma" (f64.const 0x1.7e2c44058a799p+52) (f64.const 0x1.c73b71765b8b2p+685) (f64.const -0x1.16c641df0b108p+690)) (f64.const 0x1.53ccb53de0bd1p+738))
 
 ;; Test that x+0.0 is not folded to x.
-;; See IEEE 754-2008 10.4 "Literal meaning and value-changing optimizations".
+;; See IEEE 754-2019 10.4 "Literal meaning and value-changing optimizations".
 
 (module
   (func (export "f32.no_fold_add_zero") (param $x f32) (result f32)
@@ -94,7 +94,7 @@
 (assert_return (invoke "f64.no_fold_mul_zero" (f64.const nan:0x4000000000000)) (f64.const nan:arithmetic))
 
 ;; Test that x*1.0 is not folded to x.
-;; See IEEE 754-2008 10.4 "Literal meaning and value-changing optimizations".
+;; See IEEE 754-2019 10.4 "Literal meaning and value-changing optimizations".
 
 (module
   (func (export "f32.no_fold_mul_one") (param $x f32) (result f32)


### PR DESCRIPTION
Update them to refer to IEEE 754-2019. I've confirmed that the relevant section names and numbers in 754-2019 are the same.