### PR TITLE
Use elemexpr in the text format instead of just expr

### DIFF
--- a/specification/wasm-3.0/6.4-text.modules.spectec
+++ b/specification/wasm-3.0/6.4-text.modules.spectec
@@ -101,7 +101,7 @@ grammar Telem_(I)/abbrev : (elem, idctxt) = ...
     "(" "elem" Toffset_(I) "func" Tlist(Tfuncidx_(I)) ")"
 
 grammar Telemlist_(I)/plain : (reftype, expr*) =
-  | rt:Treftype_(I) e*:Tlist(Texpr_(I)) => (rt, e*)
+  | rt:Treftype_(I) e*:Tlist(Telemexpr_(I)) => (rt, e*)
   | ...
 
 grammar Telemlist_(I)/abbrev : (reftype, expr*) =

--- a/specification/wasm-latest/6.4-text.modules.spectec
+++ b/specification/wasm-latest/6.4-text.modules.spectec
@@ -101,7 +101,7 @@ grammar Telem_(I)/abbrev : (elem, idctxt) = ...
     "(" "elem" Toffset_(I) "func" Tlist(Tfuncidx_(I)) ")"
 
 grammar Telemlist_(I)/plain : (reftype, expr*) =
-  | rt:Treftype_(I) e*:Tlist(Texpr_(I)) => (rt, e*)
+  | rt:Treftype_(I) e*:Tlist(Telemexpr_(I)) => (rt, e*)
   | ...
 
 grammar Telemlist_(I)/abbrev : (reftype, expr*) =


### PR DESCRIPTION
The text format spec for elem segments states that the grammar for elemlist is a ref type followed by list(expr). But this is obviously wrong because it leaves elemexpr completely unused, disallowing the (item (foo)) syntax.

Currently a draft PR because I can't get it to build locally for inscrutable reasons.