### PR TITLE
[spec] Add missing 'addrtype' in memory type validation

### DIFF
--- a/document/core/valid/types.rst
+++ b/document/core/valid/types.rst
@@ -539,7 +539,7 @@ Memory Types
    \frac{
      C \vdashlimits \limits : 2^{|\addrtype|-16}
    }{
-     C \vdashmemtype \limits \ok
+     C \vdashmemtype \addrtype~\limits \ok
    }
 
 


### PR DESCRIPTION
Found a potential typo!

Before:
<img width="778" alt="Screenshot 2025-06-22 at 04 07 30" src="https://github.com/user-attachments/assets/d6fe3168-a350-484d-9d00-a6caf58d2ae6" />

After:
<img width="778" alt="Screenshot 2025-06-22 at 04 08 27" src="https://github.com/user-attachments/assets/a6d3fb5f-49ca-4988-aae5-b1f14a92078e" />
