### PR TITLE
[spec] Describe backwards-compatibility and reserve 0xFF opcode

### DIFF
--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -29,9 +29,10 @@ Concretely:
 2. All non-:ref:`trapping <trap>` :ref:`executions <exec>` of a valid program retain their behaviour with an equivalent set of possible :ref:`results <syntax-result>` (or a non-empty subset).
 
   .. note::
-    This allows previously illegal programs to become executable.
+    This allows previously malformed or invalid programs to become executable.
 
-    It also allows program executions that previously trapped to execute successfully.
+    It also allows program executions that previously trapped to execute successfully,
+    although the intention is to only exercise this where the possibility of such an extension has been previously noted.
 
     And it allows reducing the set of observable behaviours of a program execution,
     e.g., by reducing non-determinism.

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -7,6 +7,39 @@ Change History
 Since the original release 1.0 of the WebAssembly specification, a number of proposals for extensions have been integrated.
 The following sections provide an overview of what has changed.
 
+All present and future versions of WebAssembly are intended to be *backwards-compatible* with all previous versions.
+Concretely:
+
+1. All syntactically :ref:`well-formed <binary>` and :ref:`valid <valid>` modules remain well-formed and valid with an equivalent :ref:`module type <syntax-moduletype>` (or a subtype).
+
+  .. note::
+     This allows previously malformed or invalid modules to become legal,
+     e.g., by adding new features or by relaxing typing rules.
+
+     It also allows reclassifying previously malformed modules as well-formed but invalid,
+     or vice versa.
+
+     And it allows refining the typing of :ref:`imports <syntax-import>` and :ref:`exports <syntax-export>`,
+     such that previously unlinkable modules become linkable.
+
+2. All non-:ref:`trapping <trap>` :ref:`executions <exec>` of a valid program retain their behaviour with an equivalent set of possible :ref:`results <syntax-result>` (or a non-empty subset).
+
+  .. note::
+    This allows previously illegal programs to become executable.
+
+    It also allows program executions that previously trapped to execute successfully.
+
+    And it allows reducing the set of observable behaviours of a program execution,
+    e.g., by reducing non-determinism.
+
+    In a program linking prior modules with modules using new features,
+    a prior module may encounter new behaviours,
+    e.g., new forms of control flow or side effects when calling into a latter module.
+
+In addition, the :ref:`instruction opcode <binary-instr>` :math:`\hex{FF}` is considered reserved for custom use and will never be allocated to represent an instruction or instruction prefix.
+
+
+
 Release 2.0
 ~~~~~~~~~~~
 

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -36,7 +36,7 @@ Concretely:
     a prior module may encounter new behaviours,
     e.g., new forms of control flow or side effects when calling into a latter module.
 
-In addition, the :ref:`instruction opcode <binary-instr>` :math:`\hex{FF}` is considered reserved for custom use and will never be allocated to represent an instruction or instruction prefix.
+In addition, future versions of WebAssembly will not allocate the :ref:`opcode <binary-instr>` :math:`\hex{FF}` to represent an instruction or instruction prefix.
 
 
 

--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -10,7 +10,7 @@ The following sections provide an overview of what has changed.
 All present and future versions of WebAssembly are intended to be *backwards-compatible* with all previous versions.
 Concretely:
 
-1. All syntactically :ref:`well-formed <binary>` and :ref:`valid <valid>` modules remain well-formed and valid with an equivalent :ref:`module type <syntax-moduletype>` (or a subtype).
+1. All syntactically well-formed (in :ref:`binary <binary>` or :ref:`text <text>` format) and :ref:`valid <valid>` modules remain well-formed and valid with an equivalent :ref:`module type <syntax-moduletype>` (or a subtype).
 
   .. note::
      This allows previously malformed or invalid modules to become legal,
@@ -21,6 +21,10 @@ Concretely:
 
      And it allows refining the typing of :ref:`imports <syntax-import>` and :ref:`exports <syntax-export>`,
      such that previously unlinkable modules become linkable.
+
+     Historically, minor breaking changes to the *text format* have been allowed
+     that turned previously possible valid modules invalid,
+     as long as they were unlikely to occur in practice.
 
 2. All non-:ref:`trapping <trap>` :ref:`executions <exec>` of a valid program retain their behaviour with an equivalent set of possible :ref:`results <syntax-result>` (or a non-empty subset).
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -729,6 +729,7 @@ Imports :math:`\import` and import descriptions :math:`\importdesc` are classifi
    pair: validation; module
    single: abstract syntax; module
 .. _valid-module:
+.. _syntax-moduletype:
 
 Modules
 ~~~~~~~


### PR DESCRIPTION
Triggered by WebAssembly/design#1539, this spells out the intended backwards-compatibility constraints we assume of future Wasm versions. I believe this captures what was discussed in that context.