### PR TITLE
Split memory64 JS API tests into separate files

### DIFF
--- a/test/js-api/memory/constructor-memory64.any.js
+++ b/test/js-api/memory/constructor-memory64.any.js
@@ -1,0 +1,52 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/assertions.js
+// META: script=/wasm/jsapi/memory/assertions.js
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": value }));
+  }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
+
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 0n, "maximum": value }));
+  }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
+}
+
+test(() => {
+  assert_throws_js(RangeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 10n, "maximum": 9n }));
+}, "Initial value exceeds maximum (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 0n };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 0, "address": "i64" });
+}, "Zero initial (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 4n };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 4, "address": "i64" });
+}, "Non-zero initial (i64)");
+
+test(() => {
+  const argument = { "initial": 1n, "address": "i64" };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 1, "address": "i64" });
+}, "Memory with i64 address constructor");
+
+test(() => {
+  const argument = { "address": "i64", "initial": "3" };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 3, "address": "i64" });
+}, "Memory with string value for initial (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": true };
+  const memory = new WebAssembly.Memory(argument);
+  assert_Memory(memory, { "size": 1, "address": "i64" });
+}, "Memory with boolean value for initial (i64)");

--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -62,28 +62,9 @@ for (const value of outOfRangeValues) {
   }, `Out-of-range maximum value in descriptor: ${format_value(value)}`);
 }
 
-const outOfRangeValuesI64 = [
-  -1n,
-  0x1_0000_0000_0000_0000n,
-];
-
-for (const value of outOfRangeValuesI64) {
-  test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": value }));
-  }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
-
-  test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 0n, "maximum": value }));
-  }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
-}
-
 test(() => {
   assert_throws_js(RangeError, () => new WebAssembly.Memory({ "initial": 10, "maximum": 9 }));
 }, "Initial value exceeds maximum");
-
-test(() => {
-  assert_throws_js(RangeError, () => new WebAssembly.Memory({ "address": "i64", "initial": 10n, "maximum": 9n }));
-}, "Initial value exceeds maximum (i64)");
 
 test(() => {
   const proxy = new Proxy({}, {
@@ -166,18 +147,6 @@ test(() => {
 }, "Non-zero initial");
 
 test(() => {
-  const argument = { "address": "i64", "initial": 0n };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 0, "address": "i64" });
-}, "Zero initial (i64)");
-
-test(() => {
-  const argument = { "address": "i64", "initial": 4n };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 4, "address": "i64" });
-}, "Non-zero initial (i64)");
-
-test(() => {
   const argument = { "initial": 0 };
   const memory = new WebAssembly.Memory(argument, {});
   assert_Memory(memory, { "size": 0 });
@@ -196,34 +165,17 @@ test(() => {
 }, "Memory with i32 address constructor");
 
 test(() => {
-  const argument = { "initial": 1n, "address": "i64" };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "address": "i64" });
-}, "Memory with i64 address constructor");
-
-test(() => {
   const argument = { "initial": "3" };
   const memory = new WebAssembly.Memory(argument);
   assert_Memory(memory, { "size": 3 });
 }, "Memory with string value for initial");
 
-test(() => {
-  const argument = { "address": "i64", "initial": "3" };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 3, "address": "i64" });
-}, "Memory with string value for initial (i64)");
 
 test(() => {
   const argument = { "initial": true };
   const memory = new WebAssembly.Memory(argument);
   assert_Memory(memory, { "size": 1 });
 }, "Memory with boolean value for initial");
