### PR TITLE
Fix prose rendering of NotOp ContextKindE

### DIFF
--- a/spectec/src/al/ast.ml
+++ b/spectec/src/al/ast.ml
@@ -89,7 +89,7 @@ and expr' =
   (* Conditions *)
   | IsCaseOfE of expr * atom                      (* expr is atom *)
   | IsValidE of expr                              (* expr is valid *)
-  | ContextKindE of atom                          (* "the fisrt non-value entry of the stack is a" atom *)
+  | ContextKindE of atom                          (* "the first non-value entry of the stack is a" atom *)
   | IsDefinedE of expr                            (* expr is defined *)
   | MatchE of expr * expr                         (* expr matches expr *)
   | HasTypeE of expr * typ                        (* expr is ty *)

--- a/spectec/src/backend-prose/print.ml
+++ b/spectec/src/backend-prose/print.ml
@@ -86,6 +86,8 @@ and string_of_expr expr =
     sprintf "%s does not match %s" (string_of_expr e1) (string_of_expr e2)
   | UnE (`NotOp, { it = MemE (e1, e2); _ }) ->
     sprintf "%s is not contained in %s" (string_of_expr e1) (string_of_expr e2)
+  | UnE (`NotOp, { it = ContextKindE a; _ }) ->
+    sprintf "the first non-value entry of the stack is not a %s" (string_of_atom a)
   | UnE (`NotOp, e) -> sprintf "not %s" (string_of_expr e)
   | UnE (op, e) -> sprintf "(%s %s)" (string_of_unop op) (string_of_expr e)
   | BinE (op, e1, e2) ->

--- a/spectec/src/backend-prose/render.ml
+++ b/spectec/src/backend-prose/render.ml
@@ -628,6 +628,9 @@ and render_expr' env expr =
     let se1 = render_expr env e1 in
     let se2 = render_expr env e2 in
     sprintf "%s is not contained in %s" se1 se2
+  | Al.Ast.UnE (`NotOp, { it = Al.Ast.ContextKindE a; _ }) ->
+    let sa = render_atom env a in
+    sprintf "the first non-value entry of the stack is not a %s" sa
   | Al.Ast.UnE (op, e) ->
     let sop = render_al_unop op in
     let se = render_expr env e in

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -19272,7 +19272,7 @@ The instruction sequence :math:`(\mathsf{block}~{\mathit{blocktype}}~{{\mathit{i
 
          #) Execute the instruction :math:`\mathsf{throw\_ref}`.
 
-      #) Else if not the first non-value entry of the stack is a :math:`\mathsf{handler}`, then:
+      #) Else if the first non-value entry of the stack is not a :math:`\mathsf{handler}`, then:
 
          a) Throw the exception :math:`{\mathit{val}'}` as a result.
 
@@ -19424,11 +19424,11 @@ The instruction sequence :math:`(\mathsf{block}~{\mathit{blocktype}}~{{\mathit{i
 
 #. Else:
 
-   a. Assert: Due to validation, not the first non-value entry of the stack is a :math:`\mathsf{label}`.
+   a. Assert: Due to validation, the first non-value entry of the stack is not a :math:`\mathsf{label}`.
 
-   #. Assert: Due to validation, not the first non-value entry of the stack is a :math:`\mathsf{frame}`.
+   #. Assert: Due to validation, the first non-value entry of the stack is not a :math:`\mathsf{frame}`.
 
-   #. Assert: Due to validation, not the first non-value entry of the stack is a :math:`\mathsf{handler}`.
+   #. Assert: Due to validation, the first non-value entry of the stack is not a :math:`\mathsf{handler}`.
 
    #. Throw the exception :math:`{\mathit{val}'}` as a result.
 
@@ -29491,7 +29491,7 @@ Step_read/throw_ref
     1) Pop the frame (FRAME_ _ { _ }) from the stack.
     2) Push the value (REF.EXN_ADDR a) to the stack.
     3) Execute the instruction THROW_REF.
-  f. Else if not the first non-value entry of the stack is a HANDLER_, then:
+  f. Else if the first non-value entry of the stack is not a HANDLER_, then:
     1) Throw the exception val' as a result.
   g. Else:
     1) Let (HANDLER_ n { catch''* }) be the topmost HANDLER_.
@@ -29560,9 +29560,9 @@ Step_read/throw_ref
         3. Push the value (REF.EXN_ADDR a) to the stack.
         4. Execute the instruction (BR l).
 6. Else:
-  a. Assert: Due to validation, not the first non-value entry of the stack is a LABEL_.
-  b. Assert: Due to validation, not the first non-value entry of the stack is a FRAME_.
-  c. Assert: Due to validation, not the first non-value entry of the stack is a HANDLER_.
+  a. Assert: Due to validation, the first non-value entry of the stack is not a LABEL_.
+  b. Assert: Due to validation, the first non-value entry of the stack is not a FRAME_.
+  c. Assert: Due to validation, the first non-value entry of the stack is not a HANDLER_.
   d. Throw the exception val' as a result.
 
 Step_read/try_table bt catch* instr*


### PR DESCRIPTION
*not* the first non-value entry of the stack is a label →
the first non-value entry of the stack is *not* a label