### PR TITLE
Use WPT version of test harness for HTML core test conversion

### DIFF
--- a/test/build.py
+++ b/test/build.py
@@ -165,9 +165,10 @@ def build_html_from_js(tests, html_dir, use_sync):
         html_file = os.path.join(html_dir, subdir, html_filename)
         js_harness = "sync_index.js" if use_sync else "async_index.js"
         harness_dir = os.path.join(js_prefix, 'harness')
+
         with open(html_file, 'w+') as f:
             content = HTML_HEADER.replace('{PREFIX}', harness_dir) \
-                                 .replace('{WPT_PREFIX}', harness_dir) \
+                                 .replace('{WPT_PREFIX}', '/resources') \
                                  .replace('{JS_HARNESS}', js_harness)
             content += '        <script src="' + js_filename + '"></script>'
             content += HTML_BOTTOM


### PR DESCRIPTION
When converting tests to HTML for use in WPT, use the path to
the test harness in WPT's resources/ directory. This is also
important because the WPT test runner users this path inclusion
to discover the tests.

There are several more things I want to simplify here but I'm
starting with just this because it matches the sed transform
that @past originally wrote in
https://github.com/web-platform-tests/wpt/pull/49277
