### PR TITLE
[spec] Fix array.new_default

### DIFF
--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -697,7 +697,7 @@ Reference Instructions
 
 .. math::
    \begin{array}{lcl@{\qquad}l}
-   F; (\I32.\CONST~n)~(\ARRAYNEWDEFAULT~x) &\stepto& (\default_{\unpacktype(\X{ft}}))^n~(\ARRAYNEWFIXED~x~n)
+   F; (\I32.\CONST~n)~(\ARRAYNEWDEFAULT~x) &\stepto& (\default_{\unpacktype(\X{ft})})^n~(\ARRAYNEWFIXED~x~n)
      \\&&
      \begin{array}[t]{@{}r@{~}l@{}}
       (\iff & \expanddt(F.\AMODULE.\MITYPES[x]) = \TARRAY~\X{ft})

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -456,7 +456,7 @@ Aggregate Reference Instructions
      \qquad
      C \vdashvaltypedefaultable \unpacktype(\X{st}) \defaultable
    }{
-     C \vdashinstr \ARRAYNEW~x : [\I32] \to [(\REF~x)]
+     C \vdashinstr \ARRAYNEWDEFAULT~x : [\I32] \to [(\REF~x)]
    }
 
 .. _valid-array.new_fixed:


### PR DESCRIPTION
<img width="680" alt="Screenshot 2025-03-27 at 2 55 32 PM" src="https://github.com/user-attachments/assets/a09abc70-35ea-4b44-83ce-1ff07e2268f4" />

I noticed that validation rule for `array.new_default` uses an incorrect instruction name,

<img width="135" alt="Screenshot 2025-03-27 at 4 39 37 PM" src="https://github.com/user-attachments/assets/befcb6cc-e12f-4b15-86bf-02aea70000e0" />

and there is also a minor typo in execution rule that a parenthesis is not in the subscript.

I have corrected it.
