### PR TITLE
return_call +indirect with multi-param / multi-result / imported funcs

### DIFF
--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -1,6 +1,8 @@
 ;; Test `return_call` operator
 
 (module
+  (import "spectest" "print_i32_f32" (func $print_i32_f32 (param i32 f32)))
+
   ;; Auxiliary definitions
   (func $const-i32 (result i32) (i32.const 0x132))
   (func $const-i64 (result i64) (i64.const 0x164))
@@ -75,6 +77,20 @@
       (else (return_call $even (i64.sub (local.get 0) (i64.const 1))))
     )
   )
+
+  ;; Functions with multiple parameters / multiple results
+  (func (export "tailprint_i32_f32") (param i32 f32)
+    (return_call $print_i32_f32 (local.get 0) (local.get 1))
+  )
+
+  (func $swizzle (param f64 i64) (result i32 f32)
+    (i32.wrap_i64 (local.get 1))
+    (f32.demote_f64 (local.get 0))
+  )
+
+  (func (export "type-f64-i64-to-i32-f32") (param f64 i64) (result i32 f32)
+    (return_call $swizzle (local.get 0) (local.get 1))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -116,7 +132,8 @@
 (assert_return (invoke "odd" (i64.const 77)) (i32.const 44))
 (assert_return (invoke "odd" (i64.const 1_000_000)) (i32.const 99))
 (assert_return (invoke "odd" (i64.const 999_999)) (i32.const 44))
-
+(assert_return (invoke "tailprint_i32_f32" (i32.const 5) (f32.const 91.0)))
+(assert_return (invoke "type-f64-i64-to-i32-f32" (f64.const 4.2) (i64.const 99)) (i32.const 99) (f32.const 4.2))
 
 ;; Invalid typing
 


### PR DESCRIPTION
Moving https://github.com/WebAssembly/tail-call/pull/25 here.

This PR adds tests of return_call and return_call indirect where:

    the function being called is an imported function
    the function being called takes multiple params
    the function being called has multiple results

These catch a bug in the WABT interpreter and two bugs in wasm2c (one of which was reported at https://github.com/WebAssembly/wabt/pull/2491).