### PR TITLE
[test][js-api] WebAssembly.Exception.length should be 2

### DIFF
--- a/test/js-api/exception/constructor.tentative.any.js
+++ b/test/js-api/exception/constructor.tentative.any.js
@@ -10,7 +10,7 @@ test(() => {
 }, "name");
 
 test(() => {
-  assert_function_length(WebAssembly.Exception, 1, "WebAssembly.Exception");
+  assert_function_length(WebAssembly.Exception, 2, "WebAssembly.Exception");
 }, "length");
 
 test(() => {


### PR DESCRIPTION
Based on: https://webassembly.github.io/spec/js-api/#exceptions
```
[LegacyNamespace=WebAssembly, Exposed=(Window,Worker,Worklet)]
interface Exception {
  constructor(Tag exceptionTag, sequence<any> payload, optional ExceptionOptions options = {});
  any getArg(Tag exceptionTag, [EnforceRange] unsigned long index);
  boolean is(Tag exceptionTag);
  readonly attribute (DOMString or undefined) stack;
};
```

At least our WPT tests are unhappy about V8 returning 1 here instead of 2 and according to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length#description) it seems like this number should include all parameters before the first one with a default value?
(I'm not very familiar with JS semantics and WebIDL definitions.)

@Ms2ger: Could you please take a look?