### PR TITLE
[spec] Test subsumption in return call result types

### DIFF
--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -113,6 +113,23 @@
 )
 
 (module
+  (func $f (result (ref array)) unreachable)
+  (func (result (ref eq))
+    return_call $f
+  )
+)
+
+(assert_invalid
+  (module
+    (func $f (result (ref eq)) unreachable)
+    (func (result (ref array))
+      return_call $f
+    )
+  )
+  "type mismatch"
+)
+
+(module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
   (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
   (rec (type $g1 (sub $f1 (func))) (type (struct)))
@@ -398,6 +415,27 @@
 (assert_return (invoke "run"))
 (assert_trap (invoke "fail1") "indirect call type mismatch")
 (assert_trap (invoke "fail2") "indirect call type mismatch")
+
+(module
+  (type $t (func (result (ref array))))
+  (table 0 funcref)
+  (func (result (ref eq))
+    i32.const 0
+    return_call_indirect (type $t)
+  )
+)
+
+(assert_invalid
+  (module
+    (type $t (func (result (ref eq))))
+    (table 0 funcref)
+    (func (result (ref array))
+      i32.const 0
+      return_call_indirect (type $t)
+    )
+  )
+  "type mismatch"
+)
 
 (module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -113,42 +113,6 @@
 )
 
 (module
-  (func $f (result (ref array)) (unreachable))
-  (func (result (ref eq))
-    (return_call $f)
-  )
-)
-
-(assert_invalid
-  (module
-    (func $f (result (ref eq)) (unreachable))
-    (func (result (ref array))
-      (return_call $f)
-    )
-  )
-  "type mismatch"
-)
-
-(module
-  (type $t (func (result (ref array))))
-  (table 0 funcref)
-  (func (result (ref eq))
-    (return_call_indirect (type $t) (i32.const 0))
-  )
-)
-
-(assert_invalid
-  (module
-    (type $t (func (result (ref eq))))
-    (table 0 funcref)
-    (func (result (ref array))
-      (return_call_indirect (type $t) (i32.const 0))
-    )
-  )
-  "type mismatch"
-)
-
-(module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
   (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
   (rec (type $g1 (sub $f1 (func))) (type (struct)))

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -113,17 +113,36 @@
 )
 
 (module
-  (func $f (result (ref array)) unreachable)
+  (func $f (result (ref array)) (unreachable))
   (func (result (ref eq))
-    return_call $f
+    (return_call $f)
   )
 )
 
 (assert_invalid
   (module
-    (func $f (result (ref eq)) unreachable)
+    (func $f (result (ref eq)) (unreachable))
     (func (result (ref array))
-      return_call $f
+      (return_call $f)
+    )
+  )
+  "type mismatch"
+)
+
+(module
+  (type $t (func (result (ref array))))
+  (table 0 funcref)
+  (func (result (ref eq))
+    (return_call_indirect (type $t) (i32.const 0))
+  )
+)
+
+(assert_invalid
+  (module
+    (type $t (func (result (ref eq))))
+    (table 0 funcref)
+    (func (result (ref array))
+      (return_call_indirect (type $t) (i32.const 0))
     )
   )
   "type mismatch"
@@ -415,27 +434,6 @@
 (assert_return (invoke "run"))
 (assert_trap (invoke "fail1") "indirect call type mismatch")
 (assert_trap (invoke "fail2") "indirect call type mismatch")
-
-(module
-  (type $t (func (result (ref array))))
-  (table 0 funcref)
-  (func (result (ref eq))
-    i32.const 0
-    return_call_indirect (type $t)
-  )
-)
-
-(assert_invalid
-  (module
-    (type $t (func (result (ref eq))))
-    (table 0 funcref)
-    (func (result (ref array))
-      i32.const 0
-      return_call_indirect (type $t)
-    )
-  )
-  "type mismatch"
-)
 
 (module
   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))

--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -91,6 +91,11 @@
   (func (export "type-f64-i64-to-i32-f32") (param f64 i64) (result i32 f32)
     (return_call $swizzle (local.get 0) (local.get 1))
   )
+
+  ;; Result subtyping
+  (type $t (func))
+  (func $f (result (ref null $t)) (ref.null $t))
+  (func (export "type-funcref") (result funcref) (return_call $f))
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -134,6 +139,7 @@
 (assert_return (invoke "odd" (i64.const 999_999)) (i32.const 44))
 (assert_return (invoke "tailprint_i32_f32" (i32.const 5) (f32.const 91.0)))
 (assert_return (invoke "type-f64-i64-to-i32-f32" (f64.const 4.2) (i64.const 99)) (i32.const 99) (f32.const 4.2))
+(assert_return (invoke "type-funcref") (ref.null func))
 
 ;; Invalid typing
 
@@ -148,6 +154,14 @@
   (module
     (func $type-num-vs-num (result i32) (return_call 1) (i32.const 0))
     (func (result i64) (i64.const 1))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $t (func))
+    (func $type-ref-vs-funcref (result (ref null $t)) (return_call 1))
+    (func (result funcref) (unreachable))
   )
   "type mismatch"
 )

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -234,6 +234,14 @@
   (func (export "call_mpmr") (param f64 i64) (result i32 f32)
     (return_call_indirect $tab4 (param f64 i64) (result i32 f32) (local.get 0) (local.get 1) (i32.const 1))
   )
+
+  ;; Result subtyping
+  (type $t (func))
+  (func $f (result (ref null $t)) (ref.null $t))
+  (table $tab5 funcref (elem $f))
+  (func (export "type-funcref") (result funcref)
+    (return_call_indirect $tab5 (result (ref null $t)) (i32.const 0))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -294,6 +302,7 @@
 
 (assert_return (invoke "call_tailprint" (i32.const 5) (f32.const 91.0)))
 (assert_return (invoke "call_mpmr" (f64.const 4.2) (i64.const 99)) (i32.const 99) (f32.const 4.2))
+(assert_return (invoke "type-funcref") (ref.null func))
 
 ;; Invalid syntax
 
@@ -444,6 +453,16 @@
     (type (func (result i64)))
     (table 0 funcref)
     (func $type-num-vs-num (i32.eqz (return_call_indirect (type 0) (i32.const 0))))
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $t (func))
+    (table 0 funcref)
+    (func $type-ref-vs-funcref (result (ref null $t))
+      (return_call_indirect (result funcref) (i32.const 0))
+    )
   )
   "type mismatch"
 )


### PR DESCRIPTION
While validating a GC module in my runtime, I found that return_call and return_call_indirect were comparing result types for exact equality instead of using result type matching. This was a left over from implementing tail call before gc, and caused a certain valid fixture to fail.

This PR adds tests for both instructions. For each instruction, I've included a valid case showing that (ref array) matches (ref eq), and an invalid case showing that the reverse direction is rejected. The cases are intentionally minimal rather than repeating the broader subsumption coverage already present.