### PR TITLE
Test that 0xff is treated as an invalid opcode.

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -1208,3 +1208,25 @@
   "unexpected content after last section"
 )
 
+;; The byte 0xff is documented as being a value that will not be used as
+;; an instruction or instruction prefix opcode. Test that implementations
+;; reject it. This test uses unreachable code in order to avoid
+;; type-checking errors that might arise if 0xff were interpreted as an
+;; instruction.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\04\01\60\00\00"       ;; Type section: 1 type
+    "\03\02\01\00"             ;; Function section: 1 function
+    "\0a\08\01"                ;; Code section: 1 function
+    ;; function 0
+    "\06\00"                   ;; Function size and local type count
+    "\00"                      ;; unreachable
+    "\ff"                      ;; 0xff
+    "\00"                      ;; might be interpreted as unreachable, or as the second byte
+                               ;; of a multi-byte instruction
+    "\00"                      ;; unreachable
+    "\0b"                      ;; end
+  )
+  "illegal opcode ff"
+)


### PR DESCRIPTION
Following up on #1900, this tests that 0xff is disallowed as an instruction and instruction prefix byte.