### PR TITLE
[bikeshed] Fix Bikeshed patch-up script and add debugging aids

### DIFF
--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -61,15 +61,15 @@ def HasBalancedTags(s):
 
 def ReplaceMath(cache, data):
   old = data
+  data = re.sub('[\\][\\][([-0-9])', '\\DOUBLESLASH[\\1', data)  # Messed up by Bikeshed
   data = data.replace('\\\\', '\\DOUBLESLASH')
   data = data.replace('\\(', '')
   data = data.replace('\\)', '')
-  data = data.replace('\\[([-0-9])', '\\DOUBLSLASH[\\1')  # Messed up by Bikeshed
   data = data.replace('\\[', '')
   data = data.replace('\\]', '')
   data = data.replace('\\DOUBLESLASH', '\\\\')
-  data = data.replace('’', '\'')       # Messed up by Bikeshed
-  data = data.replace('\\hfill', '')
+  data = data.replace('\u2019', '\'')       # Messed up by Bikeshed
+  data = data.replace('\\hfill', ' ')
   data = data.replace('\\mbox', '\\text')
   data = data.replace('\\begin{split}', '\\begin{aligned}')
   data = data.replace('\\end{split}', '\\end{aligned}')

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -68,7 +68,7 @@ def ReplaceMath(cache, data):
   data = data.replace('\\[', '')
   data = data.replace('\\]', '')
   data = data.replace('\\DOUBLESLASH', '\\\\')
-  data = data.replace('\u2019', '\'')       # Messed up by Bikeshed
+  data = data.replace('\u2019', '\'')       # "Right Single Quotation Mark" messed up by Bikeshed
   data = data.replace('\\hfill', ' ')
   data = data.replace('\\mbox', '\\text')
   data = data.replace('\\begin{split}', '\\begin{aligned}')

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -212,7 +212,7 @@ def Main():
   # Pull out math fragments.
   data = re.sub(
       'class="([^"]*)math([^"]*)"[^>]*>'
-      '((?:[ ]*<span[^>]*>[^<]*</span>)*)([^<]*)<',
+      '((?:[ \n]*<span[^>]*>[^<]*</span>)*)([^<]*)<',
       ExtractMath, data)
 
   sys.stderr.write('Processing %d fragments.\n' % len(fixups))

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -228,7 +228,8 @@ def Main():
         fixed = ('class="' + cls_before + ' ' + cls_after + '">' +
                  spans + ReplaceMath(cache, mth) + '<')
         done_fixups.append((start, end, fixed))
-      except Exception:
+      except Exception as inst:
+        sys.stderr.write('\nException: ' + inst + '\n')
         success = False
 
       q.task_done()

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -61,7 +61,7 @@ def HasBalancedTags(s):
 
 def ReplaceMath(cache, data):
   old = data
-  data = re.sub('[\\][\\]\\[([0-9]|-)', '\\DOUBLESLASH[\\1', data)  # Messed up by Bikeshed
+  data = re.sub('[\\\\]\\[([0-9]|-)', '\\\\DOUBLESLASH\\[\\1', data)  # Messed up by Bikeshed
   data = data.replace('\\\\', '\\DOUBLESLASH')
   data = data.replace('\\(', '')
   data = data.replace('\\)', '')

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -61,7 +61,7 @@ def HasBalancedTags(s):
 
 def ReplaceMath(cache, data):
   old = data
-  data = re.sub('[\\][\\][([-0-9])', '\\DOUBLESLASH[\\1', data)  # Messed up by Bikeshed
+  data = re.sub('[\\][\\]\\[([0-9]|-)', '\\DOUBLESLASH[\\1', data)  # Messed up by Bikeshed
   data = data.replace('\\\\', '\\DOUBLESLASH')
   data = data.replace('\\(', '')
   data = data.replace('\\)', '')

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -229,7 +229,7 @@ def Main():
                  spans + ReplaceMath(cache, mth) + '<')
         done_fixups.append((start, end, fixed))
       except Exception as inst:
-        sys.stderr.write('\nException: ' + inst + '\n')
+        sys.stderr.write('\nException: ' + inst.__str__() + '\n')
         success = False
 
       q.task_done()

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -108,12 +108,17 @@ def ReplaceMath(cache, data):
       data = data[:start] + v.replace('#1', data[start+len(k):end]) + data[end:]
   p = subprocess.Popen(
       ['node', os.path.join(SCRIPT_DIR, 'katex/cli.js'), '--display-mode', '--trust'],
-      stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
-  ret = p.communicate(input=data)[0]
-  if p.returncode != 0:
+      stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+  ret, err = p.communicate(input=data)
+  if p.returncode != 0 or err != "":
+    if err != "":
+      sys.stderr.write(err + '\n')
     sys.stderr.write('BEFORE:\n' + old + '\n')
     sys.stderr.write('AFTER:\n' + data + '\n')
-    raise Exception()
+    if p.returncode != 0:
+      raise Exception()
+    else:
+      sys.stderr.write('RESULT:\n' + ret + '\n')
   ret = ret.strip()
   ret = ret[ret.find('<span class="katex-html"'):]
   ret = '<span class="katex-display"><span class="katex">' + ret

--- a/document/core/util/mathjax2katex.py
+++ b/document/core/util/mathjax2katex.py
@@ -64,18 +64,18 @@ def ReplaceMath(cache, data):
   data = data.replace('\\\\', '\\DOUBLESLASH')
   data = data.replace('\\(', '')
   data = data.replace('\\)', '')
+  data = data.replace('\\[([-0-9])', '\\DOUBLSLASH[\\1')  # Messed up by Bikeshed
   data = data.replace('\\[', '')
   data = data.replace('\\]', '')
   data = data.replace('\\DOUBLESLASH', '\\\\')
-  data = data.replace('’', '\\text{’}')
-  data = data.replace('‘', '\\text{‘}')
+  data = data.replace('’', '\'')       # Messed up by Bikeshed
   data = data.replace('\\hfill', '')
   data = data.replace('\\mbox', '\\text')
   data = data.replace('\\begin{split}', '\\begin{aligned}')
   data = data.replace('\\end{split}', '\\end{aligned}')
-  data = data.replace('&amp;', '&')
-  data = data.replace('&lt;', '<')
-  data = data.replace('&gt;', '>')
+  data = data.replace('&amp;', '&')    # Messed up by Bikeshed
+  data = data.replace('&lt;', '<')     # Messed up by Bikeshed
+  data = data.replace('&gt;', '>')     # Messed up by Bikeshed
   data = data.replace('{array}[t]', '{array}')
   data = data.replace('{array}[b]', '{array}')
   data = data.replace('@{~}', '')
@@ -112,7 +112,7 @@ def ReplaceMath(cache, data):
   ret, err = p.communicate(input=data)
   if p.returncode != 0 or err != "":
     if err != "":
-      sys.stderr.write(err + '\n')
+      sys.stderr.write('\n\n' + err + '\n')
     sys.stderr.write('BEFORE:\n' + old + '\n')
     sys.stderr.write('AFTER:\n' + data + '\n')
     if p.returncode != 0:


### PR DESCRIPTION
Fixes #1924.

Bikeshed substitution steam-rolls over Latex content, which this script was supposed to fix up. But some of the cases either were outdated by changes to Sphinx/Katex/Bikeshed or never worked.

This patch now makes the script fail on warnings and adds suitable diagnostics, especially useful for CI. Unfortunately, I still can't get Bikeshed to run on my local machine.