### PR TITLE
[interpreter] Support wrapping fancy function types in JS translation

### DIFF
--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -895,3 +895,29 @@
   )
   "sub type"
 )
+
+
+;; Testing exported functions with non-flat types
+(module
+  (type $t1 (sub (func (result f32))))
+  (type $t2 (sub $t1 (func (result f32))))
+  (type $t3 (sub final $t2 (func (result f32))))
+  (rec
+    (type $t4 (func (result f32)))
+    (type $t5 (sub (func (result f32))))
+    (type $t6 (sub $t5 (func (result f32))))
+  )
+  (func (export "f1") (type $t1) (f32.const 0))
+  (func (export "f2") (type $t2) (f32.const 0))
+  (func (export "f3") (type $t3) (f32.const 0))
+  (func (export "f4") (type $t4) (f32.const 0))
+  (func (export "f5") (type $t5) (f32.const 0))
+  (func (export "f6") (type $t6) (f32.const 0))
+)
+
+(assert_return (invoke "f1") (f32.const 0))
+(assert_return (invoke "f2") (f32.const 0))
+(assert_return (invoke "f3") (f32.const 0))
+(assert_return (invoke "f4") (f32.const 0))
+(assert_return (invoke "f5") (f32.const 0))
+(assert_return (invoke "f6") (f32.const 0))


### PR DESCRIPTION
@f52985, PTAL. Fixes #1902.