### PR TITLE
[spec] fix _binary-mut anchor to point to the place it's defined

### DIFF
--- a/document/core/binary/types.rst
+++ b/document/core/binary/types.rst
@@ -100,6 +100,7 @@ $${grammar: Bresulttype}
    pair: binary format; field type
    pair: binary format; storage type
    pair: binary format; packed type
+.. _binary-mut:
 .. _binary-comptype:
 .. _binary-aggrtype:
 .. _binary-functype:
@@ -163,7 +164,6 @@ $${grammar: Btagtype}
 .. index:: global type, mutability, value type
    pair: binary format; global type
    pair: binary format; mutability
-.. _binary-mut:
 .. _binary-globaltype:
 
 Global Types


### PR DESCRIPTION
The comptype section actually defines mut, but clicking a mut link takes you to the global section.

closes #2113 