### PR TITLE
Fix wrong result type

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -1802,7 +1802,7 @@ Memory Instructions
 
 * The lane index :math:`\laneidx` must be smaller than :math:`128/N`.
 
-* Then the instruction is valid with type :math:`[\X{at}~\V128] \to [\V128]`.
+* Then the instruction is valid with type :math:`[\X{at}~\V128] \to []`.
 
 .. math::
    \frac{


### PR DESCRIPTION
<img width="790" alt="Screenshot 2025-02-25 at 1 37 26 PM" src="https://github.com/user-attachments/assets/761af915-f6ec-417d-b35f-6139c145291e" />

I noticed that the result type of store lane in the prose appears to be incorrect.
I have corrected this.