### PR TITLE
[test][harness] Add table64 to the JS spectest definitions

### DIFF
--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -118,6 +118,12 @@ function reinitializeRegistry() {
         maximum: 20,
         element: "anyfunc"
       }),
+      table64: new WebAssembly.Table({
+        initial: 10,
+        maximum: 20,
+        element: "anyfunc",
+        address: "i64"
+      }),
       memory: new WebAssembly.Memory({ initial: 1, maximum: 2 })
     };
     let handler = {

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -124,6 +124,7 @@ function reinitializeRegistry() {
         global_f32: 666.6,
         global_f64: 666.6,
         table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
+        table64: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc', address: "i64"}),
         memory: new WebAssembly.Memory({initial: 1, maximum: 2})
     };
     let handler = {


### PR DESCRIPTION
It's already present in spec interpreter and the lack of it causes some WPT tests to fail.