### PR TITLE
Fix bugs in custom section tests

### DIFF
--- a/interpreter/Makefile
+++ b/interpreter/Makefile
@@ -131,7 +131,7 @@ customquiettest/%:	$(NAME)
 		  $(TESTDIR)/run.py 2>$(@F).out --wasm `pwd`/$(NAME) --opts '$(CUSTOMOPTS)' $(if $(JS),--js '$(JS)',) $(CUSTOMTESTDIR)/$*.wast && \
 		  rm $(@F).out \
 		) || \
-		cat $(@F).out || rm $(@F).out || exit 1
+		(cat $(@F).out && rm $(@F).out && exit 1)
 
 
 # Packaging

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -26,6 +26,7 @@ struct
   let validate_with_custom (m, cs) =
     try Ok (Valid.check_module_with_custom (m, cs)) with
     | Valid.Invalid (at, msg) -> Error (at, msg)
+    | Custom.Invalid (at, msg) -> Error (at, msg)
 
   let instantiate m ims =
     try Ok (result Eval.init m ims) with

--- a/interpreter/script/runner.ml
+++ b/interpreter/script/runner.ml
@@ -518,6 +518,8 @@ let run_assertion ass =
   | AssertMalformedCustom (def, re) ->
     trace "Asserting malformed custom...";
     (match ignore (run_definition def) with
+    | exception Custom.Code (_, msg) ->
+      assert_message ass.at "custom section decoding" msg re
     | exception Custom.Syntax (_, msg) ->
       assert_message ass.at "annotation parsing" msg re
     | _ -> Assert.error ass.at "expected custom decoding/parsing error"

--- a/interpreter/valid/valid.mli
+++ b/interpreter/valid/valid.mli
@@ -1,4 +1,4 @@
 exception Invalid of Source.region * string
 
 val check_module : Ast.module_ -> Types.moduletype (* raises Invalid *)
-val check_module_with_custom : Ast.module_ * Custom.section list -> Types.moduletype (* raises Invalid, Custom.Check *)
+val check_module_with_custom : Ast.module_ * Custom.section list -> Types.moduletype (* raises Invalid, Custom.Invalid *)


### PR DESCRIPTION
Custom section tests for branch hinting were actually already failing, but the failures were being suppressed by a bad Makefile rule that was yielding an `0` exit code. In addition, a couple kinds of custom-section exceptions were not being handled like they should have been. (For example, the existing failing branch-hints test was actually completely fine, except that Custom.Invalid was not being caught, so the `assert_invalid_custom` was failing.)