### PR TITLE
[spec] Added a missing star (section 3.4.12)

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -2703,7 +2703,7 @@ Subsumption for :math:`\instr^\ast`
 .. math::
    \frac{
      \begin{array}{@{}c@{}}
-     C \vdashinstr \instr : \instrtype
+     C \vdashinstr \instr^\ast : \instrtype
      \qquad
      C \vdashinstrtype \instrtype' \ok
      \qquad


### PR DESCRIPTION
A star superscripting instr was missing in the deduction rule for subsumption (3.4.12) (but not in the text description).