### PR TITLE
[spec] Update allocmodule arguments

### DIFF
--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -670,7 +670,7 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
      &\wedge& (\expr_{\F{g}} = \global.\GINIT)^\ast \\
      &\wedge& (\expr_{\F{t}} = \table.\GINIT)^\ast \\
      &\wedge& (\expr_{\F{e}}^\ast = \elem.\EINIT)^n \\[1ex]
-     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^k, \val^\ast, (\reff^\ast)^n) \\
+     &\wedge& S', \moduleinst = \allocmodule(S, \module, \externval^k, \val_{\F{g}}^\ast, \reff_{\F{t}}^\ast, (\reff_{\F{e}}^\ast)^n) \\
      &\wedge& F = \{ \AMODULE~\moduleinst, \ALOCALS~\epsilon \} \\[1ex]
      &\wedge& (S'; F; \expr_{\F{g}} \stepto^\ast S'; F; \val_{\F{g}}~\END)^\ast \\
      &\wedge& (S'; F; \expr_{\F{t}} \stepto^\ast S'; F; \reff_{\F{t}}~\END)^\ast \\


### PR DESCRIPTION
It seems that the arguments of allocmodule have not been updated.

<img width="530" alt="Screenshot 2025-03-10 at 4 23 05 PM" src="https://github.com/user-attachments/assets/6d064467-041e-46e5-b7e7-4cafaecfc5a9" />

I have corrected it.

<img width="530" alt="Screenshot 2025-03-10 at 4 19 08 PM" src="https://github.com/user-attachments/assets/ea92b802-976b-4465-9b1b-6327badc7c38" />
