### PR TITLE
Make Echidna status checking tolerate transient failure

### DIFF
--- a/document/util/check-echidna-status.py
+++ b/document/util/check-echidna-status.py
@@ -23,13 +23,21 @@ def get_echidna_id(directory):
 def get_current_response(echidna_id):
     url = ECHIDNA_STATUS_URL + echidna_id
     print(f'Fetching {url}')
-    response = requests.get(url, allow_redirects=True)
-    if response.status_code != 200:
+    tries = 3
+    while tries:
+        response = requests.get(url, allow_redirects=True)
+        if response.status_code == 200:
+            return response.json()
+
         print(f'Got status code {response.status_code}, text:')
         print(response.text)
-        raise Exception('Failed to fetch echidna result')
+        tries -= 1
+        if tries:
+            print('Retrying in 10s')
+            time.sleep(10)
 
-    return response.json()
+    raise Exception('Failed to fetch echidna result')
+
 
 
 def get_echidna_result(echidna_id):
@@ -42,7 +50,8 @@ def get_echidna_result(echidna_id):
     result = response['results']['status']
     print(f'Echidna issue {echidna_id} is {result}.')
     print(json.dumps(response, indent=2))
-    return result == 'success'
+    if result != 'success':
+        raise Exception(f'Echidna result: {result}')
 
 
 def main(argv):
@@ -50,7 +59,10 @@ def main(argv):
     echidna_id = get_echidna_id(directory)
     print(f'Got echidna id {echidna_id}.')
     time.sleep(5)
-    if not get_echidna_result(echidna_id):
+    try:
+        get_echidna_result(echidna_id)
+    except Exception as e:
+        print(f'Echidna failure: {e}')
         sys.exit(1)
 
 


### PR DESCRIPTION
It often happens that checking the Echinda status too quickly after
request upload results in failure (to get the validation results), but
checking it shortly after that would result in success. So, make the
status-check script retry a couple of times on failure.
