### PR TITLE
[spec] Fix validation rule for catch and catch all

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -2117,7 +2117,7 @@ Control Instructions
 
 * The label :math:`C.\CLABELS[l]` must be defined in the context.
 
-* The :ref:`result type <syntax-resulttype>` :math:`[t^\ast]` must be the same as :math:`C.\CLABELS[l]`.
+* The :ref:`result type <syntax-resulttype>` :math:`[t^\ast]` must :ref:`match <match-resulttype>` :math:`C.\CLABELS[l]`.
 
 * Then the catch clause is valid.
 
@@ -2125,7 +2125,7 @@ Control Instructions
    \frac{
      \expanddt(C.\CTAGS[x]) = [t^\ast] \toF []
      \qquad
-     C.\CLABELS[l] = [t^\ast]
+     C \vdashresulttypematch [t^\ast] \matchesresulttype C.\CLABELS[l]
    }{
      C \vdashcatch \CATCH~x~l \ok
    }
@@ -2159,13 +2159,13 @@ Control Instructions
 
 * The label :math:`C.\CLABELS[l]` must be defined in the context.
 
-* The :ref:`result type <syntax-resulttype>` :math:`C.\CLABELS[l]` must be empty.
+* The :ref:`result type <syntax-resulttype>` :math:`[]` must :ref:`match <match-resulttype>` :math:`C.\CLABELS[l]`.
 
 * Then the catch clause is valid.
 
 .. math::
    \frac{
-     C.\CLABELS[l] = []
+     C \vdashresulttypematch [] \matchesresulttype C.\CLABELS[l]
    }{
      C \vdashcatch \CATCHALL~l \ok
    }


### PR DESCRIPTION
<img width="795" alt="Screenshot 2025-03-04 at 4 10 25 PM" src="https://github.com/user-attachments/assets/eb887579-036f-48f9-ac5f-a2f0ee1966a1" />

I noticed that validation rule for `catch` and `catch_all` uses equality rather than subtype.
I have corrected it.