### PR TITLE
[spec] Fixed incorrect description of fge operation

### DIFF
--- a/document/core/exec/numerics.rst
+++ b/document/core/exec/numerics.rst
@@ -1663,7 +1663,7 @@ This non-deterministic result is expressed by the following auxiliary function p
 
 * Else if both :math:`z_1` and :math:`z_2` are zeroes, then return :math:`1`.
 
-* Else if :math:`z_1` is smaller than or equal to :math:`z_2`, then return :math:`1`.
+* Else if :math:`z_1` is larger than or equal to :math:`z_2`, then return :math:`1`.
 
 * Else return :math:`0`.
 


### PR DESCRIPTION
Corrected the explanation of `z1 >= z2` to accurately reflect its meaning.