### PR TITLE
Add explicit permissions blocks to all workflows

### DIFF
--- a/.github/workflows/ci-interpreter.yml
+++ b/.github/workflows/ci-interpreter.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   interpreter:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-spec.yml
+++ b/.github/workflows/ci-spec.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ensure-wasm-latest:
     runs-on: ubuntu-latest
@@ -153,6 +156,8 @@ jobs:
 
   publish-spec:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
       - ensure-wasm-latest
       - build-core-spec

--- a/.github/workflows/ci-spectec.yml
+++ b/.github/workflows/ci-spectec.yml
@@ -12,6 +12,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   spec-tec:
     runs-on: ubuntu-latest

--- a/.github/workflows/w3c-publish.yml
+++ b/.github/workflows/w3c-publish.yml
@@ -32,6 +32,9 @@ env:
   YARN_ENABLE_IMMUTABLE_INSTALLS: false
   W3C_STATUS: ${{ github.event_name == 'workflow_dispatch' && inputs.w3c-status || 'CRD' }}
 
+permissions:
+  contents: read
+
 jobs:
   publish-to-w3c-TR:
     if: ${{ github.repository == 'WebAssembly/spec' }}


### PR DESCRIPTION
None of the four workflow files declared a permissions block, so every job ran with the default `GITHUB_TOKEN` scope.

What the defaults are depends on the org/repo configuration, and when the repo was created, per https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

By declaring these explicitly, we guarantee that the actions do not have any write access.
