### PR TITLE
[spectec] Bump OCaml version in README

### DIFF
--- a/spectec/README.md
+++ b/spectec/README.md
@@ -107,12 +107,12 @@ You will need `ocaml` installed with `dune`, `menhir`, `mdx`, and the `zarith` l
   $ opam init
   ```
 
-* Set `ocaml` as version 5.0.0 or higher.
+* Set `ocaml` as version 5.1.0 or higher.
   ```
-  $ opam switch create 5.0.0
+  $ opam switch create 5.1.0
   ```
   
-* Install `dune` version 3.11.0, `menhir` version 20230608, `mdx` version 2.3.1, and `zarith` version 1.13, via `opam` (default versions)
+* Install `dune` version 3.11.0, `menhir` version 20230608, `mdx` version 2.3.1, and `zarith` version 1.13, via `opam`
   ```
   $ opam install dune menhir mdx zarith
   ```


### PR DESCRIPTION
As `src/frontend/dim.ml` in SpecTec uses `Map.add_to_list` API added since OCaml v5.1, this PR updates the SpecTec README accordingly.

```bash
File "src/frontend/dim.ml", line 95, characters 10-25:
95 |   dims := Map.add_to_list id.it (id.at, ctx, mode) !dims
```