### PR TITLE
[spec] Remove note restricting `memidx <= 0` in text format

### DIFF
--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -266,10 +266,6 @@ The data is written as a :ref:`string <text-string>`, which may be split up into
 
 $${grammar: Tdata_ Tdatastring {Tmemuse_/plain Toffset_/plain}}
 
-.. note::
-   In the current version of WebAssembly, the only valid memory index is 0
-   or a symbolic :ref:`memory identifier <text-id>` resolving to the same value.
-
 
 Abbreviations
 .............


### PR DESCRIPTION
We could alternatively replace the "no memidx>0 are allowed" note with "it used to be the case that memidx>0 were not allowed in the text format", so that anybody who visits is made aware of the change. Not sure if there's a preference for one or the other in the general spec.