### PR TITLE
Update bits used for malformed memory/table/global flags

### DIFF
--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -815,7 +815,7 @@
       "\00asm" "\01\00\00\00"
       "\04\04\01"                           ;; table section with one entry
       "\70"                                 ;; anyfunc
-      "\02"                                 ;; malformed table limits flag
+      "\08"                                 ;; malformed table limits flag
       "\00"                                 ;; dummy byte
   )
   "integer too large"
@@ -860,7 +860,7 @@
   (module binary
       "\00asm" "\01\00\00\00"
       "\05\03\01"                           ;; memory section with one entry
-      "\02"                                 ;; malformed memory limits flag
+      "\10"                                 ;; malformed memory limits flag
       "\00"                                 ;; dummy byte
   )
   "integer too large"

--- a/test/core/global.wast
+++ b/test/core/global.wast
@@ -384,7 +384,7 @@
       "\0a\67\6c\6f\62\61\6c\5f\69\33\32" ;; "global_i32"
       "\03"                          ;; GlobalImport
       "\7f"                          ;; i32
-      "\02"                          ;; malformed mutability
+      "\04"                          ;; malformed mutability
   )
   "malformed mutability"
 )
@@ -411,7 +411,7 @@
     "\06\86\80\80\80\00"  ;; global section
       "\01"               ;; length 1
       "\7f"               ;; i32
-      "\02"               ;; malformed mutability
+      "\04"               ;; malformed mutability
       "\41\00"            ;; i32.const 0
       "\0b"               ;; end
   )


### PR DESCRIPTION
This commit updates a few locations where tests assert that various bits are invalid to set for memories, tables, and globals:

* For memories bit 0b10 of the "flags" byte was tested to ensure that it's invalid, but this bit is used in the WebAssembly threads proposal to indicate a shared memory. Additionally bit 0b100 is used by the memory64 proposal and the 0b1000 bit is used by the custom-page-sizes proposal. This changes the test to assert that bit 0b10000 is invalid as it's not in use by any proposal.

* For tables bit 0b10 of the "flags" byte was tested to ensure that it's invalid, but this bit is used in the WebAssembly shared-everything-threads proposal to indicate a shared table. Additionally bit 0b100 is used by the memory64 proposal. This changes the test to assert that bit 0b1000 is invalid as it's not in use by any proposal.

* For globals bit 0b10 of the "flags" byte was tested to ensure that it's invalid, but this bit is used in the WebAssembly shared-everything-threads proposal to indicate a shared global. This changes the test to assert that bit 0b100 is invalid as it's not in use by any proposal.