### PR TITLE
[ci] Fix spec publishing in forks

### DIFF
--- a/.github/workflows/ci-spec.yml
+++ b/.github/workflows/ci-spec.yml
@@ -14,12 +14,12 @@ on:
 
 jobs:
   ensure-wasm-latest:
-    if: ${{ github.repository == 'WebAssembly/spec' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Diff wasm-latest
+        if: ${{ github.repository == 'WebAssembly/spec' }}
         run: cd specification && bash diff-wasm-latest.sh
 
   build-core-spec:


### PR DESCRIPTION
publish-spec lists ensure-wasm-latest in its needs, but that job only runs in WebAssembly/spec. A job whose needs include a skipped job is skipped as well, so forks (i.e. proposal repos) stopped publishing their rendered spec to GitHub Pages entirely once they picked up the ensure-wasm-latest job.

Guard publish-spec on nothing having failed instead, which tolerates the skipped job while still blocking publication when a build or the wasm-latest check fails.