### PR TITLE
[test/interpreter] Extern convert as const expr

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -1012,8 +1012,9 @@ let is_const (c : context) (e : instr) =
   | Const _ | VecConst _
   | Binary (Value.I32 I32Op.(Add | Sub | Mul))
   | Binary (Value.I64 I64Op.(Add | Sub | Mul))
-  | RefNull _ | RefFunc _
-  | RefI31 | StructNew _ | ArrayNew _ | ArrayNewFixed _ -> true
+  | RefNull _ | RefFunc _ | RefI31
+  | StructNew _ | ArrayNew _ | ArrayNewFixed _
+  | ExternConvert _ -> true
   | GlobalGet x -> let GlobalT (mut, _t) = global c x in mut = Cons
   | _ -> false
 

--- a/test/core/gc/extern.wast
+++ b/test/core/gc/extern.wast
@@ -3,6 +3,9 @@
   (type $st (struct))
   (type $at (array i8))
 
+  (global externref (extern.convert_any (ref.null any)))
+  (global anyref (any.convert_extern (ref.null extern)))
+
   (table 10 anyref)
 
   (elem declare func $f)


### PR DESCRIPTION
Fix #1889.

@f52985, PTAL. Turns out we already have tests for the other const instructions, distributed over the respective test files.