### PR TITLE
[spectec] Fix prose title of if instruction

### DIFF
--- a/spectec/src/al/al_util.ml
+++ b/spectec/src/al/al_util.ml
@@ -268,7 +268,7 @@ let unwrap_cate e =
   | _ -> fail_expr "unwrap_cate" e
 
 let name_of_algo algo = match algo.it with
-  | RuleA (name, _, _, _) -> Print.string_of_atom name
+  | RuleA (mixop, _, _, _) -> Print.string_of_mixop mixop
   | FuncA (name, _, _) -> name
 
 let params_of_algo algo = match algo.it with

--- a/spectec/src/al/ast.ml
+++ b/spectec/src/al/ast.ml
@@ -146,9 +146,9 @@ and instr' =
 (* Algorithms *)
 
 type algorithm = algorithm' phrase
-and algorithm' =                                    (* `algorithm` f`(`expr*`)` `{`instr*`}` *)
-  | RuleA of atom * anchor * arg list * instr list  (* reduction rule *)
-  | FuncA of id * arg list * instr list             (* helper function *)
+and algorithm' =                                     (* `algorithm` f`(`expr*`)` `{`instr*`}` *)
+  | RuleA of mixop * anchor * arg list * instr list  (* reduction rule *)
+  | FuncA of id * arg list * instr list              (* helper function *)
 
 
 (* Scripts *)

--- a/spectec/src/al/eq.ml
+++ b/spectec/src/al/eq.ml
@@ -142,8 +142,8 @@ and eq_instrs il1 il2 = eq_list eq_instr il1 il2
 
 let eq_algos al1 al2 =
   match al1.it, al2.it with
-  | RuleA (a1, an1, al1, il1), RuleA (a2, an2, al2, il2) ->
-    Atom.eq a1 a2 && an1 = an2 && eq_args al1 al2 && eq_instrs il1 il2
+  | RuleA (m1, an1, al1, il1), RuleA (m2, an2, al2, il2) ->
+    Mixop.eq m1 m2 && an1 = an2 && eq_args al1 al2 && eq_instrs il1 il2
   | FuncA (i1, al1, il1), FuncA (i2, al2, il2) ->
     i1 = i2 && eq_args al1 al2 && eq_instrs il1 il2
   | _ -> false

--- a/spectec/src/backend-interpreter/ds.ml
+++ b/spectec/src/backend-interpreter/ds.ml
@@ -25,8 +25,8 @@ let to_map algos =
   let f acc algo =
     let rmap, fmap = acc in
     match algo.it with
-    | RuleA (atom, _, _, _) ->
-        let name = Print.string_of_atom atom in
+    | RuleA (mixop, _, _, _) ->
+        let name = mixop |> Xl.Mixop.head |> Option.get |> Print.string_of_atom in
         Map.add name algo rmap, fmap
     | FuncA (name, _, _) -> rmap, Map.add name algo fmap
   in

--- a/spectec/src/backend-prose/render.ml
+++ b/spectec/src/backend-prose/render.ml
@@ -1483,20 +1483,22 @@ and render_instrs env algoname depth instrs =
 
 (* Prose *)
 
-let render_atom_title env name params =
-  (* TODO a workaround, for algorithms named label or name
-     that are defined as LABEL_ or FRAME_ in the dsl *)
-  let name' =
-    match name.it with
-    | Atom.Atom "label" -> Atom.Atom "LABEL_"
-    | Atom.Atom "frame" -> Atom.Atom "FRAME_"
-    | Atom.Atom s -> Atom.Atom (String.uppercase_ascii s)
-    | _ -> name.it
+let render_mixop_title env mixop params =
+  let head = Mixop.head mixop in
+  (* HARDCODE: Tweak for these instructinos *)
+  let mixop =
+    match head with
+    | Some atom ->
+      (match atom.it with
+      | Atom ("LABEL_" | "FRAME_" | "HANDLER_") -> Mixop.Atom atom
+      | _ -> mixop
+      )
+    | _ -> mixop
   in
-  let name = name' $$ no_region % name.note in
-  let op = Mixop.(Seq (Atom name :: List.init (List.length params) (fun _ -> Arg ()))) in
   let params = List.filter_map (fun a -> match a.it with Al.Ast.ExpA e -> Some e | _ -> None) params in
-  let expr = Al.Al_util.caseE (op, params) ~at:no_region ~note:Al.Al_util.no_note in
+  if List.length params + 1 <> List.length (Mixop.flatten mixop) then
+    error (match head with | Some atom -> atom.at | None -> no_region) "Failed to render prose header";
+  let expr = Al.Al_util.caseE (mixop, params) ~at:no_region ~note:Al.Al_util.no_note in
   match al_to_el_expr expr with
   | Some ({ it = El.Ast.ParenE exp; _ }) -> render_el_exp env exp
   | Some exp -> render_el_exp env exp
@@ -1504,12 +1506,6 @@ let render_atom_title env name params =
 
 let render_funcname_title env fname params =
   render_expr env (Al.Al_util.callE (fname, params) ~at:no_region ~note:Al.Al_util.no_note)
-
-let _render_pred env name params instrs =
-  let title = render_atom_title env name params in
-  title ^ "\n" ^
-  String.make (String.length title) '.' ^ "\n" ^
-  render_stmts env 0 instrs
 
 let render_rule env concl prems =
   init_typs ();
