### PR TITLE
Fix typo for reserved instructions in appendix

### DIFF
--- a/document/core/appendix/index-instructions.py
+++ b/document/core/appendix/index-instructions.py
@@ -378,7 +378,7 @@ INSTRUCTIONS = [
     Instruction(2.0, r'\TABLEGROW~x', r'\hex{FC}~\hex{0F}', r'[t~\X{at}] \to [\X{at}]', r'valid-table.grow', r'exec-table.grow'),
     Instruction(2.0, r'\TABLESIZE~x', r'\hex{FC}~\hex{10}', r'[] \to [\X{at}]', r'valid-table.size', r'exec-table.size'),
     Instruction(2.0, r'\TABLEFILL~x', r'\hex{FC}~\hex{11}', r'[\X{at}~t~\X{at}] \to []', r'valid-table.fill', r'exec-table.fill'),
-    Instruction(0.0, None, r'\hex{FC}~\hex{1E} \dots'),
+    Instruction(0.0, None, r'\hex{FC}~\hex{12} \dots'),
     Instruction(2.0, r'\V128.\VLOAD~x~\memarg', r'\hex{FD}~~\hex{00}', r'[\X{at}] \to [\V128]', r'valid-vload-val', r'exec-vload-val'),
     Instruction(2.0, r'\V128.\VLOAD\K{8x8\_s}~x~\memarg', r'\hex{FD}~~\hex{01}', r'[\X{at}] \to [\V128]', r'valid-vload-pack', r'exec-vload-pack'),
     Instruction(2.0, r'\V128.\VLOAD\K{8x8\_u}~x~\memarg', r'\hex{FD}~~\hex{02}', r'[\X{at}] \to [\V128]', r'valid-vload-pack', r'exec-vload-pack'),


### PR DESCRIPTION
The table.fill instruction is 0xFC 0x11, and then the next line says 0xFC 0x1E... is reserved. It appears that the present instructions are correct, and the reserved section should have started at 0xFC 0x12 instead.