### PR TITLE
[test][harness] Fix table64 in the JS spectest definitions

### DIFF
--- a/test/harness/async_index.js
+++ b/test/harness/async_index.js
@@ -119,8 +119,8 @@ function reinitializeRegistry() {
         element: "anyfunc"
       }),
       table64: new WebAssembly.Table({
-        initial: 10,
-        maximum: 20,
+        initial: 10n,
+        maximum: 20n,
         element: "anyfunc",
         address: "i64"
       }),

--- a/test/harness/sync_index.js
+++ b/test/harness/sync_index.js
@@ -124,7 +124,7 @@ function reinitializeRegistry() {
         global_f32: 666.6,
         global_f64: 666.6,
         table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),
-        table64: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc', address: "i64"}),
+        table64: new WebAssembly.Table({initial: 10n, maximum: 20n, element: 'anyfunc', address: "i64"}),
         memory: new WebAssembly.Memory({initial: 1, maximum: 2})
     };
     let handler = {


### PR DESCRIPTION
Followup from #2017. The values need to be BigInts in the i64 case.