### PR TITLE
fix(test): correct expected test invocation

### DIFF
--- a/test/core/exceptions/try_table.wast
+++ b/test/core/exceptions/try_table.wast
@@ -331,8 +331,8 @@
 (assert_return (invoke "catchless-try" (i32.const 0)) (i32.const 0))
 (assert_return (invoke "catchless-try" (i32.const 1)) (i32.const 1))
 
-(assert_exception (invoke "return-call-in-try-catch"))
-(assert_exception (invoke "return-call-indirect-in-try-catch"))
+(assert_return (invoke "return-call-in-try-catch"))
+(assert_return (invoke "return-call-indirect-in-try-catch"))
 
 (assert_return (invoke "try-with-param"))
 


### PR DESCRIPTION
In both tested tail-call invocations, the exception is thrown, but caught. That's why we can't use `assert_exception`.