### PR TITLE
[spec] Fix `Localval_ok/unset` making `local.set` untypeable

### DIFF
--- a/specification/wasm-3.0/7.1-soundness.configurations.spectec
+++ b/specification/wasm-3.0/7.1-soundness.configurations.spectec
@@ -343,7 +343,8 @@ rule Localval_ok/set:
   -- Val_ok: s |- val : t
 
 rule Localval_ok/unset:
-  s |- eps : UNSET BOT
+  s |- eps : UNSET t
+  -- Valtype_ok: {} |- t : OK
 
 rule Frame_ok:
   s |- {LOCALS (val?)*, MODULE moduleinst} : C ++ {LOCALS lct*}

--- a/specification/wasm-latest/7.1-soundness.configurations.spectec
+++ b/specification/wasm-latest/7.1-soundness.configurations.spectec
@@ -343,7 +343,8 @@ rule Localval_ok/set:
   -- Val_ok: s |- val : t
 
 rule Localval_ok/unset:
-  s |- eps : UNSET BOT
+  s |- eps : UNSET t
+  -- Valtype_ok: {} |- t : OK
 
 rule Frame_ok:
   s |- {LOCALS (val?)*, MODULE moduleinst} : C ++ {LOCALS lct*}


### PR DESCRIPTION
Fixes #2205 .

On the validity guards: I don't think `Localval_ok/set` needs a guard, because `store_ok s` + `s |- val : t` should be able to derive that. Only the `unset` version needs it as the type is arbitrary.