### PR TITLE
[interpreter] Reject subtypes with multiple supertypes

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -159,6 +159,7 @@ let check_comptype (c : context) (ct : comptype) at =
 
 let check_subtype (c : context) (sut : subtype) at =
   let SubT (_fin, uts, ct) = sut in
+  require (List.length uts <= 1) at "multiple supertypes";
   List.iter (fun ut -> check_typeuse c ut at) uts;
   check_comptype c ct at
 

--- a/test/core/gc/type-subtyping.wast
+++ b/test/core/gc/type-subtyping.wast
@@ -949,6 +949,15 @@
   "sub type"
 )
 
+;; Testing the number of allowed supertypes
+
+(assert_invalid
+  (module
+    (type $parent1 (sub (struct)))
+    (type $parent2 (sub (struct)))
+    (type $child (sub $parent1 $parent2 (struct))))
+  "multiple supertypes"
+)
 
 ;; Testing exported functions with non-flat types
 (module


### PR DESCRIPTION
## Summary

WebAssembly allows a subtype to refer to a previously declared parent type as its supertype. The current specification restricts a subtype to have at most one direct supertype.

<img width="689" height="113" alt="스크린샷 2026-08-24 오후 8 38 58" src="https://github.com/user-attachments/assets/dd53b02d-c675-4b45-a085-0b3241349be6" />


It also notes that future versions of WebAssembly may allow subtypes to have more than one supertype.

The validation specification written in SpecTec correctly enforces this restriction by requiring the number of direct supertypes to be at most one.

```spectec
rule Subtype_ok:
  C |- SUB FINAL? (_IDX x)* comptype : OK(x_0)
  -- if |x*| <= 1 ;; restricts the number of supertypes to be at most one
  -- (if x < x_0)*
  -- (if $unrolldt(C.TYPES[x]) = SUB yy* comptype')*
  ----
  -- Comptype_ok: C |- comptype : OK
  -- (Comptype_sub: C |- comptype <: comptype')*
```

However, the OCaml reference interpreter does not check the number of direct supertypes. It only iterates over the supertype list and validates each referenced type individually.

```OCaml
let check_subtype (c : context) (sut : subtype) at =
  let SubT (_fin, uts, ct) = sut in
  List.iter (fun ut -> check_typeuse c ut at) uts; (* does not check the number of supertypes here *)
  check_comptype c ct at
```

Consequently, the reference interpreter accepts subtype definitions with multiple direct supertypes, even though the current declarative specification requires them to be rejected.

This PR adds the missing cardinality check to `check_subtype`. It also adds a regression test containing two valid non-final parent struct types and a child type that directly inherits from both. The module is rejected specifically because the child has more than one direct supertype.

## Testing

- `make -C interpreter test/gc/type-subtyping`
- `make -C interpreter unittest`