-
-test(() => {
-  const argument = { "address": "i64", "initial": true };
-  const memory = new WebAssembly.Memory(argument);
-  assert_Memory(memory, { "size": 1, "address": "i64" });
-}, "Memory with boolean value for initial (i64)");
 
 test(() => {
   assert_throws_js(TypeError, () => new WebAssembly.Memory({ "initial": 1, "address": "none" }));

--- a/test/js-api/memory/grow-memory64.any.js
+++ b/test/js-api/memory/grow-memory64.any.js
@@ -1,0 +1,97 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/memory/assertions.js
+
+test(() => {
+  const argument = { "address": "i64", "initial": 0n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
+}, "Zero initial (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 3n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 3 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 3n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 5 }, "New buffer after growing");
+}, "Non-zero initial (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(2n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
+  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
+}, "Zero initial with respected maximum (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
+
+  const result = memory.grow(1n);
+  assert_equals(result, 0n);
+
+  const newMemory = memory.buffer;
+  assert_not_equals(oldMemory, newMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing once");
+  assert_ArrayBuffer(newMemory, { "size": 1 }, "New buffer after growing once");
+
+  const result2 = memory.grow(1n);
+  assert_equals(result2, 1n);
+
+  const newestMemory = memory.buffer;
+  assert_not_equals(newMemory, newestMemory);
+  assert_ArrayBuffer(oldMemory, { "detached": true }, "New buffer after growing twice");
+  assert_ArrayBuffer(newMemory, { "detached": true }, "New buffer after growing twice");
+  assert_ArrayBuffer(newestMemory, { "size": 2 }, "Newest buffer after growing twice");
+}, "Zero initial with respected maximum grown twice (i64)");
+
+test(() => {
+  const argument = { "address": "i64", "initial": 1n, "maximum": 2n };
+  const memory = new WebAssembly.Memory(argument);
+  const oldMemory = memory.buffer;
+  assert_ArrayBuffer(oldMemory, { "size": 1 }, "Buffer before growing");
+
+  assert_throws_js(RangeError, () => memory.grow(2n));
+  assert_equals(memory.buffer, oldMemory);
+  assert_ArrayBuffer(memory.buffer, { "size": 1 }, "Buffer before trying to grow");
+}, "Zero initial growing too much (i64)");
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x10000000000000000n,
+  "0x10000000000000000",
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    const argument = { "address": "i64", "initial": 0n };
+    const memory = new WebAssembly.Memory(argument);
+    assert_throws_js(TypeError, () => memory.grow(value));
+  }, `Out-of-range i64 argument: ${format_value(value)}`);
+}
+

