### PR TITLE
[spec] Preserve host function arguments on divergence

### DIFF
--- a/specification/wasm-3.0/4.3-execution.instructions.spectec
+++ b/specification/wasm-3.0/4.3-execution.instructions.spectec
@@ -190,7 +190,7 @@ rule Step/call_ref-hostfunc-res:
   -- if RES s' result <- $hostcall(_HOSTFUNC hf, s, val^n)
 
 rule Step/call_ref-hostfunc-div:
-  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)  ~>  s; f; (REF.FUNC_ADDR a) (CALL_REF yy)
+  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)  ~>  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)
   ----
   -- if $funcinst((s; f))[a] = fi
   -- Expand: fi.TYPE ~~ FUNC t_1^n -> t_2^m

--- a/specification/wasm-latest/4.3-execution.instructions.spectec
+++ b/specification/wasm-latest/4.3-execution.instructions.spectec
@@ -190,7 +190,7 @@ rule Step/call_ref-hostfunc-res:
   -- if RES s' result <- $hostcall(_HOSTFUNC hf, s, val^n)
 
 rule Step/call_ref-hostfunc-div:
-  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)  ~>  s; f; (REF.FUNC_ADDR a) (CALL_REF yy)
+  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)  ~>  s; f; val^n (REF.FUNC_ADDR a) (CALL_REF yy)
   ----
   -- if $funcinst((s; f))[a] = fi
   -- Expand: fi.TYPE ~~ FUNC t_1^n -> t_2^m


### PR DESCRIPTION
## Summary

Previously, the reduction rule for host function divergence dropped the call arguments `val^n` from the resulting configuration.

<img width="718" height="524" alt="스크린샷 2026-08-24 오후 1 30 08" src="https://github.com/user-attachments/assets/be1379b9-335c-469b-925f-33d33b786ca4" />

According to the WebAssembly specificaiton, the post-conditions for executing host functions must match those in the execution rule for invoking host functions. However, a host function that takes one or more arguments, one reduction step by `Step/call_ref-hostfunc-div` removes `val^n` and leaves only `(REF.FUNC_ADDR a) (CALL_REF yy)`. Neither host-function execution rule can then apply because the required operands are missing. 

## Fix 

The updated rule preserves the complete configuration, making the divergence case as exact self-loop as intended.  