### PR TITLE
[spec] Remove vestigial prime symbol in data segment text format

### DIFF
--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -659,7 +659,7 @@ The data is written as a :ref:`string <text-string>`, which may be split up into
      \text{(}~\text{data}~~\Tid^?~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \DINIT~b^\ast, \DMODE~\DPASSIVE \} \\ &&|&
      \text{(}~\text{data}~~\Tid^?~~x{:}\Tmemuse_I~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~x', \DOFFSET~e \} \} \\
+       \Rightarrow\quad \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~x, \DOFFSET~e \} \} \\
    \production{data string} & \Tdatastring &::=&
      (b^\ast{:}\Tstring)^\ast \quad\Rightarrow\quad \concat((b^\ast)^\ast) \\
    \production{memory use} & \Tmemuse_I &::=&


### PR DESCRIPTION
Pre-2018, the spec for the text format defined data and element segments as having an implicit "table 0" or "memory 0" with mathematical notation with an `𝑥′` that takes the value 0 if the memidx wasn't present in the text format.

https://github.com/WebAssembly/spec/pull/752 (responding to https://github.com/WebAssembly/reference-types/pull/3#discussion_r174529288) removed the definitions of `x'` and instead defined a text-format abbreviation for data and elem segments, e.g.:

> Also, the memory index can be omitted, defaulting to 0.
> ‘(’ ‘data’ ‘(’ ‘offset’ expr𝐼 ‘)’ . . . ‘)’ ≡ ‘(’ ‘data’ 0 ‘(’ ‘offset’ expr𝐼 ‘)’ . . . ‘)’

However, that commit only removed the prime symbol (from  `𝑥′` ) for the production for element segments but kept it in for data segments. This commit removes the vestigial prime from `𝑥′` for data segments.