### PR TITLE
[spec] Update limits type in wasm-3.0 text format spec

### DIFF
--- a/document/core/text/types.rst
+++ b/document/core/text/types.rst
@@ -303,7 +303,7 @@ Address Types
 Abbreviations
 .............
 
-The address type can be omited, in which case it defaults :math:`\I32`:
+The address type can be omitted, in which case it defaults :math:`\I32`:
 
 .. math::
    \begin{array}{llclll}
@@ -322,8 +322,8 @@ Limits
 .. math::
     \begin{array}{llclll}
     \production{limits} & \Tlimits &::=&
-      n{:}\Tu32 &\Rightarrow& \{ \LMIN~n, \LMAX~\epsilon \} \\ &&|&
-      n{:}\Tu32~~m{:}\Tu32 &\Rightarrow& \{ \LMIN~n, \LMAX~m \} \\
+      n{:}\Tu64 &\Rightarrow& \{ \LMIN~n, \LMAX~\epsilon \} \\ &&|&
+      n{:}\Tu64~~m{:}\Tu64 &\Rightarrow& \{ \LMIN~n, \LMAX~m \} \\
     \end{array}
 
 


### PR DESCRIPTION
In memory64, the types of _limits_ `min` and `max` were updated to u64 in the abstract syntax and the binary format specification. This updates the text format spec to match.

This is already tested by the wasm-3.0 tests, e.g. this `assert_invalid` test from `memory.wast` is an `assert_malformed` on the main branch:
```wasm
(assert_invalid
  (module (memory 0x1_0000_0000))
  "memory size"
)
```
