### PR TITLE
[interpreter] JS Conversion: make of_loc optionally quote its output

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -661,19 +661,19 @@ let add_unicode_char buf uc =
   else
     add_char buf (Char.chr uc)
 
-let of_string_with iter add_char s =
+let of_string_with ?(quoted=true) iter add_char s =
   let buf = Buffer.create 256 in
-  Buffer.add_char buf '\"';
+  if quoted then Buffer.add_char buf '\"';
   iter (add_char buf) s;
-  Buffer.add_char buf '\"';
+  if quoted then Buffer.add_char buf '\"';
   Buffer.contents buf
 
 let of_bytes = of_string_with String.iter add_hex_char
-let of_string = of_string_with String.iter add_char
+let of_string ?(quoted=true) = of_string_with ~quoted String.iter add_char
 let of_name = of_string_with List.iter add_unicode_char
 
-let of_loc at =
-  of_string (Filename.basename at.left.file ^ ":" ^ string_of_int at.left.line)
+let of_loc ?(quoted=true) at =
+  of_string ~quoted (Filename.basename at.left.file ^ ":" ^ string_of_int at.left.line)
 
 let of_float z =
   match string_of_float z with
@@ -812,8 +812,8 @@ let of_assertion env ass =
     of_assertion' env act loc "assert_exception" [] None
 
 let of_command env cmd =
+  "\n// " ^ of_loc ~quoted:false cmd.at ^ "\n" ^
   let loc = of_loc cmd.at in
-  "\n// " ^ loc ^ "\n" ^
   match cmd.it with
   | Module (x_opt, def) ->
     let rec unquote def =


### PR DESCRIPTION
Use the unquoted form in the comment, to match the previous output.