--- a/test/js-api/memory/grow.any.js
+++ b/test/js-api/memory/grow.any.js
@@ -48,21 +48,6 @@ test(() => {
 }, "Zero initial");
 
 test(() => {
-  const argument = { "address": "i64", "initial": 0n };
-  const memory = new WebAssembly.Memory(argument);
-  const oldMemory = memory.buffer;
-  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
-
-  const result = memory.grow(2n);
-  assert_equals(result, 0n);
-
-  const newMemory = memory.buffer;
-  assert_not_equals(oldMemory, newMemory);
-  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
-  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
-}, "Zero initial (i64)");
-
-test(() => {
   const argument = { "initial": { valueOf() { return 0 } } };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -93,21 +78,6 @@ test(() => {
 }, "Non-zero initial");
 
 test(() => {
-  const argument = { "address": "i64", "initial": 3n };
-  const memory = new WebAssembly.Memory(argument);
-  const oldMemory = memory.buffer;
-  assert_ArrayBuffer(oldMemory, { "size": 3 }, "Buffer before growing");
-
-  const result = memory.grow(2n);
-  assert_equals(result, 3n);
-
-  const newMemory = memory.buffer;
-  assert_not_equals(oldMemory, newMemory);
-  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
-  assert_ArrayBuffer(newMemory, { "size": 5 }, "New buffer after growing");
-}, "Non-zero initial (i64)");
-
-test(() => {
   const argument = { "initial": 0, "maximum": 2 };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -121,21 +91,6 @@ test(() => {
   assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
   assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
 }, "Zero initial with respected maximum");
-
-test(() => {
-  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
-  const memory = new WebAssembly.Memory(argument);
-  const oldMemory = memory.buffer;
-  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
-
-  const result = memory.grow(2n);
-  assert_equals(result, 0n);
-
-  const newMemory = memory.buffer;
-  assert_not_equals(oldMemory, newMemory);
-  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing");
-  assert_ArrayBuffer(newMemory, { "size": 2 }, "New buffer after growing");
-}, "Zero initial with respected maximum (i64)");
 
 test(() => {
   const argument = { "initial": 0, "maximum": 2 };
@@ -162,30 +117,6 @@ test(() => {
 }, "Zero initial with respected maximum grown twice");
 
 test(() => {
-  const argument = { "address": "i64", "initial": 0n, "maximum": 2n };
-  const memory = new WebAssembly.Memory(argument);
-  const oldMemory = memory.buffer;
-  assert_ArrayBuffer(oldMemory, { "size": 0 }, "Buffer before growing");
-
-  const result = memory.grow(1n);
-  assert_equals(result, 0n);
-
-  const newMemory = memory.buffer;
-  assert_not_equals(oldMemory, newMemory);
-  assert_ArrayBuffer(oldMemory, { "detached": true }, "Old buffer after growing once");
-  assert_ArrayBuffer(newMemory, { "size": 1 }, "New buffer after growing once");
-
-  const result2 = memory.grow(1n);
-  assert_equals(result2, 1n);
-
-  const newestMemory = memory.buffer;
-  assert_not_equals(newMemory, newestMemory);
-  assert_ArrayBuffer(oldMemory, { "detached": true }, "New buffer after growing twice");
-  assert_ArrayBuffer(newMemory, { "detached": true }, "New buffer after growing twice");
-  assert_ArrayBuffer(newestMemory, { "size": 2 }, "Newest buffer after growing twice");
-}, "Zero initial with respected maximum grown twice (i64)");
-
-test(() => {
   const argument = { "initial": 1, "maximum": 2 };
   const memory = new WebAssembly.Memory(argument);
   const oldMemory = memory.buffer;
@@ -195,17 +126,6 @@ test(() => {
   assert_equals(memory.buffer, oldMemory);
   assert_ArrayBuffer(memory.buffer, { "size": 1 }, "Buffer before trying to grow");
 }, "Zero initial growing too much");
-
-test(() => {
-  const argument = { "address": "i64", "initial": 1n, "maximum": 2n };
-  const memory = new WebAssembly.Memory(argument);
-  const oldMemory = memory.buffer;
-  assert_ArrayBuffer(oldMemory, { "size": 1 }, "Buffer before growing");
-
-  assert_throws_js(RangeError, () => memory.grow(2n));
-  assert_equals(memory.buffer, oldMemory);
-  assert_ArrayBuffer(memory.buffer, { "size": 1 }, "Buffer before trying to grow");
-}, "Zero initial growing too much (i64)");
 
 const outOfRangeValues = [
   undefined,
@@ -225,20 +145,6 @@ for (const value of outOfRangeValues) {
     const memory = new WebAssembly.Memory(argument);
     assert_throws_js(TypeError, () => memory.grow(value));
   }, `Out-of-range argument: ${format_value(value)}`);
-}
-
-const outOfRangeValuesI64 = [
-  -1n,
-  0x10000000000000000n,
-  "0x10000000000000000",
-];
-
-for (const value of outOfRangeValuesI64) {
-  test(() => {
-    const argument = { "address": "i64", "initial": 0n };
-    const memory = new WebAssembly.Memory(argument);
-    assert_throws_js(TypeError, () => memory.grow(value));
-  }, `Out-of-range i64 argument: ${format_value(value)}`);
 }
 
 test(() => {

--- a/test/js-api/table/constructor-memory64.any.js
+++ b/test/js-api/table/constructor-memory64.any.js
@@ -1,0 +1,69 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+// META: script=/wasm/jsapi/assertions.js
+// META: script=/wasm/jsapi/table/assertions.js
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x1_0000_0000_0000_0000n,
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": value }));
+  }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
+
+  test(() => {
+    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 0n, "maximum": value }));
+  }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
+}
+
+test(() => {
+  assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 10n, "maximum": 9n }));
+}, "Initial value exceeds maximum (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 0n };
+  const table = new WebAssembly.Table(argument);
+  assert_Table(table, { "length": 0n }, "i64");
+}, "Basic (zero, i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_Table(table, { "length": 5n }, "i64");
+}, "Basic (non-zero, i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 3n, "address": "i64" };
+  const table = new WebAssembly.Table(argument);
+  // Once this is merged with the type reflection proposal we should check the
+  // address type of `table`.
+  assert_equals(table.length, 3n);
+}, "Table with i64 address constructor");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": "3", "address": "i64" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 3n);
+}, "Table with string value for initial (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": true, "address": "i64" };
+  const table = new WebAssembly.Table(argument);
+  assert_equals(table.length, 1n);
+}, "Table with boolean value for initial (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": "3", "address": "i64" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(3n);
+  assert_equals(table.length, 3n);
+}, "Table with string value for maximum (i64)");
+
+test(() => {
+  const argument = { "element": "anyfunc", "initial": 0n, "maximum": true, "address": "i64" };
+  const table = new WebAssembly.Table(argument);
+  table.grow(1n);
+  assert_equals(table.length, 1n);
+}, "Table with boolean value for maximum (i64)");

