### PR TITLE
Add wast source information to JS-converted test cases

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -53,7 +53,7 @@ function register(name, instance) {
   registry[name] = instance.exports;
 }
 
-function module(bytes, valid = true) {
+function module(bytes, source, valid = true) {
   let buffer = new ArrayBuffer(bytes.length);
   let view = new Uint8Array(buffer);
   for (let i = 0; i < bytes.length; ++i) {
@@ -92,8 +92,8 @@ function run(action) {
   action();
 }
 
-function assert_malformed(bytes) {
-  try { module(bytes, false) } catch (e) {
+function assert_malformed(bytes, source) {
+  try { module(bytes, source, false) } catch (e) {
     if (e instanceof WebAssembly.CompileError) return;
   }
   throw new Error("Wasm decoding failure expected");
@@ -103,8 +103,8 @@ function assert_malformed_custom(bytes) {
   return;
 }
 
-function assert_invalid(bytes) {
-  try { module(bytes, false) } catch (e) {
+function assert_invalid(bytes, source) {
+  try { module(bytes, source, false) } catch (e) {
     if (e instanceof WebAssembly.CompileError) return;
   }
   throw new Error("Wasm validation failure expected");
@@ -128,7 +128,7 @@ function assert_uninstantiable(mod) {
   throw new Error("Wasm trap expected");
 }
 
-function assert_trap(action) {
+function assert_trap(action, source) {
   try { action() } catch (e) {
     if (e instanceof WebAssembly.RuntimeError) return;
   }
@@ -150,7 +150,7 @@ function assert_exhaustion(action) {
   throw new Error("Wasm resource exhaustion expected");
 }
 
-function assert_return(action, ...expected) {
+function assert_return(action, source, ...expected) {
   let actual = action();
   if (actual === undefined) {
     actual = [];
@@ -820,7 +820,7 @@ let of_command env cmd =
   let source_str = Filename.basename cmd.at.left.file ^
     ":" ^ string_of_int cmd.at.left.line in
   let source_str_quoted = "\"" ^ source_str ^ "\"" in
-  let source_str_as_arg = ", " ^ source_str in
+  let source_str_as_arg = ", " ^ source_str_quoted in
   "\n// " ^ source_str ^ "\n" ^
   match cmd.it with
   | Module (x_opt, def) ->

--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -151,10 +151,9 @@ function binary(bytes) {
  * Returns a compiled module, or throws if there was an error at compilation.
  */
 function module(bytes, source, valid = true) {
-  let test = valid
-    ? "Test that WebAssembly compilation succeeds"
-    : "Test that WebAssembly compilation fails";
-  test += ` (${source})`;
+  const test = `${ valid ? "Test that WebAssembly compilation succeeds" :
+                "Test that WebAssembly compilation fails"} (${source})`;
+
   const loc = new Error().stack.toString().replace("Error", "");
   let buffer = binary(bytes);
   let validated = WebAssembly.validate(buffer);

--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -150,10 +150,11 @@ function binary(bytes) {
 /**
  * Returns a compiled module, or throws if there was an error at compilation.
  */
-function module(bytes, valid = true) {
-  const test = valid
+function module(bytes, source, valid = true) {
+  let test = valid
     ? "Test that WebAssembly compilation succeeds"
     : "Test that WebAssembly compilation fails";
+  test += ` (${source})`;
   const loc = new Error().stack.toString().replace("Error", "");
   let buffer = binary(bytes);
   let validated = WebAssembly.validate(buffer);
@@ -167,6 +168,7 @@ function module(bytes, valid = true) {
       uniqueTest(_ => {
         assert_true(valid, loc);
       }, test);
+      module.source = source;
       return module;
     },
     error => {
@@ -181,26 +183,27 @@ function module(bytes, valid = true) {
   return chain;
 }
 
-function assert_invalid(bytes) {
-  module(bytes, EXPECT_INVALID);
+function assert_invalid(bytes, source) {
+  module(bytes, source, EXPECT_INVALID);
 }
 
 const assert_malformed = assert_invalid;
 
-function assert_invalid_custom(bytes) {
-  module(bytes);
+function assert_invalid_custom(bytes, source) {
+  module(bytes, source);
 }
 
 const assert_malformed_custom = assert_invalid_custom;
 
 function instance(module, imports, valid = true) {
-  const test = valid
+  let test = valid
     ? "Test that WebAssembly instantiation succeeds"
     : "Test that WebAssembly instantiation fails";
   const loc = new Error().stack.toString().replace("Error", "");
   chain = Promise.all([module, imports, chain])
     .then(values => {
       let imports = values[1] ? values[1] : registry;
+      test += ` (${values[0].source})`;
       return WebAssembly.instantiate(values[0], imports);
     })
     .then(
@@ -235,8 +238,8 @@ function call(instance, name, args) {
   });
 }
 
-function run(action) {
-  const test = "Run a WebAssembly test without special assertions";
+function run(action, source) {
+  const test = `Run a WebAssembly test without special assertions (${source})`;
   const loc = new Error().stack.toString().replace("Error", "");
   chain = Promise.all([chain, action()])
     .then(
@@ -256,8 +259,8 @@ function run(action) {
     .catch(_ => {});
 }
 
-function assert_trap(action) {
-  const test = "Test that a WebAssembly code traps";
+function assert_trap(action, source) {
+  const test = `Test that a WebAssembly code traps (${source})`;
   const loc = new Error().stack.toString().replace("Error", "");
   chain = Promise.all([chain, action()])
     .then(
@@ -279,8 +282,8 @@ function assert_trap(action) {
     .catch(_ => {});
 }
 
-function assert_return(action, ...expected) {
-  const test = "Test that a WebAssembly code returns a specific result";
+function assert_return(action, source, ...expected) {
+  const test = `Test that a WebAssembly code returns a specific result (${source})`;
   const loc = new Error().stack.toString().replace("Error", "");
   chain = Promise.all([action(), chain])
     .then(


### PR DESCRIPTION
Currently the JS/HTML test conversion outputs a test name for each test, but each name is generic
(such as "#2 Test that WebAssembly compilation succeeds", where the only thing unique is a
prepended number. In the async version, the order of these tests doesn't even correspond
simply to the order of tests in the wast file because each test generates multiple assertions
as promises which do not all resolve together for the same tests. The result is hard to
interpret and debug. This is related to #1860 although this particular issue isn't in the
list there.

This PR adds a "source" argument to various functions and passes the information from
the interpreter's AST through the various conversions into the JS files. The result is test
names such as "#2 Test that WebAssembly compilation succeeds (address.wast:3)".
There are still a few non-unique names. "Reinitialize the default imports" and the wrapper
modules that are used when values can't be passed cleanly to JS aren't updated; but
those modules are not directly part of the feature under test and are less likely to fail,
ao it didn't seem worth it.