### PR TITLE
[test][js-api] WebAssembly.Global.<prototype>.set should not throw without argument

### DIFF
--- a/test/js-api/global/value-get-set.any.js
+++ b/test/js-api/global/value-get-set.any.js
@@ -131,7 +131,14 @@ test(() => {
   const setter = desc.set;
   assert_equals(typeof setter, "function");
 
-  assert_throws_js(TypeError, () => setter.call(global));
+  assert_equals(global.value, 0);
+
+  assert_equals(setter.call(global, undefined), undefined);
+  assert_equals(global.value, 0);
+
+  // Should behave as if 'undefined' was passed as the argument.
+  assert_equals(setter.call(global), undefined);
+  assert_equals(global.value, 0);
 }, "Calling setter without argument");
 
 test(() => {


### PR DESCRIPTION
This change landed in the Web Platform Tests repository via: https://github.com/web-platform-tests/wpt/commit/5078da54e150d8d380062402eb09ada3aa0857fd
Corresponding issue: https://github.com/WebAssembly/spec/issues/2075