--- a/test/js-api/table/constructor.any.js
+++ b/test/js-api/table/constructor.any.js
@@ -71,28 +71,10 @@ for (const value of outOfRangeValues) {
   }, `Out-of-range maximum value in descriptor: ${format_value(value)}`);
 }
 
-const outOfRangeValuesI64 = [
-  -1n,
-  0x1_0000_0000_0000_0000n,
-];
-
-for (const value of outOfRangeValuesI64) {
-  test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": value }));
-  }, `Out-of-range initial i64 value in descriptor: ${format_value(value)}`);
-
-  test(() => {
-    assert_throws_js(TypeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 0n, "maximum": value }));
-  }, `Out-of-range maximum i64 value in descriptor: ${format_value(value)}`);
-}
 
 test(() => {
   assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "initial": 10, "maximum": 9 }));
 }, "Initial value exceeds maximum");
-
-test(() => {
-  assert_throws_js(RangeError, () => new WebAssembly.Table({ "element": "anyfunc", "address": "i64", "initial": 10n, "maximum": 9n }));
-}, "Initial value exceeds maximum (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
@@ -105,18 +87,6 @@ test(() => {
   const table = new WebAssembly.Table(argument);
   assert_Table(table, { "length": 5 });
 }, "Basic (non-zero)");
-
-test(() => {
-  const argument = { "element": "anyfunc", "address": "i64", "initial": 0n };
-  const table = new WebAssembly.Table(argument);
-  assert_Table(table, { "length": 0n }, "i64");
-}, "Basic (zero, i64)");
-
-test(() => {
-  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
-  const table = new WebAssembly.Table(argument);
-  assert_Table(table, { "length": 5n }, "i64");
-}, "Basic (non-zero, i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0 };
@@ -259,36 +229,16 @@ test(() => {
 }, "Table with i32 address constructor");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 3n, "address": "i64" };
-  const table = new WebAssembly.Table(argument);
-  // Once this is merged with the type reflection proposal we should check the
-  // address type of `table`.
-  assert_equals(table.length, 3n);
-}, "Table with i64 address constructor");
-
-test(() => {
   const argument = { "element": "anyfunc", "initial": "3", "address": "i32" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 3);
 }, "Table with string value for initial");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": "3", "address": "i64" };
-  const table = new WebAssembly.Table(argument);
-  assert_equals(table.length, 3n);
-}, "Table with string value for initial (i64)");
-
-test(() => {
   const argument = { "element": "anyfunc", "initial": true, "address": "i32" };
   const table = new WebAssembly.Table(argument);
   assert_equals(table.length, 1);
 }, "Table with boolean value for initial");
