### PR TITLE
[js-api] Fix `ToValueType` error case

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -1179,7 +1179,7 @@ which can be simultaneously referenced by multiple {{Instance}} objects. Each
     1. If |s| equals "v128", return [=v128=].
     1. If |s| equals "anyfunc", return [=funcref=].
     1. If |s| equals "externref", return [=externref=].
-    1. Assert: This step is not reached.
+    1. Throw a {{TypeError}} exception.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Any invalid / unsupported string should run into this, so this shouldn't be an assertion but an error?
I assume we don't need new tests as this should already be covered by https://github.com/WebAssembly/spec/blob/main/test/js-api/global/constructor.any.js#L82?