### PR TITLE
Select 128 can only be select_t

### DIFF
--- a/test/core/simd/simd_select.wast
+++ b/test/core/simd/simd_select.wast
@@ -2,7 +2,7 @@
 
 (module
   (func (export "select_v128_i32") (param v128 v128 i32) (result v128)
-    (select (local.get 0) (local.get 1) (local.get 2))
+    (select (result v128) (local.get 0) (local.get 1) (local.get 2))
   )
 )
 


### PR DESCRIPTION
This is a fix on top of the recently merged #1899 .

From the spec:
![Screenshot from 2025-05-09 11-06-24](https://github.com/user-attachments/assets/2a8b0061-7de6-4801-becd-1ce5245ecd3c)

> If missing, the operands must be of [numeric type](https://webassembly.github.io/spec/core/syntax/types.html#syntax-numtype).

With numtype:
![Screenshot from 2025-05-09 11-10-01](https://github.com/user-attachments/assets/95883942-1dad-497c-a904-51f5423e0f5d)

Vector Types are not Number Types, hence the select type should be explicitly defined.
