### PR TITLE
Ensure wasm-latest is correct in CI

### DIFF
--- a/.github/workflows/ci-spec.yml
+++ b/.github/workflows/ci-spec.yml
@@ -3,16 +3,25 @@ name: CI for specs
 on:
   push:
     branches: [ main, wasm-3.0 ]
-    paths: [ .github/**, document/**, spectec/** ]
+    paths: [ .github/**, document/**, spectec/**, specification/** ]
 
   pull_request:
     branches: [ main, wasm-3.0 ]
-    paths: [ .github/**, document/**, spectec/** ]
+    paths: [ .github/**, document/**, spectec/**, specification/** ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
+  ensure-wasm-latest:
+    if: ${{ github.repository == 'WebAssembly/spec' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Diff wasm-latest
+        run: bash .github/workflows/diff-wasm-latest.sh
+
   build-core-spec:
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +154,7 @@ jobs:
   publish-spec:
     runs-on: ubuntu-latest
     needs:
+      - ensure-wasm-latest
       - build-core-spec
       - build-js-api-spec
       - build-web-api-spec

--- a/.github/workflows/diff-wasm-latest.sh
+++ b/.github/workflows/diff-wasm-latest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Identify the highest versioned directory
+HIGHEST_VER=$(ls -d specification/wasm-[0-9]* 2>/dev/null | sort -V | tail -n 1)
+
+if [ -z "$HIGHEST_VER" ]; then
+    echo "❌ Error: No wasm-X.Y versioned directories found in specification/"
+    exit 1
+fi
+
+LATEST="specification/wasm-latest"
+
+# Check that wasm-latest exists
+if [ ! -d "$LATEST" ]; then
+    echo "❌ Error: $LATEST does not exist."
+    exit 1
+fi
+
+# Diff the highest version with wasm-latest and check that the diff is empty
+echo "Checking for differences between $HIGHEST_VER and $LATEST..."
+
+if diff -qr "$HIGHEST_VER" "$LATEST" > /dev/null; then
+    echo "✅ Success: Contents match. No changes needed."
+else
+    echo "🔍 Differences detected:"
+    echo "--------------------------------"
+    diff -r "$HIGHEST_VER" "$LATEST"
+    echo "--------------------------------"
+    exit 1
+fi

--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -4,9 +4,9 @@ on:
   push:
     # Disable on forks!
     branches: [ main ]
-    paths: [ .github/**, document/** ]
+    paths: [ .github/**, document/**, specification/** ]
   pull_request:
-    paths: [ .github/**, document/** ]
+    paths: [ .github/**, document/**, specification/** ]
 
   # Allows you to run this workflow manually from the Actions tab, gh CLI tool,
   # or REST API. THe w3c-status options correspond to the valid options for


### PR DESCRIPTION
In the upstream spec repo, the contents of wasm-latest must always be
the same as the highest numbered wasm-X.Y spec directory. Add a CI
script to enforce this.
