### PR TITLE
[spec] Fixed typo in prose of `is_packtype` showing the negation of the intended premise

### DIFF
--- a/specification/wasm-3.0/2.3-validation.instructions.spectec
+++ b/specification/wasm-3.0/2.3-validation.instructions.spectec
@@ -252,7 +252,7 @@ rule Instr_ok/struct.new_default:
   -- Expand: C.TYPES[x] ~~ STRUCT (mut? zt)*
   -- (Defaultable: |- $unpack(zt) DEFAULTABLE)*
 
-def $is_packtype(storagetype) : bool             hint(show %1 = $unpack(%1)) hint(prose "%1 is a packed type")
+def $is_packtype(storagetype) : bool             hint(show %1 =/= $unpack(%1)) hint(prose "%1 is a packed type")
 def $is_packtype(zt) = zt =/= $unpack(zt)
 
 rule Instr_ok/struct.get:

--- a/specification/wasm-latest/2.3-validation.instructions.spectec
+++ b/specification/wasm-latest/2.3-validation.instructions.spectec
@@ -252,7 +252,7 @@ rule Instr_ok/struct.new_default:
   -- Expand: C.TYPES[x] ~~ STRUCT (mut? zt)*
   -- (Defaultable: |- $unpack(zt) DEFAULTABLE)*
 
-def $is_packtype(storagetype) : bool             hint(show %1 = $unpack(%1)) hint(prose "%1 is a packed type")
+def $is_packtype(storagetype) : bool             hint(show %1 =/= $unpack(%1)) hint(prose "%1 is a packed type")
 def $is_packtype(zt) = zt =/= $unpack(zt)
 
 rule Instr_ok/struct.get:


### PR DESCRIPTION
`is_packtype` is currently rendered to display the equality between the original type and its unpacked version, instead of the intended inequality.