### PR TITLE
[test] Correct catch clause in type mismatch test

### DIFF
--- a/test/core/exceptions/try_table.wast
+++ b/test/core/exceptions/try_table.wast
@@ -459,7 +459,7 @@
     (tag $e (param (ref null $t)))
     (func (export "catch_ref") (result (ref $t))
       (block $l (result (ref $t) (ref exn))
-        (try_table (catch $e $l))
+        (try_table (catch_ref $e $l))
         (unreachable)
       )
     )


### PR DESCRIPTION
As the function's export name says, it should be `catch_ref` instead of `catch` in `try_table`, otherwise it will be similar to the previous `"catch"` test.

Here is after changed to `catch_ref`:

<img width="1456" height="964" alt="image" src="https://github.com/user-attachments/assets/b0919467-9999-4a4b-b2fd-a7797fa58dd2" />

