### PR TITLE
[test] Unify error messages in gc and exception tests

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -769,7 +769,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_resulttype) : infer_ins
     require (i < Lib.List32.length fts) e.at
       ("unknown field " ^ I32.to_string_u i);
     let FieldT (mut, st) = Lib.List32.nth fts i in
-    require (mut == Var) e.at "field is immutable";
+    require (mut == Var) e.at "immutable field";
     let t = unpacked_storagetype st in
     [RefT (Null, UseHT (Def (type_ c x))); t] --> [], []
 
@@ -811,7 +811,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_resulttype) : infer_ins
 
   | ArraySet x ->
     let FieldT (mut, st) = array_type c x in
-    require (mut == Var) e.at "array is immutable";
+    require (mut == Var) e.at "immutable array";
     let t = unpacked_storagetype st in
     [RefT (Null, UseHT (Def (type_ c x))); NumT I32T; t] --> [], []
 
@@ -821,19 +821,19 @@ let rec check_instr (c : context) (e : instr) (s : infer_resulttype) : infer_ins
   | ArrayCopy (x, y) ->
     let FieldT (mutd, std) = array_type c x in
     let FieldT (_muts, sts) = array_type c y in
-    require (mutd = Var) e.at "array is immutable";
+    require (mutd = Var) e.at "immutable array";
     require (match_storagetype c.types sts std) e.at "array types do not match";
     [RefT (Null, UseHT (Def (type_ c x))); NumT I32T; RefT (Null, UseHT (Def (type_ c y))); NumT I32T; NumT I32T] --> [], []
 
   | ArrayFill x ->
     let FieldT (mut, st) = array_type c x in
-    require (mut = Var) e.at "array is immutable";
+    require (mut = Var) e.at "immutable array";
     let t = unpacked_storagetype st in
     [RefT (Null, UseHT (Def (type_ c x))); NumT I32T; t; NumT I32T] --> [], []
 
   | ArrayInitData (x, y) ->
     let FieldT (mut, st) = array_type c x in
-    require (mut = Var) e.at "array is immutable";
+    require (mut = Var) e.at "immutable array";
     let () = data c y in
     let t = unpacked_storagetype st in
     require (is_numtype t || is_vectype t) x.at
@@ -842,7 +842,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_resulttype) : infer_ins
 
   | ArrayInitElem (x, y) ->
     let FieldT (mut, st) = array_type c x in
-    require (mut = Var) e.at "array is immutable";
+    require (mut = Var) e.at "immutable array";
     let rt = elem c y in
     require (match_valtype c.types (RefT rt) (unpacked_storagetype st)) x.at
       ("type mismatch: element segment's type " ^ string_of_reftype rt ^

--- a/test/core/exceptions/tag.wast
+++ b/test/core/exceptions/tag.wast
@@ -53,7 +53,7 @@
     )
     (tag (import "M" "tag") (type $t2))
   )
-  "incompatible import"
+  "incompatible import type"
 )
 
 (assert_unlinkable
@@ -61,5 +61,5 @@
     (type $t (func))
     (tag (import "M" "tag") (type $t))
   )
-  "incompatible import"
+  "incompatible import type"
 )

--- a/test/core/gc/array.wast
+++ b/test/core/gc/array.wast
@@ -296,7 +296,7 @@
       (array.set $a (local.get $a) (i32.const 0) (i64.const 1))
     )
   )
-  "array is immutable"
+  "immutable array"
 )
 
 (assert_invalid

--- a/test/core/gc/array_copy.wast
+++ b/test/core/gc/array_copy.wast
@@ -11,7 +11,7 @@
       (array.copy $a $b (local.get $1) (i32.const 0) (local.get $2) (i32.const 0) (i32.const 0))
     )
   )
-  "array is immutable"
+  "immutable array"
 )
 
 (assert_invalid

--- a/test/core/gc/array_fill.wast
+++ b/test/core/gc/array_fill.wast
@@ -10,7 +10,7 @@
       (array.fill $a (local.get $1) (i32.const 0) (local.get $2) (i32.const 0))
     )
   )
-  "array is immutable"
+  "immutable array"
 )
 
 (assert_invalid

--- a/test/core/gc/array_init_data.wast
+++ b/test/core/gc/array_init_data.wast
@@ -12,7 +12,7 @@
       (array.init_data $a $d1 (local.get $1) (i32.const 0) (i32.const 0) (i32.const 0))
     )
   )
-  "array is immutable"
+  "immutable array"
 )
 
 (assert_invalid

--- a/test/core/gc/array_init_elem.wast
+++ b/test/core/gc/array_init_elem.wast
@@ -12,7 +12,7 @@
       (array.init_elem $a $e1 (local.get $1) (i32.const 0) (i32.const 0) (i32.const 0))
     )
   )
-  "array is immutable"
+  "immutable array"
 )
 
 (assert_invalid

--- a/test/core/gc/struct.wast
+++ b/test/core/gc/struct.wast
@@ -136,7 +136,7 @@
       (struct.set $s 0 (local.get $s) (i64.const 1))
     )
   )
-  "field is immutable"
+  "immutable field"
 )
 
 

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -551,9 +551,9 @@
 ;; return_call_indirect expects funcref type but receives externref
 (assert_invalid
   (module
-  (type (func))
-  (table 10 externref)
-  (func $return-call-indirect (return_call_indirect (type 0) (i32.const 0)))
+    (type (func))
+    (table 10 externref)
+    (func $return-call-indirect (return_call_indirect (type 0) (i32.const 0)))
   )
   "type mismatch"
 )


### PR DESCRIPTION
1. As PR #2019 , unify the "incompatible import" as "incompatible import type".
2. According to the changes of commit https://github.com/WebAssembly/spec/commit/e1fa7528a8e1d8c07646064acc69f3b2d7629ec5 , which changes the message "global is immutable" to "immutable global", modify the messages:
   * "array is immutable" -> "immutable array"
   * "field is immutable" -> "immutable field"