### PR TITLE
[spec] Add noexn case for nullref typing

### DIFF
--- a/document/core/exec/values.rst
+++ b/document/core/exec/values.rst
@@ -54,7 +54,7 @@ The following auxiliary typing rules specify this typing relation relative to a 
    \frac{
      \vdashheaptype t \ok
      \qquad
-     t' \in \{\NONE, \NOFUNC, \NOEXTERN\}
+     t' \in \{\NONE, \NOFUNC, \NOEXN, \NOEXTERN\}
      \qquad
      \vdashheaptypematch t' \matchesheaptype t
    }{


### PR DESCRIPTION
I noticed that `noexn` case is missing in null reference typing.
I have added that.
<img width="433" alt="Screenshot 2025-03-05 at 2 33 48 PM" src="https://github.com/user-attachments/assets/4a5fa05c-96b6-4581-a2b1-d485baaefd6a" />