-
-test(() => {
-  const argument = { "element": "anyfunc", "initial": true, "address": "i64" };
-  const table = new WebAssembly.Table(argument);
-  assert_equals(table.length, 1n);
-}, "Table with boolean value for initial (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 0, "maximum": "3", "address": "i32" };
@@ -298,25 +248,11 @@ test(() => {
 }, "Table with string value for maximum");
 
 test(() => {
-  const argument = { "element": "anyfunc", "initial": 0n, "maximum": "3", "address": "i64" };
-  const table = new WebAssembly.Table(argument);
-  table.grow(3n);
-  assert_equals(table.length, 3n);
-}, "Table with string value for maximum (i64)");
-
-test(() => {
   const argument = { "element": "anyfunc", "initial": 0, "maximum": true, "address": "i32" };
   const table = new WebAssembly.Table(argument);
   table.grow(1);
   assert_equals(table.length, 1);
 }, "Table with boolean value for maximum");
-
-test(() => {
-  const argument = { "element": "anyfunc", "initial": 0n, "maximum": true, "address": "i64" };
-  const table = new WebAssembly.Table(argument);
-  table.grow(1n);
-  assert_equals(table.length, 1n);
-}, "Table with boolean value for maximum (i64)");
 
 test(() => {
   const argument = { "element": "anyfunc", "initial": 3, "address": "unknown" };

--- a/test/js-api/table/grow-memory64.any.js
+++ b/test/js-api/table/grow-memory64.any.js
@@ -1,0 +1,47 @@
+// META: global=window,dedicatedworker,jsshell
+// META: script=/wasm/jsapi/wasm-module-builder.js
+// META: script=assertions.js
+
+test(() => {
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(5), "before", "i64");
+
+  const result = table.grow(3n);
+  assert_equals(result, 5n);
+  assert_equal_to_array(table, nulls(8), "after", "i64");
+}, "Basic i64");
+
+test(() => {
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 3n, "maximum": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(3), "before", "i64");
+
+  const result = table.grow(2n);
+  assert_equals(result, 3n);
+  assert_equal_to_array(table, nulls(5), "after", "i64");
+}, "Reached maximum (i64)");
+
+
+test(() => {
+  const argument = { "element": "anyfunc", "address": "i64", "initial": 2n, "maximum": 5n };
+  const table = new WebAssembly.Table(argument);
+  assert_equal_to_array(table, nulls(2), "before", "i64");
+
+  assert_throws_js(RangeError, () => table.grow(4n));
+  assert_equal_to_array(table, nulls(2), "after", "i64");
+}, "Exceeded maximum (i64)");
+
+const outOfRangeValuesI64 = [
+  -1n,
+  0x10000000000000000n,
+  "0x10000000000000000",
+];
+
+for (const value of outOfRangeValuesI64) {
+  test(() => {
+    const argument = { "element": "anyfunc", "address": "i64", "initial": 1n };
+    const table = new WebAssembly.Table(argument);
+    assert_throws_js(TypeError, () => table.grow(value));
+  }, `Out-of-range i64 argument: ${format_value(value)}`);
+}

--- a/test/js-api/table/grow.any.js
+++ b/test/js-api/table/grow.any.js
@@ -48,16 +48,6 @@ test(() => {
 }, "Basic i32");
 
 test(() => {
-  const argument = { "element": "anyfunc", "address": "i64", "initial": 5n };
-  const table = new WebAssembly.Table(argument);
-  assert_equal_to_array(table, nulls(5), "before", "i64");
-
-  const result = table.grow(3n);
-  assert_equals(result, 5n);
-  assert_equal_to_array(table, nulls(8), "after", "i64");
-}, "Basic i64");
-
-test(() => {
   const argument = { "element": "anyfunc", "initial": 3, "maximum": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(3), "before");
@@ -68,16 +58,6 @@ test(() => {
 }, "Reached maximum (i32)");
 
 test(() => {
-  const argument = { "element": "anyfunc", "address": "i64", "initial": 3n, "maximum": 5n };
-  const table = new WebAssembly.Table(argument);
-  assert_equal_to_array(table, nulls(3), "before", "i64");
-
-  const result = table.grow(2n);
-  assert_equals(result, 3n);
-  assert_equal_to_array(table, nulls(5), "after", "i64");
-}, "Reached maximum (i64)");
-
-test(() => {
   const argument = { "element": "anyfunc", "initial": 2, "maximum": 5 };
   const table = new WebAssembly.Table(argument);
   assert_equal_to_array(table, nulls(2), "before");
@@ -85,15 +65,6 @@ test(() => {
   assert_throws_js(RangeError, () => table.grow(4));
   assert_equal_to_array(table, nulls(2), "after");
 }, "Exceeded maximum (i32)");
-
-test(() => {
-  const argument = { "element": "anyfunc", "address": "i64", "initial": 2n, "maximum": 5n };
-  const table = new WebAssembly.Table(argument);
-  assert_equal_to_array(table, nulls(2), "before", "i64");
-
-  assert_throws_js(RangeError, () => table.grow(4n));
-  assert_equal_to_array(table, nulls(2), "after", "i64");
-}, "Exceeded maximum (i64)");
 
 const outOfRangeValues = [
   undefined,
@@ -113,20 +84,6 @@ for (const value of outOfRangeValues) {
     const table = new WebAssembly.Table(argument);
     assert_throws_js(TypeError, () => table.grow(value));
   }, `Out-of-range argument: ${format_value(value)}`);
-}
-
-const outOfRangeValuesI64 = [
-  -1n,
-  0x10000000000000000n,
-  "0x10000000000000000",
-];
-
-for (const value of outOfRangeValuesI64) {
-  test(() => {
-    const argument = { "element": "anyfunc", "address": "i64", "initial": 1n };
-    const table = new WebAssembly.Table(argument);
-    assert_throws_js(TypeError, () => table.grow(value));
-  }, `Out-of-range i64 argument: ${format_value(value)}`);
 }
 
 test(() => {


### PR DESCRIPTION
Part of #1950, similarly to what was done with the memory64 core tests
