### PR TITLE
Fix typo in testharness.js

### DIFF
--- a/test/harness/testharness.js
+++ b/test/harness/testharness.js
@@ -132,7 +132,7 @@ policies and contribution forms [3].
     };
 
     WindowTestEnvironment.prototype._forEach_windows = function(callback) {
-        // Iterate of the the windows [self ... top, opener]. The callback is passed
+        // Iterate of the windows [self ... top, opener]. The callback is passed
         // two objects, the first one is the windows object itself, the second one
         // is a boolean indicating whether or not its on the same origin as the
         // current window.


### PR DESCRIPTION
This was already done upstream in https://github.com/web-platform-tests/wpt/pull/50557.