### PR TITLE
[spec] Fix minor error on v128.store_lane oob condition

### DIFF
--- a/specification/wasm-2.0/8-reduction.spectec
+++ b/specification/wasm-2.0/8-reduction.spectec
@@ -583,7 +583,7 @@ rule Step/vstore-val:
 
 rule Step/vstore_lane-oob:
   z; (CONST I32 i) (VCONST V128 c) (VSTORE_LANE V128 N ao j)  ~>  z; TRAP
-  -- if $(i + ao.OFFSET + N) > |$mem(z, 0).BYTES|
+  -- if $(i + ao.OFFSET + N/8) > |$mem(z, 0).BYTES|
 
 rule Step/vstore_lane-val:
   z; (CONST I32 i) (VCONST V128 c) (VSTORE_LANE V128 N ao j)  ~>  $with_mem(z, 0, $(i + ao.OFFSET), $(N/8), b*); eps

--- a/specification/wasm-3.0/4.3-execution.instructions.spectec
+++ b/specification/wasm-3.0/4.3-execution.instructions.spectec
@@ -530,7 +530,7 @@ rule Step/vstore-val:
 rule Step/vstore_lane-oob:
   z; (CONST at i) (VCONST V128 c) (VSTORE_LANE V128 N x ao j)  ~>  z; TRAP
   ----
-  -- if $(i + ao.OFFSET + N) > |$mem(z, x).BYTES|
+  -- if $(i + ao.OFFSET + N/8) > |$mem(z, x).BYTES|
 
 rule Step/vstore_lane-val:
   z; (CONST at i) (VCONST V128 c) (VSTORE_LANE V128 N x ao j)  ~>  $with_mem(z, x, $(i + ao.OFFSET), $(N/8), b*); eps

--- a/specification/wasm-latest/4.3-execution.instructions.spectec
+++ b/specification/wasm-latest/4.3-execution.instructions.spectec
@@ -530,7 +530,7 @@ rule Step/vstore-val:
 rule Step/vstore_lane-oob:
   z; (CONST at i) (VCONST V128 c) (VSTORE_LANE V128 N x ao j)  ~>  z; TRAP
   ----
-  -- if $(i + ao.OFFSET + N) > |$mem(z, x).BYTES|
+  -- if $(i + ao.OFFSET + N/8) > |$mem(z, x).BYTES|
 
 rule Step/vstore_lane-val:
   z; (CONST at i) (VCONST V128 c) (VSTORE_LANE V128 N x ao j)  ~>  $with_mem(z, x, $(i + ao.OFFSET), $(N/8), b*); eps


### PR DESCRIPTION
Fixed a minor error in v128.store_lane's oob condition (`N` is bit-width instead of byte-width).