### PR TITLE
[spec] Update align and offset type in text format for memory64

### DIFF
--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -385,10 +385,10 @@ Lexically, an |Toffset| or |Talign| phrase is considered a single :ref:`keyword 
    \production{memory argument} & \Tmemarg_N &::=&
      o{:}\Toffset~~a{:}\Talign_N &\Rightarrow& \{ \ALIGN~n,~\OFFSET~o \} & (\iff a = 2^n) \\
    \production{memory offset} & \Toffset &::=&
-     \text{offset{=}}o{:}\Tu32 &\Rightarrow& o \\ &&|&
+     \text{offset{=}}o{:}\Tu64 &\Rightarrow& o \\ &&|&
      \epsilon &\Rightarrow& 0 \\
    \production{memory alignment} & \Talign_N &::=&
-     \text{align{=}}a{:}\Tu32 &\Rightarrow& a \\ &&|&
+     \text{align{=}}a{:}\Tu64 &\Rightarrow& a \\ &&|&
      \epsilon &\Rightarrow& N \\
    \production{instruction} & \Tplaininstr_I &::=& \dots \phantom{averylonginstructionnameforvectext} && \phantom{vechasreallylonginstructionnames} \\ &&|&
      \text{i32.load}~~x{:}\Tmemidx~~m{:}\Tmemarg_4 &\Rightarrow& \I32.\LOAD~x~m \\ &&|&

--- a/test/core/align.wast
+++ b/test/core/align.wast
@@ -1000,3 +1000,25 @@
   )
   "malformed memop flags"
 )
+
+;; Max align and offset in non-malformed text
+(module
+  (memory i64 1)
+  (func
+    i64.const 0
+    i32.load offset=0xFFFF_FFFF_FFFF_FFFF
+    drop
+  )
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (func
+      i32.const 0
+      i32.load offset=0xFFFF_FFFF_FFFF_FFFF align=0x8000_0000_0000_0000
+      drop
+    )
+  )
+  "alignment must not be larger than natural"
+)


### PR DESCRIPTION
In memory64/wasm-3.0,
- in the abstract syntax and binary format, the type of a memarg offset was updated to u64, and
- in the reference interpreter's text parser, the type of a memarg `align` $a = 2^n$ was updated to u64.

This updates the text format spec to match and adds tests for extreme cases. These surface some bugs/out-of-date parsing logic in WABT and wasm-tools.