### PR TITLE
[test] Unify the trap message in gc/type-subtyping

### DIFF
--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -280,12 +280,12 @@
   )
 )
 (assert_return (invoke "run"))
-(assert_trap (invoke "fail1") "indirect call")
-(assert_trap (invoke "fail2") "indirect call")
-(assert_trap (invoke "fail3") "indirect call")
-(assert_trap (invoke "fail4") "cast")
-(assert_trap (invoke "fail5") "cast")
-(assert_trap (invoke "fail6") "cast")
+(assert_trap (invoke "fail1") "indirect call type mismatch")
+(assert_trap (invoke "fail2") "indirect call type mismatch")
+(assert_trap (invoke "fail3") "indirect call type mismatch")
+(assert_trap (invoke "fail4") "cast failure")
+(assert_trap (invoke "fail5") "cast failure")
+(assert_trap (invoke "fail6") "cast failure")
 
 (module
   (type $t1 (sub (func)))
@@ -311,10 +311,10 @@
     (drop)
   )
 )
-(assert_trap (invoke "fail1") "indirect call")
-(assert_trap (invoke "fail2") "indirect call")
-(assert_trap (invoke "fail3") "cast")
-(assert_trap (invoke "fail4") "cast")
+(assert_trap (invoke "fail1") "indirect call type mismatch")
+(assert_trap (invoke "fail2") "indirect call type mismatch")
+(assert_trap (invoke "fail3") "cast failure")
+(assert_trap (invoke "fail4") "cast failure")
 
 (module
   (type $t1 (sub (func)))
@@ -342,8 +342,8 @@
   )
 )
 (assert_return (invoke "run"))
-(assert_trap (invoke "fail1") "indirect call")
-(assert_trap (invoke "fail2") "indirect call")
+(assert_trap (invoke "fail1") "indirect call type mismatch")
+(assert_trap (invoke "fail2") "indirect call type mismatch")
 
 (module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
@@ -608,7 +608,7 @@
     (rec (type $g1 (sub $f1 (func))) (type (struct)))
     (func (import "M5" "g") (type $g1))
   )
-  "incompatible import"
+  "incompatible import type"
 )
 
 (module
@@ -700,7 +700,7 @@
     (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
     (func (import "M10" "f") (type $f11))
   )
-  "incompatible import"
+  "incompatible import type"
 )
 
 (module
@@ -716,7 +716,7 @@
     (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
     (func (import "M11" "f") (type $f11))
   )
-  "incompatible import"
+  "incompatible import type"
 )
 
 
@@ -829,7 +829,7 @@
     (type $a (sub (array (ref none))))
     (type $b (sub $a (array (ref any))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -837,7 +837,7 @@
     (type $a (sub (array (mut (ref any)))))
     (type $b (sub $a (array (mut (ref none)))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -845,7 +845,7 @@
     (type $a (sub (array (mut (ref any)))))
     (type $b (sub $a (array (ref any))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -853,7 +853,7 @@
     (type $a (sub (array (ref any))))
     (type $b (sub $a (array (mut (ref any)))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -861,7 +861,7 @@
     (type $a (sub (struct (field (ref none)))))
     (type $b (sub $a (struct (field (ref any)))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -869,7 +869,7 @@
     (type $a (sub (struct (field (mut (ref any))))))
     (type $b (sub $a (struct (field (mut (ref none))))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -877,7 +877,7 @@
     (type $a (sub (struct (field (mut (ref any))))))
     (type $b (sub $a (struct (field (ref any)))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid
@@ -885,7 +885,7 @@
     (type $a (sub (struct (field (ref any)))))
     (type $b (sub $a (struct (field (mut (ref any))))))
   )
-  "sub type 1 does not match super type"
+  "sub type"
 )
 
 (assert_invalid


### PR DESCRIPTION
1. Unify the "indirect call" as "indirect call type mismatch"
2. Unify the "cast" as "cast failure"
3. Unify the "incompatible import" as "incompatible import type"
4. Unify the "sub type 1 does not match super type" as "sub type"