### PR TITLE
[spec test] results type must exact match in the return call

### DIFF
--- a/test/core/return_call.wast
+++ b/test/core/return_call.wast
@@ -221,9 +221,27 @@
 )
 (assert_invalid
   (module
-    (func $f (result i32 i32) unreachable)
+    (func $type-result-more (result i32 i32) unreachable)
     (func (result i32)
-      return_call $f
+      return_call $type-result-more
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-result-fewer (result i32) unreachable)
+    (func (result i32 i32)
+      return_call $type-result-fewer
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func $type-result-i64-vs-i32 (result i64) unreachable)
+    (func (result i32)
+      return_call $type-result-i64-vs-i32
     )
   )
   "type mismatch"

--- a/test/core/return_call_indirect.wast
+++ b/test/core/return_call_indirect.wast
@@ -557,11 +557,33 @@
 )
 (assert_invalid
   (module
-    (type $ty (func (result i32 i32)))
+    (type $type-result-more (func (result i32 i32)))
     (import "env" "table" (table $table 0 funcref))
-    (func (param i32) (result i32)
+    (func $type-result-more (param i32) (result i32)
       local.get 0
-      return_call_indirect $table (type $ty)
+      return_call_indirect $table (type $type-result-more)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $type-result-fewer (func (result i32)))
+    (import "env" "table" (table $table 0 funcref))
+    (func $type-result-fewer (param i32) (result i32 i32)
+      local.get 0
+      return_call_indirect $table (type $type-result-fewer)
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $type-result-i64-vs-i32 (func (result i64)))
+    (import "env" "table" (table $table 0 funcref))
+    (func $type-result-i64-vs-i32 (param i32) (result i32)
+      local.get 0
+      return_call_indirect $table (type $type-result-i64-vs-i32)
     )
   )
   "type mismatch"

--- a/test/core/return_call_ref.wast
+++ b/test/core/return_call_ref.wast
@@ -387,10 +387,30 @@
 
 (assert_invalid
   (module
-    (type $ty (func (result i32 i32)))
-    (func (param (ref $ty)) (result i32)
+    (type $type-result-more (func (result i32 i32)))
+    (func $type-result-more (param (ref $type-result-more)) (result i32)
       local.get 0
-      return_call_ref $ty
+      return_call_ref $type-result-more
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $type-result-fewer (func (result i32)))
+    (func $type-result-fewer (param (ref $type-result-fewer)) (result i32 i32)
+      local.get 0
+      return_call_ref $type-result-fewer
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (type $type-result-i64-vs-i32 (func (result i64)))
+    (func $type-result-i64-vs-i32 (param (ref $type-result-i64-vs-i32)) (result i32)
+      local.get 0
+      return_call_ref $type-result-i64-vs-i32
     )
   )
   "type mismatch"


### PR DESCRIPTION
required by spec. Results types of callee and caller in return call must be an exact match