### PR TITLE
[interpreter] Fix missing type check for `return_call_indirect`

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -543,6 +543,9 @@ let rec check_instr (c : context) (e : instr) (s : infer_result_type) : infer_in
   | ReturnCallIndirect (x, y) ->
     let TableT (at, _lim, t) = table c x in
     let FuncT (ts1, ts2) = func_type c y in
+    require (match_ref_type c.types t (Null, FuncHT)) x.at
+      ("type mismatch: instruction requires table of function type" ^
+       " but table has element type " ^ string_of_ref_type t);
     require (match_result_type c.types ts2 c.results) e.at
       ("type mismatch: current function requires result type " ^
        string_of_result_type c.results ^

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -548,6 +548,16 @@
   "type mismatch"
 )
 
+;; return_call_indirect expects funcref type but receives externref
+(assert_invalid
+  (module
+  (type (func))
+  (table 10 externref)
+  (func $return-call-indirect (return_call_indirect (type 0) (i32.const 0)))
+  )
+  "type mismatch"
+)
+
 ;; Unbound type
 
 (assert_invalid


### PR DESCRIPTION
This PR fixes a missing type check for `return_call_indirect` instruction.

`return_call_indirect` expects a function reference, and the module should be considered invalid if the non-function reference is given (as in `call_indirect` instruction).
However, the current validation behaves incorrectly, and pass such invalid module.
This PR fixes this error, and adds the new test case:
```wast
(assert_invalid
  (module
  (type (func))
  (table 10 externref)
  (func $return-call-indirect (return_call_indirect (type 0) (i32.const 0)))
  )
  "type mismatch"
)
```