### PR TITLE
Fix cross-references to constant expressions

### DIFF
--- a/document/core/appendix/changes.rst
+++ b/document/core/appendix/changes.rst
@@ -338,7 +338,7 @@ Extended Constant Expressions
 
 Allowed basic numeric computations in constant expressions. [#proposal-extconst]_
 
-* Extended set of :ref:`constant instructions <valid-const>` with:
+* Extended set of :ref:`constant instructions <valid-constant>` with:
 
   - :math:`\K{i}\X{nn}\K{.add}`
   - :math:`\K{i}\X{nn}\K{.sub}`
@@ -584,7 +584,7 @@ Added managed reference types. [#proposal-gc]_
   - |ANYCONVERTEXTERN|
   - |EXTERNCONVERTANY|
 
-* Extended set of :ref:`constant instructions <valid-const>` with:
+* Extended set of :ref:`constant instructions <valid-constant>` with:
 
   - |REFI31|
   - |STRUCTNEW|

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -1259,15 +1259,15 @@
 .. |vdashinstrs| mathdef:: \xref{valid/instructions}{valid-instrs}{\vdash}
 .. |vdashcatch| mathdef:: \xref{valid/instructions}{valid-catch}{\vdash}
 .. |vdashexpr| mathdef:: \xref{valid/instructions}{valid-expr}{\vdash}
-.. |vdashinstrconst| mathdef:: \xref{valid/instructions}{valid-const}{\vdash}
-.. |vdashexprconst| mathdef:: \xref{valid/instructions}{valid-const}{\vdash}
-.. |vdashexprokconst| mathdef:: \xref{valid/instructions}{valid-const}{\vdash}
+.. |vdashinstrconst| mathdef:: \xref{valid/instructions}{valid-constant}{\vdash}
+.. |vdashexprconst| mathdef:: \xref{valid/instructions}{valid-constant}{\vdash}
+.. |vdashexprokconst| mathdef:: \xref{valid/instructions}{valid-constant}{\vdash}
 
 .. |OKcatch| mathdef:: \xref{valid/instructions}{valid-catch}{\K{ok}}
 
-.. |CONSTinstrconst| mathdef:: \xref{valid/instructions}{valid-const}{\K{const}}
-.. |CONSTexprconst| mathdef:: \xref{valid/instructions}{valid-const}{\K{const}}
-.. |CONSTexprokconst| mathdef:: \xref{valid/instructions}{valid-const}{\K{const}}
+.. |CONSTinstrconst| mathdef:: \xref{valid/instructions}{valid-constant}{\K{const}}
+.. |CONSTexprconst| mathdef:: \xref{valid/instructions}{valid-constant}{\K{const}}
+.. |CONSTexprokconst| mathdef:: \xref{valid/instructions}{valid-constant}{\K{const}}
 
 .. |vdashexternidx| mathdef:: \xref{valid/modules}{valid-externidx}{\vdash}
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -289,4 +289,4 @@ $${rule: Module_ok}
    However, this recursion is just a specification device.
    All types needed to construct ${:C} can easily be determined from a simple pre-pass over the module that does not perform any actual validation.
 
-   Globals, however, are not recursive but evaluated sequentially, such that each :ref:`constant expressions <valid-const>` only has access to imported or previously defined globals.
+   Globals, however, are not recursive but evaluated sequentially, such that each :ref:`constant expressions <valid-constant>` only has access to imported or previously defined globals.


### PR DESCRIPTION
Links to constant expressions in the spec were incorrectly linking to the t.const instruction, which is irrelevant.

This is the considerably more straightforward counterpart to #2144 :)