@@ -1523,8 +1519,8 @@ let render_rule env concl prems =
     sprintf "%s if:\n%s" sconcl sprems
 
 let render_rule_algo env name params instrs =
-  let title = render_atom_title env name params in
-  let rname = Al.Print.string_of_atom name in
+  let title = render_mixop_title env name params in
+  let rname = Al.Print.string_of_mixop name in
   title ^ "\n" ^
   String.make (String.length title) '.' ^ "\n" ^
   render_instrs env rname 0 instrs

--- a/spectec/src/exe-spectec/main.ml
+++ b/spectec/src/exe-spectec/main.ml
@@ -223,8 +223,8 @@ let () =
     let match_algo_name algo_name al_elt =
       algo_name = "" ||
       (match al_elt.Util.Source.it with
-      | Al.Ast.RuleA (a, _, _, _) ->
-        Al.Print.string_of_atom a = String.uppercase_ascii algo_name
+      | Al.Ast.RuleA (m, _, _, _) ->
+        Al.Print.string_of_mixop m = String.uppercase_ascii algo_name
       | Al.Ast.FuncA (id , _, _) ->
         id = String.lowercase_ascii algo_name)
     in

--- a/spectec/src/il2al/manual.ml
+++ b/spectec/src/il2al/manual.ml
@@ -12,7 +12,6 @@ let listT ty = Il.Ast.IterT (ty, Il.Ast.List) $ no_region
 let expA e = ExpA e $ e.at
 
 let eval_expr =
-  let open Xl.Atom in
   let ty_instrs = listT instrT in
   let ty_vals = listT valT in
   let instrs = iter_var "instr" List instrT in
@@ -24,7 +23,10 @@ let eval_expr =
     Il.Env.bind_def !Al.Valid.il_env ("Eval_expr" $ no_region) ([param], ty_vals, []);
 
   RuleA (
-    Atom "Eval_expr" $$ no_region % {def=""; case=""},
+    Xl.Mixop.(Seq [
+      Atom Xl.Atom.(Atom "Eval_expr" $$ no_region % {def=""; case=""});
+      Arg ()
+    ]),
     "Eval_expr",
     [expA instrs],
     [

--- a/spectec/src/il2al/translate.ml
+++ b/spectec/src/il2al/translate.ml
@@ -1216,13 +1216,7 @@ and translate_rgroup (rule: rule_def) =
   let winstr = extract_winstr (List.hd rgroup) rule.at in
   let instrs = translate_rgroup' rule in
 
-  let name =
-    try
-      match Mixop.head (case_of_case winstr) with
-      | Some atom -> atom
-      | _ -> failwith ""
-    with _ -> error rule.at "The reduction rules do not have valid or consistent target Wasm instructions."
-  in
+  let name = case_of_case winstr in
   let anchor = rel_id.it ^ "/" ^ instr_name in
   let al_params =
     if List.mem instr_name ["frame"; "label"; "handler"] then [] else

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -1019,8 +1019,8 @@ The module :math:`(\mathsf{module}~{{\mathit{type}}^\ast}~{{\mathit{import}}^\as
    a. Push the value :math:`{\mathit{val}}_2` to the stack.
 
 
-:math:`\mathsf{if}~{t^?}~{{\mathit{instr}}_1^\ast}~{{\mathit{instr}}_2^\ast}`
-.............................................................................
+:math:`\mathsf{if}~{t^?}~{{\mathit{instr}}_1^\ast}~\mathsf{else}~{{\mathit{instr}}_2^\ast}`
+...........................................................................................
 
 
 1. Assert: Due to validation, a value of number type :math:`\mathsf{i{\scriptstyle 32}}` is on the top of the stack.
@@ -6240,8 +6240,8 @@ The module :math:`(\mathsf{module}~{{\mathit{type}}^\ast}~{{\mathit{import}}^\as
    a. Push the value :math:`{\mathit{val}}_2` to the stack.
 
 
-:math:`\mathsf{if}~{\mathit{bt}}~{{\mathit{instr}}_1^\ast}~{{\mathit{instr}}_2^\ast}`
-.....................................................................................
+:math:`\mathsf{if}~{\mathit{bt}}~{{\mathit{instr}}_1^\ast}~\mathsf{else}~{{\mathit{instr}}_2^\ast}`
+...................................................................................................
 
 
 1. Assert: Due to validation, a value of number type :math:`\mathsf{i{\scriptstyle 32}}` is on the top of the stack.
@@ -19005,8 +19005,8 @@ The instruction sequence :math:`(\mathsf{block}~{\mathit{blocktype}}~{{\mathit{i
    a. Push the value :math:`{\mathit{val}}_2` to the stack.
 
 
-:math:`\mathsf{if}~{\mathit{bt}}~{{\mathit{instr}}_1^\ast}~{{\mathit{instr}}_2^\ast}`
-.....................................................................................
+:math:`\mathsf{if}~{\mathit{bt}}~{{\mathit{instr}}_1^\ast}~\mathsf{else}~{{\mathit{instr}}_2^\ast}`
+...................................................................................................
 
 
 1. Assert: Due to validation, a value of number type :math:`\mathsf{i{\scriptstyle 32}}` is on the top of the stack.


### PR DESCRIPTION
Fixes #2151.

Previously, the `RuleA` algorithm used `atom` to render the title, which caused loss of information. It now uses `mixop` instead, preserving the full information and allowing the `else` atom to be rendered correctly.