### PR TITLE
[spec] Add missing subtype rule for exn

### DIFF
--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -76,6 +76,8 @@ A :ref:`heap type <syntax-heaptype>` :math:`\heaptype_1` matches a :ref:`heap ty
 
 * Or :math:`\heaptype_1` is :math:`\NOFUNC` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\FUNC`.
 
+* Or :math:`\heaptype_1` is :math:`\NOEXN` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\EXN`.
+
 * Or :math:`\heaptype_1` is :math:`\NOEXTERN` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\EXTERN`.
 
 * Or :math:`\heaptype_1` is :math:`\BOTH`.
@@ -165,6 +167,12 @@ A :ref:`heap type <syntax-heaptype>` :math:`\heaptype_1` matches a :ref:`heap ty
      C \vdashheaptypematch \X{ht} \matchesheaptype \FUNC
    }{
      C \vdashheaptypematch \NOFUNC \matchesheaptype \X{ht}
+   }
+   \qquad
+   \frac{
+     C \vdashheaptypematch \X{ht} \matchesheaptype \EXN
+   }{
+     C \vdashheaptypematch \NOEXN \matchesheaptype \X{ht}
    }
    \qquad
    \frac{

--- a/document/core/valid/matching.rst
+++ b/document/core/valid/matching.rst
@@ -76,9 +76,9 @@ A :ref:`heap type <syntax-heaptype>` :math:`\heaptype_1` matches a :ref:`heap ty
 
 * Or :math:`\heaptype_1` is :math:`\NOFUNC` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\FUNC`.
 
-* Or :math:`\heaptype_1` is :math:`\NOEXN` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\EXN`.
+* Or :math:`\heaptype_1` is :math:`\NOEXN` and :math:`\heaptype_2` is :math:`\EXN`.
 
-* Or :math:`\heaptype_1` is :math:`\NOEXTERN` and :math:`\heaptype_2` :ref:`matches <match-heaptype>` :math:`\EXTERN`.
+* Or :math:`\heaptype_1` is :math:`\NOEXTERN` and :math:`\heaptype_2` is :math:`\EXTERN`.
 
 * Or :math:`\heaptype_1` is :math:`\BOTH`.
 
@@ -170,15 +170,13 @@ A :ref:`heap type <syntax-heaptype>` :math:`\heaptype_1` matches a :ref:`heap ty
    }
    \qquad
    \frac{
-     C \vdashheaptypematch \X{ht} \matchesheaptype \EXN
    }{
-     C \vdashheaptypematch \NOEXN \matchesheaptype \X{ht}
+     C \vdashheaptypematch \NOEXN \matchesheaptype \EXN
    }
    \qquad
    \frac{
-     C \vdashheaptypematch \X{ht} \matchesheaptype \EXTERN
    }{
-     C \vdashheaptypematch \NOEXTERN \matchesheaptype \X{ht}
+     C \vdashheaptypematch \NOEXTERN \matchesheaptype \EXTERN
    }
 
 .. math::


### PR DESCRIPTION
I noticed that subtype rule for exn appears to be missing.

<img width="773" alt="Screenshot 2025-03-04 at 3 57 03 PM" src="https://github.com/user-attachments/assets/1e427b2c-be9f-418d-ba67-d1c1574afdf2" />

I have added the rule.