### PR TITLE
[js-api] Test validation of string builtin types

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -906,6 +906,8 @@ class WasmModuleBuilder {
     return this.types.length - 1;
   }
 
+  nextTypeIndex() { return this.types.length; }
+
   static defaultFor(type) {
     switch (type) {
       case kWasmI32:


### PR DESCRIPTION
Validation should fail if string builtin imports do not have the expected types. Add a test for this validation.