### PR TITLE
[spec] Add valtype validity guard to `Local_ok`

### DIFF
--- a/specification/wasm-3.0/2.4-validation.modules.spectec
+++ b/specification/wasm-3.0/2.4-validation.modules.spectec
@@ -45,10 +45,12 @@ rule Table_ok:
 
 rule Local_ok/set:
   C |- LOCAL t : SET t
+  -- Valtype_ok: C |- t : OK
   -- Defaultable: |- t DEFAULTABLE
 
 rule Local_ok/unset:
   C |- LOCAL t : UNSET t
+  -- Valtype_ok: C |- t : OK
   -- Nondefaultable: |- t NONDEFAULTABLE
 
 rule Func_ok:

--- a/specification/wasm-latest/2.4-validation.modules.spectec
+++ b/specification/wasm-latest/2.4-validation.modules.spectec
@@ -45,10 +45,12 @@ rule Table_ok:
 
 rule Local_ok/set:
   C |- LOCAL t : SET t
+  -- Valtype_ok: C |- t : OK
   -- Defaultable: |- t DEFAULTABLE
 
 rule Local_ok/unset:
   C |- LOCAL t : UNSET t
+  -- Valtype_ok: C |- t : OK
   -- Nondefaultable: |- t NONDEFAULTABLE
 
 rule Func_ok:

--- a/spectec/test-frontend/TEST.md
+++ b/spectec/test-frontend/TEST.md
@@ -4620,11 +4620,13 @@ relation Local_ok: `%|-%:%`(context, local, localtype)
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule set{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(SET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Defaultable: `|-%DEFAULTABLE`(t,)
 
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule unset{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(UNSET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Nondefaultable: `|-%NONDEFAULTABLE`(t,)
 
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
@@ -4732,13 +4734,13 @@ relation Export_ok: `%|-%:%%`(context, export, name, externtype)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:136.1-136.100
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:138.1-138.100
 relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:181.1-182.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:183.1-184.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:184.1-187.54
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:186.1-189.54
   rule cons{C : context, global_1 : global, `global*` : global*, gt_1 : globaltype, `gt*` : globaltype*}:
     `%|-%:%`(C, [global_1] ++ global*{global <- `global*`}, [gt_1] ++ gt*{gt <- `gt*`})
     -- Global_ok: `%|-%:%`(C, global_1, gt_1)
@@ -4748,13 +4750,13 @@ relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:135.1-135.98
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:137.1-137.98
 relation Types_ok: `%|-%:%`(context, type*, deftype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:173.1-174.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:175.1-176.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:176.1-179.49
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:178.1-181.49
   rule cons{C : context, type_1 : type, `type*` : type*, `dt_1*` : deftype*, `dt*` : deftype*}:
     `%|-%:%`(C, [type_1] ++ type*{type <- `type*`}, dt_1*{dt_1 <- `dt_1*`} ++ dt*{dt <- `dt*`})
     -- Type_ok: `%|-%:%`(C, type_1, dt_1*{dt_1 <- `dt_1*`})

--- a/spectec/test-latex/TEST.md
+++ b/spectec/test-latex/TEST.md
@@ -7661,6 +7661,8 @@ $$
 $$
 \begin{array}{@{}c@{}}\displaystyle
 \frac{
+C \vdash t : \mathsf{ok}
+ \qquad
 {{\mathrm{default}}}_{t} \neq \epsilon
 }{
 C \vdash \mathsf{local}~t : \mathsf{set}~t
@@ -7672,6 +7674,8 @@ $$
 $$
 \begin{array}{@{}c@{}}\displaystyle
 \frac{
+C \vdash t : \mathsf{ok}
+ \qquad
 {{\mathrm{default}}}_{t} = \epsilon
 }{
 C \vdash \mathsf{local}~t : \mathsf{unset}~t

--- a/spectec/test-middlend/TEST.md
+++ b/spectec/test-middlend/TEST.md
@@ -4143,11 +4143,13 @@ relation Local_ok: `%|-%:%`(context, local, localtype)
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule set{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(SET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Defaultable: `|-%DEFAULTABLE`(t,)
 
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule unset{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(UNSET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Nondefaultable: `|-%NONDEFAULTABLE`(t,)
 
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
@@ -4255,13 +4257,13 @@ relation Export_ok: `%|-%:%%`(context, export, name, externtype)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:136.1-136.100
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:138.1-138.100
 relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:181.1-182.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:183.1-184.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:184.1-187.54
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:186.1-189.54
   rule cons{C : context, global_1 : global, `global*` : global*, gt_1 : globaltype, `gt*` : globaltype*}:
     `%|-%:%`(C, [global_1] ++ global*{global <- `global*`}, [gt_1] ++ gt*{gt <- `gt*`})
     -- Global_ok: `%|-%:%`(C, global_1, gt_1)
@@ -4271,13 +4273,13 @@ relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:135.1-135.98
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:137.1-137.98
 relation Types_ok: `%|-%:%`(context, type*, deftype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:173.1-174.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:175.1-176.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:176.1-179.49
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:178.1-181.49
   rule cons{C : context, type_1 : type, `type*` : type*, `dt_1*` : deftype*, `dt*` : deftype*}:
     `%|-%:%`(C, [type_1] ++ type*{type <- `type*`}, dt_1*{dt_1 <- `dt_1*`} ++ dt*{dt <- `dt*`})
     -- Type_ok: `%|-%:%`(C, type_1, dt_1*{dt_1 <- `dt_1*`})
@@ -16010,11 +16012,13 @@ relation Local_ok: `%|-%:%`(context, local, localtype)
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule set{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(SET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Defaultable: `|-%DEFAULTABLE`(t,)
 
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule unset{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(UNSET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Nondefaultable: `|-%NONDEFAULTABLE`(t,)
 
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
@@ -16122,13 +16126,13 @@ relation Export_ok: `%|-%:%%`(context, export, name, externtype)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:136.1-136.100
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:138.1-138.100
 relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:181.1-182.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:183.1-184.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:184.1-187.54
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:186.1-189.54
   rule cons{C : context, global_1 : global, `global*` : global*, gt_1 : globaltype, `gt*` : globaltype*}:
     `%|-%:%`(C, [global_1] ++ global*{global <- `global*`}, [gt_1] ++ gt*{gt <- `gt*`})
     -- Global_ok: `%|-%:%`(C, global_1, gt_1)
@@ -16138,13 +16142,13 @@ relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:135.1-135.98
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:137.1-137.98
 relation Types_ok: `%|-%:%`(context, type*, deftype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:173.1-174.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:175.1-176.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:176.1-179.49
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:178.1-181.49
   rule cons{C : context, type_1 : type, `type*` : type*, `dt_1*` : deftype*, `dt*` : deftype*}:
     `%|-%:%`(C, [type_1] ++ type*{type <- `type*`}, dt_1*{dt_1 <- `dt_1*`} ++ dt*{dt <- `dt*`})
     -- Type_ok: `%|-%:%`(C, type_1, dt_1*{dt_1 <- `dt_1*`})
@@ -27987,11 +27991,13 @@ relation Local_ok: `%|-%:%`(context, local, localtype)
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule set{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(SET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Defaultable: `|-%DEFAULTABLE`(t,)
 
   ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
   rule unset{C : context, t : valtype}:
     `%|-%:%`(C, LOCAL_local(t), `%%`_localtype(UNSET_init, t))
+    -- Valtype_ok: `%|-%:OK`(C, t)
     -- Nondefaultable: `|-%NONDEFAULTABLE`(t,)
 
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
@@ -28109,13 +28115,13 @@ relation Export_ok: `%|-%:%%`(context, export, name, externtype)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:136.1-136.100
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:138.1-138.100
 relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:181.1-182.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:183.1-184.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:184.1-187.54
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:186.1-189.54
   rule cons{C : context, global_1 : global, `global*` : global*, gt_1 : globaltype, `gt*` : globaltype*}:
     `%|-%:%`(C, [global_1] ++ global*{global <- `global*`}, [gt_1] ++ gt*{gt <- `gt*`})
     -- Global_ok: `%|-%:%`(C, global_1, gt_1)
@@ -28125,13 +28131,13 @@ relation Globals_ok: `%|-%:%`(context, global*, globaltype*)
 ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec
 rec {
 
-;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:135.1-135.98
+;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:137.1-137.98
 relation Types_ok: `%|-%:%`(context, type*, deftype*)
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:173.1-174.17
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:175.1-176.17
   rule empty{C : context}:
     `%|-%:%`(C, [], [])
 
-  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:176.1-179.49
+  ;; ../../../../specification/wasm-latest/2.4-validation.modules.spectec:178.1-181.49
   rule cons{C : context, type_1 : type, `type*` : type*, `dt_1*` : deftype*, `dt*` : deftype*}:
     `%|-%:%`(C, [type_1] ++ type*{type <- `type*`}, dt_1*{dt_1 <- `dt_1*`} ++ dt*{dt <- `dt*`})
     -- Type_ok: `%|-%:%`(C, type_1, dt_1*{dt_1 <- `dt_1*`})

--- a/spectec/test-prose/TEST.md
+++ b/spectec/test-prose/TEST.md
@@ -16881,6 +16881,8 @@ The table :math:`(\mathsf{table}~{\mathit{tabletype}}~{\mathit{expr}})` is :ref:
 The local :math:`(\mathsf{local}~t)` is :ref:`valid <valid-val>` with the local type :math:`({\mathit{init}}~t)` if:
 
 
+   * The value type :math:`t` is :ref:`valid <valid-val>`.
+
    * Either:
 
       * The initialization status :math:`{\mathit{init}}` is of the form :math:`\mathsf{set}`.
@@ -16899,6 +16901,8 @@ The local :math:`(\mathsf{local}~t)` is :ref:`valid <valid-val>` with the local 
 The local :math:`(\mathsf{local}~t)` is :ref:`valid <valid-val>` with the local type :math:`(\mathsf{set}~t)` if:
 
 
+   * The value type :math:`t` is :ref:`valid <valid-val>`.
+
    * A :ref:`default value <aux-default>` for :math:`t` is defined.
 
 
@@ -16906,6 +16910,8 @@ The local :math:`(\mathsf{local}~t)` is :ref:`valid <valid-val>` with the local 
 
 The local :math:`(\mathsf{local}~t)` is :ref:`valid <valid-val>` with the local type :math:`(\mathsf{unset}~t)` if:
 
+
+   * The value type :math:`t` is :ref:`valid <valid-val>`.
 
    * A :ref:`default value <aux-default>` for :math:`t` is not defined.
 
@@ -29257,6 +29263,7 @@ Table_ok
 
 Local_ok
 - the local (LOCAL t) is valid with the local type (init t) if:
+  - the value type t is valid.
   - Either:
     - the initialization status init is SET.
     - A :ref:`default value <aux-default>` for t is defined.
@@ -29266,10 +29273,12 @@ Local_ok
 
 Local_ok/set
 - the local (LOCAL t) is valid with the local type (SET t) if:
+  - the value type t is valid.
   - A :ref:`default value <aux-default>` for t is defined.
 
 Local_ok/unset
 - the local (LOCAL t) is valid with the local type (UNSET t) if:
+  - the value type t is valid.
   - A :ref:`default value <aux-default>` for t is not defined.
 
 Func_ok


### PR DESCRIPTION
The two rules for `Local_ok` is missing a validity guard for the type it quotes:
https://github.com/WebAssembly/spec/blob/869387d57e9a6f6fd65554a7593bd7e4e921787d/specification/wasm-3.0/2.4-validation.modules.spectec#L46-L53

It is used by `Func_ok` downstream later in the file, but it only delegates to `Local_ok` without any guard there either.

This seems to be missing since the guard is present for all other rules in that region, and there are also tests in the test suite that target these guards: https://github.com/WebAssembly/spec/blob/869387d57e9a6f6fd65554a7593bd7e4e921787d/test/core/ref.wast#L59-L63

(The reference interpreter correctly reject these invalid modules.)