### PR TITLE
Update async_index.js and sync_index.js

### DIFF
--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -66,6 +66,15 @@ const EXPECT_INVALID = false;
 
 /* DATA **********************************************************************/
 
+let hostrefs = {};
+let hostsym = Symbol("hostref");
+function hostref(s) {
+  if (! (s in hostrefs)) hostrefs[s] = {[hostsym]: s};
+  return hostrefs[s];
+}
+function eq_ref(x, y) {
+  return x === y ? 1 : 0;
+}
 let externrefs = {};
 let externsym = Symbol("externref");
 function externref(s) {
@@ -96,6 +105,8 @@ function reinitializeRegistry() {
         return;
 
     let spectest = {
+        hostref: hostref,
+        eq_ref: eq_ref,
         externref: externref,
         is_externref: is_externref,
         is_funcref: is_funcref,
@@ -203,7 +214,7 @@ function assert_invalid_custom(bytes) {
 
 const assert_malformed_custom = assert_invalid_custom;
 
-function instance(bytes, imports = registry, valid = true) {
+function instance(mod, imports = registry, valid = true) {
     if (imports instanceof Result) {
         if (imports.isError())
             return imports;
@@ -212,10 +223,9 @@ function instance(bytes, imports = registry, valid = true) {
 
     let err = null;
 
-    let m, i;
+    let i;
     try {
-        let m = module(bytes);
-        i = new WebAssembly.Instance(m, imports);
+        i = new WebAssembly.Instance(mod, imports);
     } catch(e) {
         err = e;
     }


### PR DESCRIPTION
Aafter f83f8101ddb98da50b01f31e6b1f9dbaaf122679 the arguments to instance() are
always a module object rather than the bytes. Update index_async.js and
index_sync.js to match the change to js.ml