### PR TITLE
Fix Bikeshed fixup to properly balance section elements

### DIFF
--- a/document/core/util/bikeshed_fixup.py
+++ b/document/core/util/bikeshed_fixup.py
@@ -63,7 +63,7 @@ def Main():
   # get carried over into the resulting bikeshed output and then end up causing
   # the W3C pubrules checker to refuse to autopublish that bikeshed output.
   data = re.sub(r'.+?(<div class="toctree-wrapper compound">.+)',
-                r'<!doctype HTML>\n<meta charset="utf-8">\n<body>\1',
+                r'<!doctype HTML>\n<meta charset="utf-8">\n<body><section id="webassembly-specification">\1',
                 data, flags=re.DOTALL)
 
   # Drop spurious navigation from footer.


### PR DESCRIPTION
This regex removes all the leading content up to the div containing the "Introduction" heading, but this content includes an opening `<section>` tag that wraps all of the front matter. The updated version of Bikeshed is throwing errors because of the unbalanced closing tag.
Fix this by adding the opening tag back.